### PR TITLE
Fix incorrectly set build architecture

### DIFF
--- a/c/ldv-validator-v0.8/Makefile
+++ b/c/ldv-validator-v0.8/Makefile
@@ -1,3 +1,5 @@
 LEVEL := ../
 
+CC.Arch := 64
+
 include $(LEVEL)/Makefile.config

--- a/c/signedintegeroverflow-regression/Makefile
+++ b/c/signedintegeroverflow-regression/Makefile
@@ -1,3 +1,5 @@
 LEVEL := ../
 
+CC.Arch := 64
+
 include $(LEVEL)/Makefile.config

--- a/c/termination-15/Makefile
+++ b/c/termination-15/Makefile
@@ -1,3 +1,5 @@
 LEVEL := ../
 
+CC.Arch := 64
+
 include $(LEVEL)/Makefile.config

--- a/c/termination-libowfat/Makefile
+++ b/c/termination-libowfat/Makefile
@@ -1,3 +1,5 @@
 LEVEL := ../
 
+CC.Arch := 64
+
 include $(LEVEL)/Makefile.config

--- a/c/termination-restricted-15/Makefile
+++ b/c/termination-restricted-15/Makefile
@@ -1,3 +1,5 @@
 LEVEL := ../
 
+CC.Arch := 64
+
 include $(LEVEL)/Makefile.config


### PR DESCRIPTION
Fix incorrectly set build architecture (was implicitly 32-bit but should be 64-bit) to match what is documented at
http://sv-comp.sosy-lab.org/2016/benchmarks.php