### PR TITLE
Fixed wrong argument types of thread functions

### DIFF
--- a/c/seq-pthread/cs_read_write_lock_false-unreach-call.c
+++ b/c/seq-pthread/cs_read_write_lock_false-unreach-call.c
@@ -327,7 +327,7 @@ void __VERIFIER_atomic_take_read_lock()
 	if (__CS_ret) r[__CS_round]= __CS_u.r[__CS_round];
 }
 
-void *writer()
+void *writer(void *arg)
 {
 	__CS_cs(); if (__CS_ret != 0) return 0;
 	__VERIFIER_atomic_take_write_lock();
@@ -338,7 +338,7 @@ void *writer()
 	__CS_cs(); if (__CS_ret != 0) return 0;
 }
 
-void *reader()
+void *reader(void *arg)
 {
 	int l;
 	__CS_cs(); if (__CS_ret != 0) return 0;

--- a/c/seq-pthread/cs_read_write_lock_false-unreach-call.i
+++ b/c/seq-pthread/cs_read_write_lock_false-unreach-call.i
@@ -790,7 +790,7 @@ void __VERIFIER_atomic_take_read_lock()
  r[__CS_round] = r[__CS_round] + 1;
  if (__CS_ret) r[__CS_round]= __CS_u.r[__CS_round];
 }
-void *writer()
+void *writer(void *arg)
 {
  __CS_cs(); if (__CS_ret != 0) return 0;
  __VERIFIER_atomic_take_write_lock();
@@ -800,7 +800,7 @@ void *writer()
  w[__CS_round] = 0;
  __CS_cs(); if (__CS_ret != 0) return 0;
 }
-void *reader()
+void *reader(void *arg)
 {
  int l;
  __CS_cs(); if (__CS_ret != 0) return 0;

--- a/c/seq-pthread/cs_read_write_lock_true-unreach-call.c
+++ b/c/seq-pthread/cs_read_write_lock_true-unreach-call.c
@@ -335,7 +335,7 @@ void __VERIFIER_atomic_release_read_lock()
 	if (__CS_ret) r[__CS_round]= __CS_u.r[__CS_round];
 }
 
-void *writer()
+void *writer(void *arg)
 {
 	__CS_cs(); if (__CS_ret != 0) return 0;
 	__VERIFIER_atomic_take_write_lock();
@@ -346,7 +346,7 @@ void *writer()
 	__CS_cs(); if (__CS_ret != 0) return 0;
 }
 
-void *reader()
+void *reader(void *arg)
 {
 	int l;
 	__CS_cs(); if (__CS_ret != 0) return 0;

--- a/c/seq-pthread/cs_read_write_lock_true-unreach-call.i
+++ b/c/seq-pthread/cs_read_write_lock_true-unreach-call.i
@@ -799,7 +799,7 @@ void __VERIFIER_atomic_release_read_lock()
  r[__CS_round] = r[__CS_round] - 1;
  if (__CS_ret) r[__CS_round]= __CS_u.r[__CS_round];
 }
-void *writer()
+void *writer(void *arg)
 {
  __CS_cs(); if (__CS_ret != 0) return 0;
  __VERIFIER_atomic_take_write_lock();
@@ -809,7 +809,7 @@ void *writer()
  w[__CS_round] = 0;
  __CS_cs(); if (__CS_ret != 0) return 0;
 }
-void *reader()
+void *reader(void *arg)
 {
  int l;
  __CS_cs(); if (__CS_ret != 0) return 0;


### PR DESCRIPTION
Argument types of functions reader and writer did not match
what was expected by the respective invocations through
function pointers.