### PR TITLE
Depreciated concurrency atomic fix  - pthread-lit

### DIFF
--- a/c/pthread-ext/06_ticket_true-unreach-call.c
+++ b/c/pthread-ext/06_ticket_true-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 
 //Ticket lock with proportional backoff
 //
@@ -19,7 +22,8 @@ volatile unsigned now_serving = 0;
 #define NEXT(e) ((e + 1) % FAILED)
 // #define NEXT(e) ((e+1 == FAILED)?0:e+1)
 
-unsigned __VERIFIER_atomic_fetch_and_increment__next_ticket(){
+unsigned fetch_and_increment__next_ticket(){
+        __VERIFIER_atomic_begin();
 	unsigned value;
 
 		if(NEXT(next_ticket) == now_serving){ 
@@ -31,13 +35,14 @@ unsigned __VERIFIER_atomic_fetch_and_increment__next_ticket(){
 			next_ticket = NEXT(next_ticket);
 		}
 
+	__VERIFIER_atomic_end();
 	return value;
 }
 
 inline void acquire_lock(){
 	unsigned my_ticket; 
 
-	my_ticket = __VERIFIER_atomic_fetch_and_increment__next_ticket(); //returns old value; arithmetic overflow is harmless (Alex: it is not if we have 2^64 threads)
+	my_ticket = fetch_and_increment__next_ticket(); //returns old value; arithmetic overflow is harmless (Alex: it is not if we have 2^64 threads)
 
 	if(my_ticket == FAILED){
 		assume(0);

--- a/c/pthread-ext/06_ticket_true-unreach-call.i
+++ b/c/pthread-ext/06_ticket_true-unreach-call.i
@@ -1,5 +1,8 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
@@ -636,6 +639,7 @@ extern int pthread_atfork (void (*__prepare) (void),
 volatile unsigned next_ticket = 0;
 volatile unsigned now_serving = 0;
 unsigned __VERIFIER_atomic_fetch_and_increment__next_ticket(){
+ __VERIFIER_atomic_begin();
  unsigned value;
   if(((next_ticket + 1) % 3) == now_serving){
    value = 3;
@@ -645,11 +649,12 @@ unsigned __VERIFIER_atomic_fetch_and_increment__next_ticket(){
    value = next_ticket;
    next_ticket = ((next_ticket + 1) % 3);
   }
+ __VERIFIER_atomic_end();
  return value;
 }
 inline void acquire_lock(){
  unsigned my_ticket;
- my_ticket = __VERIFIER_atomic_fetch_and_increment__next_ticket();
+ my_ticket = fetch_and_increment__next_ticket();
  if(my_ticket == 3){
   __VERIFIER_assume(0);
  }else{

--- a/c/pthread-ext/06_ticket_true-unreach-call.i
+++ b/c/pthread-ext/06_ticket_true-unreach-call.i
@@ -638,7 +638,7 @@ extern int pthread_atfork (void (*__prepare) (void),
 
 volatile unsigned next_ticket = 0;
 volatile unsigned now_serving = 0;
-unsigned __VERIFIER_atomic_fetch_and_increment__next_ticket(){
+unsigned fetch_and_increment__next_ticket(){
  __VERIFIER_atomic_begin();
  unsigned value;
   if(((next_ticket + 1) % 3) == now_serving){

--- a/c/pthread-lit/assert.h
+++ b/c/pthread-lit/assert.h
@@ -6,10 +6,4 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/assert.h
+++ b/c/pthread-lit/assert.h
@@ -6,4 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fk2012_true-unreach-call.c
+++ b/c/pthread-lit/fk2012_true-unreach-call.c
@@ -12,54 +12,62 @@ volatile int lock1;
 volatile int lock2;
 volatile int counter;
 
-void __VERIFIER_atomic_acquire1() {
+void acquire1() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock1 == 0);
     lock1 = 1;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_release1() {
+void release1() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock1 == 1);
     lock1 = 0;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_acquire2() {
+void acquire2() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock2 == 0);
     lock2 = 1;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_release2() {
+void release2() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock2 == 1);
     lock2 = 0;
+    __VERIFIER_atomic_end();
 }
 
 void* producer(void *arg) {
     int batch = __VERIFIER_nondet_int();
-    __VERIFIER_atomic_acquire2();
-    __VERIFIER_atomic_acquire1();
+    acquire2();
+    acquire1();
     if (counter > 0) {
 	counter++;
-	__VERIFIER_atomic_release1();
-	__VERIFIER_atomic_release2();
+	release1();
+	release2();
 	return 1;
     } else {
-	__VERIFIER_atomic_release1();
+	release1();
 	counter = 0;
 	while (batch > 0) {
 	    counter++;
 	    batch--;
 	}
 	batch = counter;
-	__VERIFIER_atomic_release2();
+	release2();
 	return batch;
     }
 }
 
 void* consumer(void *arg) {
     while (1) {
-	__VERIFIER_atomic_acquire1();
+	acquire1();
 	if (counter > 0) { break; }
-	__VERIFIER_atomic_release1();
+	release1();
     }
     counter--;
     __VERIFIER_assert(counter >= 0);
-    __VERIFIER_atomic_release1();
+    release1();
 }
 
 int main () {

--- a/c/pthread-lit/fk2012_true-unreach-call.i
+++ b/c/pthread-lit/fk2012_true-unreach-call.i
@@ -1022,52 +1022,60 @@ extern int pthread_atfork (void (*__prepare) (void),
 volatile int lock1;
 volatile int lock2;
 volatile int counter;
-void __VERIFIER_atomic_acquire1() {
+void acquire1() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock1 == 0);
     lock1 = 1;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_release1() {
+void release1() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock1 == 1);
     lock1 = 0;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_acquire2() {
+void acquire2() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock2 == 0);
     lock2 = 1;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_release2() {
+void release2() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock2 == 1);
     lock2 = 0;
+    __VERIFIER_atomic_end();
 }
 void* producer(void *arg) {
     int batch = __VERIFIER_nondet_int();
-    __VERIFIER_atomic_acquire2();
-    __VERIFIER_atomic_acquire1();
+    acquire2();
+    acquire1();
     if (counter > 0) {
  counter++;
- __VERIFIER_atomic_release1();
- __VERIFIER_atomic_release2();
+ release1();
+ release2();
  return 1;
     } else {
- __VERIFIER_atomic_release1();
+ release1();
  counter = 0;
  while (batch > 0) {
      counter++;
      batch--;
  }
  batch = counter;
- __VERIFIER_atomic_release2();
+ release2();
  return batch;
     }
 }
 void* consumer(void *arg) {
     while (1) {
- __VERIFIER_atomic_acquire1();
+ acquire1();
  if (counter > 0) { break; }
- __VERIFIER_atomic_release1();
+ release1();
     }
     counter--;
     __VERIFIER_assert(counter >= 0);
-    __VERIFIER_atomic_release1();
+    release1();
 }
 int main () {
     pthread_t t;

--- a/c/pthread-lit/fk2012_true-unreach-call.i
+++ b/c/pthread-lit/fk2012_true-unreach-call.i
@@ -1,6 +1,9 @@
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 extern void __VERIFIER_assume(int);
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 extern int __VERIFIER_nondet_int(void);
 typedef long unsigned int size_t;
 typedef int wchar_t;

--- a/c/pthread-lit/fkp2013_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_false-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int x;
 void* thr1(void* arg) {

--- a/c/pthread-lit/fkp2013_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_false-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int x;
 void* thr1(void* arg) {

--- a/c/pthread-lit/fkp2013_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_true-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int x;
 void* thr1(void* arg) {

--- a/c/pthread-lit/fkp2013_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_true-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int x;
 void* thr1(void* arg) {

--- a/c/pthread-lit/fkp2013_variant_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_false-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int x;
 volatile int n;

--- a/c/pthread-lit/fkp2013_variant_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_false-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int x;
 volatile int n;

--- a/c/pthread-lit/fkp2013_variant_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_true-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int x;
 volatile int n;

--- a/c/pthread-lit/fkp2013_variant_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_true-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int x;
 volatile int n;

--- a/c/pthread-lit/fkp2014_true-unreach-call.c
+++ b/c/pthread-lit/fkp2014_true-unreach-call.c
@@ -8,17 +8,21 @@ volatile int s;
 volatile int t;
 
 
-void __VERIFIER_atomic_inct() {
+void inct() {
+    __VERIFIER_atomic_begin();
     t++;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_incs() {
+void incs() {
+    __VERIFIER_atomic_begin();
     s++;
+    __VERIFIER_atomic_end();
 }
 
 void* thr(void* arg) {
-    __VERIFIER_atomic_inct();
-    __VERIFIER_atomic_assert(s < t);
-    __VERIFIER_atomic_incs();
+    inct();
+    __VERIFIER_assert(s < t);
+    incs();
 }
 
 int main() {

--- a/c/pthread-lit/fkp2014_true-unreach-call.i
+++ b/c/pthread-lit/fkp2014_true-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int s;
 volatile int t;

--- a/c/pthread-lit/fkp2014_true-unreach-call.i
+++ b/c/pthread-lit/fkp2014_true-unreach-call.i
@@ -654,25 +654,23 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int s;
 volatile int t;
-void __VERIFIER_atomic_inct() {
+void inct() {
+    __VERIFIER_atomic_begin();
     t++;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_incs() {
+void incs() {
+    __VERIFIER_atomic_begin();
     s++;
+    __VERIFIER_atomic_end();
 }
 void* thr(void* arg) {
-    __VERIFIER_atomic_inct();
-    __VERIFIER_atomic_assert(s < t);
-    __VERIFIER_atomic_incs();
+    inct();
+    __VERIFIER_assert(s < t);
+    incs();
 }
 int main() {
     pthread_t t;

--- a/c/pthread-lit/qw2004_false-unreach-call.c
+++ b/c/pthread-lit/qw2004_false-unreach-call.c
@@ -19,14 +19,17 @@ int BCSP_IoIncrement() {
     return 0;
 }
 
-int __VERIFIER_atomic_dec() {
+int dec() {
+    __VERIFIER_atomic_begin();
     pendingIo--;
-    return pendingIo;    
+    int tmp = pendingIo;
+    __VERIFIER_atomic_end();
+    return tmp;
 }
 
 void BCSP_IoDecrement() {
     int pending;
-    pending = __VERIFIER_atomic_dec();
+    pending = dec();
     if (pending == 0) {
 	stoppingEvent = 1;
     }

--- a/c/pthread-lit/qw2004_false-unreach-call.i
+++ b/c/pthread-lit/qw2004_false-unreach-call.i
@@ -673,13 +673,16 @@ int BCSP_IoIncrement() {
     }
     return 0;
 }
-int __VERIFIER_atomic_dec() {
+int dec() {
+    __VERIFIER_atomic_begin();
     pendingIo--;
-    return pendingIo;
+    int tmp = pendingIo;
+    __VERIFIER_atomic_end();
+    return tmp;
 }
 void BCSP_IoDecrement() {
     int pending;
-    pending = __VERIFIER_atomic_dec();
+    pending = dec();
     if (pending == 0) {
  stoppingEvent = 1;
     }

--- a/c/pthread-lit/qw2004_false-unreach-call.i
+++ b/c/pthread-lit/qw2004_false-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_false-unreach-call.i
+++ b/c/pthread-lit/qw2004_false-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_true-unreach-call.c
+++ b/c/pthread-lit/qw2004_true-unreach-call.c
@@ -10,23 +10,29 @@ volatile int pendingIo;
 volatile int stoppingEvent;
 volatile int stopped;
 
-int __VERIFIER_atomic_BCSP_IoIncrement() {
+int BCSP_IoIncrement() {
+    __VERIFIER_atomic_begin();
     if (stoppingFlag) {
+        __VERIFIER_atomic_end();
 	return -1;
     } else {
 	pendingIo = pendingIo + 1;
     }
+    __VERIFIER_atomic_end();
     return 0;
 }
 
-int __VERIFIER_atomic_dec() {
+int dec() {
+    __VERIFIER_atomic_begin();
     pendingIo--;
-    return pendingIo;    
+    int tmp = pendingIo;
+    __VERIFIER_atomic_end();
+    return tmp;
 }
 
 void BCSP_IoDecrement() {
     int pending;
-    pending = __VERIFIER_atomic_dec();
+    pending = dec();
     if (pending == 0) {
 	stoppingEvent = 1;
     }
@@ -34,7 +40,7 @@ void BCSP_IoDecrement() {
 
 void* BCSP_PnpAdd(void* arg) {
     int status;
-    status = __VERIFIER_atomic_BCSP_IoIncrement();
+    status = BCSP_IoIncrement();
     if (status == 0) {
 	__VERIFIER_assert(!stopped);
     }

--- a/c/pthread-lit/qw2004_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_true-unreach-call.i
@@ -665,28 +665,34 @@ volatile int stoppingFlag;
 volatile int pendingIo;
 volatile int stoppingEvent;
 volatile int stopped;
-int __VERIFIER_atomic_BCSP_IoIncrement() {
+int BCSP_IoIncrement() {
+    __VERIFIER_atomic_begin();
     if (stoppingFlag) {
+        __VERIFIER_atomic_end();
  return -1;
     } else {
  pendingIo = pendingIo + 1;
     }
+    __VERIFIER_atomic_end();
     return 0;
 }
-int __VERIFIER_atomic_dec() {
+int dec() {
+    __VERIFIER_atomic_begin();
     pendingIo--;
-    return pendingIo;
+    int tmp = pendingIo;
+    __VERIFIER_atomic_end();
+    return tmp;
 }
 void BCSP_IoDecrement() {
     int pending;
-    pending = __VERIFIER_atomic_dec();
+    pending = dec();
     if (pending == 0) {
  stoppingEvent = 1;
     }
 }
 void* BCSP_PnpAdd(void* arg) {
     int status;
-    status = __VERIFIER_atomic_BCSP_IoIncrement();
+    status = BCSP_IoIncrement();
     if (status == 0) {
  __VERIFIER_assert(!stopped);
     }

--- a/c/pthread-lit/qw2004_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_true-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_true-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.c
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.c
@@ -13,34 +13,39 @@ volatile int pendingIo;
 volatile int stoppingEvent;
 volatile int stopped;
 
-int __VERIFIER_atomic_BCSP_IoIncrement() {
+int BCSP_IoIncrement() {
+    __VERIFIER_atomic_begin();
     if (stoppingFlag) {
+        __VERIFIER_atomic_end();
 	return -1;
     } else {
 	pendingIo = pendingIo + 1;
     }
+    __VERIFIER_atomic_end();
     return 0;
 }
 
-void __VERIFIER_atomic_BCSP_IoDecrement() {
+void BCSP_IoDecrement() {
+    __VERIFIER_atomic_begin();
     pendingIo--;
     if (pendingIo == 0) {
 	stoppingEvent = 1;
     }
+    __VERIFIER_atomic_end();
 }
 
 void* BCSP_PnpAdd(void* arg) {
     int status;
-    status = __VERIFIER_atomic_BCSP_IoIncrement();
+    status = BCSP_IoIncrement();
     if (status == 0) {
 	__VERIFIER_assert(!stopped);
-	__VERIFIER_atomic_BCSP_IoDecrement();
+	BCSP_IoDecrement();
     }
 }
 
 void* BCSP_PnpStop(void* arg) {
     stoppingFlag = 1;
-    __VERIFIER_atomic_BCSP_IoDecrement();
+    BCSP_IoDecrement();
     __VERIFIER_assume(stoppingEvent);
     stopped = 1;
 }

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.i
@@ -665,31 +665,36 @@ volatile int stoppingFlag;
 volatile int pendingIo;
 volatile int stoppingEvent;
 volatile int stopped;
-int __VERIFIER_atomic_BCSP_IoIncrement() {
+int BCSP_IoIncrement() {
+    __VERIFIER_atomic_begin();
     if (stoppingFlag) {
+        __VERIFIER_atomic_end();
  return -1;
     } else {
  pendingIo = pendingIo + 1;
     }
+    __VERIFIER_atomic_end();
     return 0;
 }
-void __VERIFIER_atomic_BCSP_IoDecrement() {
+void BCSP_IoDecrement() {
+    __VERIFIER_atomic_begin();
     pendingIo--;
     if (pendingIo == 0) {
  stoppingEvent = 1;
     }
+    __VERIFIER_atomic_end();
 }
 void* BCSP_PnpAdd(void* arg) {
     int status;
-    status = __VERIFIER_atomic_BCSP_IoIncrement();
+    status = BCSP_IoIncrement();
     if (status == 0) {
  __VERIFIER_assert(!stopped);
- __VERIFIER_atomic_BCSP_IoDecrement();
+ BCSP_IoDecrement();
     }
 }
 void* BCSP_PnpStop(void* arg) {
     stoppingFlag = 1;
-    __VERIFIER_atomic_BCSP_IoDecrement();
+    BCSP_IoDecrement();
     __VERIFIER_assume(stoppingEvent);
     stopped = 1;
 }

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.i
@@ -654,12 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/sssc12_true-unreach-call.c
+++ b/c/pthread-lit/sssc12_true-unreach-call.c
@@ -10,14 +10,18 @@ volatile int len;
 volatile int next;
 volatile int lock;
 
-void __VERIFIER_atomic_acquire() {
+void acquire() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 0);
     lock = 1;
+    __VERIFIER_atomic_end();
 }
 
-void __VERIFIER_atomic_release() {
+void release() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 1);
     lock = 0;
+    __VERIFIER_atomic_end();
 }
 
 void* thr(void* arg) {
@@ -25,12 +29,12 @@ void* thr(void* arg) {
     c = 0;
     end = 0;
     
-    __VERIFIER_atomic_acquire();
+    acquire();
     if (next + 10 <= len) {
 	c = next;
 	next = end = next + 10;
     }
-    __VERIFIER_atomic_release();
+    release();
     while (c < end) {
 	__VERIFIER_assert(0 <= c && c < len);
 	data[c] = 0;

--- a/c/pthread-lit/sssc12_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_true-unreach-call.i
@@ -654,6 +654,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 int *data;
 volatile int len;

--- a/c/pthread-lit/sssc12_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_true-unreach-call.i
@@ -654,35 +654,33 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 int *data;
 volatile int len;
 volatile int next;
 volatile int lock;
-void __VERIFIER_atomic_acquire() {
+void acquire() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 0);
     lock = 1;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_release() {
+void release() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 1);
     lock = 0;
+    __VERIFIER_atomic_end();
 }
 void* thr(void* arg) {
     int c, end;
     c = 0;
     end = 0;
-    __VERIFIER_atomic_acquire();
+    acquire();
     if (next + 10 <= len) {
  c = next;
  next = end = next + 10;
     }
-    __VERIFIER_atomic_release();
+    release();
     while (c < end) {
  __VERIFIER_assert(0 <= c && c < len);
  data[c] = 0;

--- a/c/pthread-lit/sssc12_variant_true-unreach-call.c
+++ b/c/pthread-lit/sssc12_variant_true-unreach-call.c
@@ -10,26 +10,30 @@ volatile int len;
 volatile int next;
 volatile int lock;
 
-void __VERIFIER_atomic_acquire() {
+void acquire() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 0);
     lock = 1;
+    __VERIFIER_atomic_end();
 }
 
-void __VERIFIER_atomic_release() {
+void release() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 1);
     lock = 0;
+    __VERIFIER_atomic_end();
 }
 
 void* thr(void* arg) {
     int c, end;
     c = 0;
     end = 0;
-    __VERIFIER_atomic_acquire();
+    acquire();
     if (next + 10 <= len) {
 	c = next;
 	next = end = next + 10;
     }
-    __VERIFIER_atomic_release();
+    release();
     while (c < end) {
 	data[c] = 0;
 	data[c] = 1;

--- a/c/pthread-lit/sssc12_variant_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_variant_true-unreach-call.i
@@ -656,6 +656,9 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
+int __global_lock;
+void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
+void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
 int __VERIFIER_nondet_int();
 int *data;
 volatile int len;

--- a/c/pthread-lit/sssc12_variant_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_variant_true-unreach-call.i
@@ -656,35 +656,33 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-void __VERIFIER_atomic_assert(int cond) {
-  if (!(cond)) {
-    ERROR: __VERIFIER_error();
-  }
-  return;
-}
 int __VERIFIER_nondet_int();
 int *data;
 volatile int len;
 volatile int next;
 volatile int lock;
-void __VERIFIER_atomic_acquire() {
+void acquire() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 0);
     lock = 1;
+    __VERIFIER_atomic_end();
 }
-void __VERIFIER_atomic_release() {
+void release() {
+    __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock == 1);
     lock = 0;
+    __VERIFIER_atomic_end();
 }
 void* thr(void* arg) {
     int c, end;
     c = 0;
     end = 0;
-    __VERIFIER_atomic_acquire();
+    acquire();
     if (next + 10 <= len) {
  c = next;
  next = end = next + 10;
     }
-    __VERIFIER_atomic_release();
+    release();
     while (c < end) {
  data[c] = 0;
  data[c] = 1;


### PR DESCRIPTION
This pull request removes depreciated __VERIFIER_atomic_*() declarations, definitions, and calls from the pthread-lit group of benchmarks.

It changes occurrences of __VERIFIER_atomic_*() to *(), and wraps the bodies of such function definitions in __VERIFIER_atomic_begin() and __VERIFIER_atomic_end() calls.