### PR TITLE
Fix broken TravisCI build status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ## Build Status
 
-[![Build Status](https://travis-ci.org/dbeyer/sv-benchmarks.svg?branch=master)](https://travis-ci.org/dbeyer/sv-benchmarks)
+[![Build Status](https://travis-ci.org/sosy-lab/sv-benchmarks.svg?branch=master)](https://travis-ci.org/sosy-lab/sv-benchmarks)


### PR DESCRIPTION
 The breakage is due to the move of the repository from dbeyer/sv-benchmarks to sosy-lab/sv-benchmarks on GitHub.