### PR TITLE
Added checks to ensure that something was attached

### DIFF
--- a/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.i.pp.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-usb-serial-whiteheat.ko_true-unreach-call.cil.out.i.pp.i
@@ -7773,8 +7773,10 @@ int main(void)
         case_4:
         if (ldv_s_whiteheat_device_usb_serial_driver == 2) {
           {
-          whiteheat_attach(var_group1);
-          whiteheat_release(var_group1);
+          int attach_status = whiteheat_attach(var_group1);
+          if (attach_status != -19 && attach_status != -12) {
+            whiteheat_release(var_group1);
+          }
           ldv_s_whiteheat_device_usb_serial_driver = 0;
           }
         } else {


### PR DESCRIPTION
Function whiteheat_attach can fail without actually attaching anything. On the
other hand, whiteheat_release actually has an assertion that checks that
something was attached. So it should not be called if nothing was attached,
which is indicated with error codes -19 and -12.