### PR TITLE
Show the value of `WARNINGS_AS_ERRORS` when the `debug_vars` target is run

### DIFF
--- a/c/Makefile.rules
+++ b/c/Makefile.rules
@@ -276,4 +276,5 @@ debug_vars:
 	@echo "ROOT_DIR := $(ROOT_DIR)"
 	@echo "SKIP_LEVEL := $(SKIP_LEVEL)"
 	@echo "SYNTAX_ONLY := $(SYNTAX_ONLY)"
+	@echo "WARNINGS_AS_ERRORS := $(WARNINGS_AS_ERRORS)"
 


### PR DESCRIPTION
Show the value of `WARNINGS_AS_ERRORS` when the `debug_vars` target is run