### PR TITLE
removing string argument of __VERIFIER_error in Forester examples

### DIFF
--- a/c/forester-heap/dll-01_false-unreach-call.c
+++ b/c/forester-heap/dll-01_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with inner list of length 0 or 1.
  *

--- a/c/forester-heap/dll-01_false-unreach-call.i
+++ b/c/forester-heap/dll-01_false-unreach-call.i
@@ -1125,7 +1125,7 @@ int main()
  SLL* list = malloc(sizeof(SLL));
  list->next = ((void*)0);
  list->prev = ((void*)0);
- do { if (!(list != ((void*)0))) __VERIFIER_error("assertion failed: " "list != NULL");} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "list->inner != NULL || list->inner == NULL");} while (0);;
+ do { if (!(list != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error();} while (0);;
 
  SLL* end = list;
 
@@ -1137,15 +1137,15 @@ int main()
   end->next->prev = end;
   end = end->next;
   end->next = ((void*)0);
-  do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-  do { if (!(end != ((void*)0))) __VERIFIER_error("assertion failed: " "end != NULL");} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "end->inner != NULL || end->inner == NULL");} while (0);;
+  do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+  do { if (!(end != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error();} while (0);;
  }
 
  end = ((void*)0);
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
@@ -1157,12 +1157,12 @@ int main()
     len = 1;
    else
     len = 2;
-   do { if (!(((void*)0) != inner)) __VERIFIER_error("assertion failed: " "NULL != inner");} while (0);
-   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error("assertion failed: " "NULL == inner->inner");} while (0);
-   do { if (!(((void*)0) != inner->next)) __VERIFIER_error("assertion failed: " "NULL != inner->next");} while (0);
+   do { if (!(((void*)0) != inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) != inner->next)) __VERIFIER_error();} while (0);
    inner = inner->inner;
   }
-  do { if (!(len <= 1)) __VERIFIER_error("assertion failed: " "len <= 1");} while (0);
+  do { if (!(len <= 1)) __VERIFIER_error();} while (0);
 
   end = end->next;
  }
@@ -1174,9 +1174,9 @@ int main()
 
   if (((void*)0) != end)
   {
-   do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-   do { if (!(((void*)0) == end->inner)) __VERIFIER_error("assertion failed: " "NULL == end->inner");} while (0);
-   do { if (!(((void*)0) == end->next)) __VERIFIER_error("assertion failed: " "NULL == end->next");} while (0);
+   do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->next)) __VERIFIER_error();} while (0);
    free(end);
    end = ((void*)0);
   }

--- a/c/forester-heap/dll-01_true-unreach-call.c
+++ b/c/forester-heap/dll-01_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with inner list of length 0 or 1.
  *

--- a/c/forester-heap/dll-01_true-unreach-call.i
+++ b/c/forester-heap/dll-01_true-unreach-call.i
@@ -1125,7 +1125,7 @@ int main()
  SLL* list = malloc(sizeof(SLL));
  list->next = ((void*)0);
  list->prev = ((void*)0);
- do { if (!(list != ((void*)0))) __VERIFIER_error("assertion failed: " "list != NULL");} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "list->inner != NULL || list->inner == NULL");} while (0);;
+ do { if (!(list != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error();} while (0);;
 
  SLL* end = list;
 
@@ -1137,15 +1137,15 @@ int main()
   end->next->prev = end;
   end = end->next;
   end->next = ((void*)0);
-  do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-  do { if (!(end != ((void*)0))) __VERIFIER_error("assertion failed: " "end != NULL");} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "end->inner != NULL || end->inner == NULL");} while (0);;
+  do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+  do { if (!(end != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error();} while (0);;
  }
 
  end = ((void*)0);
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
@@ -1157,12 +1157,12 @@ int main()
     len = 1;
    else
     len = 2;
-   do { if (!(((void*)0) != inner)) __VERIFIER_error("assertion failed: " "NULL != inner");} while (0);
-   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error("assertion failed: " "NULL == inner->inner");} while (0);
-   do { if (!(((void*)0) == inner->next)) __VERIFIER_error("assertion failed: " "NULL == inner->next");} while (0);
+   do { if (!(((void*)0) != inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->next)) __VERIFIER_error();} while (0);
    inner = inner->inner;
   }
-  do { if (!(len <= 1)) __VERIFIER_error("assertion failed: " "len <= 1");} while (0);
+  do { if (!(len <= 1)) __VERIFIER_error();} while (0);
 
   end = end->next;
  }
@@ -1174,9 +1174,9 @@ int main()
 
   if (((void*)0) != end)
   {
-   do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-   do { if (!(((void*)0) == end->inner)) __VERIFIER_error("assertion failed: " "NULL == end->inner");} while (0);
-   do { if (!(((void*)0) == end->next)) __VERIFIER_error("assertion failed: " "NULL == end->next");} while (0);
+   do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->next)) __VERIFIER_error();} while (0);
    free(end);
    list->inner = ((void*)0);
   }

--- a/c/forester-heap/dll-circular_false-unreach-call.c
+++ b/c/forester-heap/dll-circular_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A circular list where a head of list is marked
  * by integer value 0. The rest of list forms

--- a/c/forester-heap/dll-circular_false-unreach-call.i
+++ b/c/forester-heap/dll-circular_false-unreach-call.i
@@ -1144,16 +1144,16 @@ int main()
 
   x->data = state;
 
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = state;
 
  x = head->next;
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (x->data != 0)
  {
-  do { if (!(x->next->data != 0 && x->data > x->next->data)) __VERIFIER_error("assertion failed: " "x->next->data != 0 && x->data > x->next->data");} while (0);
+  do { if (!(x->next->data != 0 && x->data > x->next->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/dll-circular_true-unreach-call.c
+++ b/c/forester-heap/dll-circular_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A circular list where a head of list is marked
  * by integer value 0. The rest of list forms

--- a/c/forester-heap/dll-circular_true-unreach-call.i
+++ b/c/forester-heap/dll-circular_true-unreach-call.i
@@ -1145,16 +1145,16 @@ int main()
 
   x->data = state;
 
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = state;
 
  x = head->next;
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (x->data != 0)
  {
-  do { if (!(x->next->data == 0 || x->data <= x->next->data)) __VERIFIER_error("assertion failed: " "x->next->data == 0 || x->data <= x->next->data");} while (0);
+  do { if (!(x->next->data == 0 || x->data <= x->next->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/dll-optional_false-unreach-call.c
+++ b/c/forester-heap/dll-optional_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with nodes which can point to an optional
  * external node. Whether an optional node is allocated

--- a/c/forester-heap/dll-optional_false-unreach-call.i
+++ b/c/forester-heap/dll-optional_false-unreach-call.i
@@ -1129,7 +1129,7 @@ int main()
  x = head;
  while (x != ((void*)0))
  {
-  do { if (!(x->data == 2 && x->opt == x)) __VERIFIER_error("assertion failed: " "x->data == 2 && x->opt == x");} while (0);
+  do { if (!(x->data == 2 && x->opt == x)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/dll-optional_true-unreach-call.c
+++ b/c/forester-heap/dll-optional_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with nodes which can point to an optional
  * external node. Whether an optional node is allocated

--- a/c/forester-heap/dll-optional_true-unreach-call.i
+++ b/c/forester-heap/dll-optional_true-unreach-call.i
@@ -1129,7 +1129,7 @@ int main()
  x = head;
  while (x != ((void*)0))
  {
-  do { if (!((x->data == 2 && x->opt != x && x->opt->next == ((void*)0)) || x->opt == x)) __VERIFIER_error("assertion failed: " "(x->data == 2 && x->opt != x && x->opt->next == NULL) || x->opt == x");} while (0);
+  do { if (!((x->data == 2 && x->opt != x && x->opt->next == ((void*)0)) || x->opt == x)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/dll-queue_false-unreach-call.c
+++ b/c/forester-heap/dll-queue_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * We create a list with nodes containing the integers 0, 1, 2, and 3.
  * The list can form sequences 0, 01, 012, 0123^*. A particular sequence is created

--- a/c/forester-heap/dll-queue_false-unreach-call.i
+++ b/c/forester-heap/dll-queue_false-unreach-call.i
@@ -1146,35 +1146,35 @@ int main()
    status = 3;
   }
 
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(item != ((void*)0))) __VERIFIER_error("assertion failed: " "item != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(item != ((void*)0))) __VERIFIER_error();} while (0);
  }
 
- do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
+ do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
  if (status == 1)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 2)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 3)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next->data != 3)) __VERIFIER_error("assertion failed: " "head->next->next->next->data != 3");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next->data != 3)) __VERIFIER_error();} while (0);
  }
 
  item = head->next;
  while(item && __VERIFIER_nondet_int())
  {
-  do { if (!(!status || item->data > 0)) __VERIFIER_error("assertion failed: " "!status || item->data > 0");} while (0);
+  do { if (!(!status || item->data > 0)) __VERIFIER_error();} while (0);
   item = item->next;
  }
 

--- a/c/forester-heap/dll-queue_true-unreach-call.c
+++ b/c/forester-heap/dll-queue_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * We create a list with nodes containing the integers 0, 1, 2, and 3.
  * The list can form sequences 0, 01, 012, 0123^*. A particular sequence is created

--- a/c/forester-heap/dll-queue_true-unreach-call.i
+++ b/c/forester-heap/dll-queue_true-unreach-call.i
@@ -1146,35 +1146,35 @@ int main()
    status = 3;
   }
 
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(item != ((void*)0))) __VERIFIER_error("assertion failed: " "item != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(item != ((void*)0))) __VERIFIER_error();} while (0);
  }
 
- do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
+ do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
  if (status == 1)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 2)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 3)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next->data == 3)) __VERIFIER_error("assertion failed: " "head->next->next->next->data == 3");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next->data == 3)) __VERIFIER_error();} while (0);
  }
 
  item = head->next;
  while(item && __VERIFIER_nondet_int())
  {
-  do { if (!(!status || item->data > 0)) __VERIFIER_error("assertion failed: " "!status || item->data > 0");} while (0);
+  do { if (!(!status || item->data > 0)) __VERIFIER_error();} while (0);
   item = item->next;
  }
 

--- a/c/forester-heap/dll-rb-cnstr_1_false-unreach-call.c
+++ b/c/forester-heap/dll-rb-cnstr_1_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*

--- a/c/forester-heap/dll-rb-cnstr_1_false-unreach-call.i
+++ b/c/forester-heap/dll-rb-cnstr_1_false-unreach-call.i
@@ -1158,8 +1158,8 @@ int main()
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
@@ -1169,7 +1169,7 @@ int main()
    end = end->next;
   }
 
-  do { if (!(end->next)) __VERIFIER_error("assertion failed: " "end->next");} while (0);
+  do { if (!(end->next)) __VERIFIER_error();} while (0);
   end = end->next;
  }
 

--- a/c/forester-heap/dll-rb-cnstr_1_true-unreach-call.c
+++ b/c/forester-heap/dll-rb-cnstr_1_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*

--- a/c/forester-heap/dll-rb-cnstr_1_true-unreach-call.i
+++ b/c/forester-heap/dll-rb-cnstr_1_true-unreach-call.i
@@ -1152,24 +1152,24 @@ int main()
    end->next = ((void*)0);
    end->colour = BLACK;
   }
-  do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
-  do { if (!(((void*)0) == end->next)) __VERIFIER_error("assertion failed: " "NULL == end->next");} while (0);
-  do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
+  do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
+  do { if (!(((void*)0) == end->next)) __VERIFIER_error();} while (0);
+  do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
  }
 
  end = ((void*)0);
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
  while (((void*)0) != end)
  {
   if (RED == end->colour)
   {
    end = end->next;
-   do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-   do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+   do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+   do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
   }
 
   end = end->next;

--- a/c/forester-heap/dll-rb-sentinel_false-unreach-call.c
+++ b/c/forester-heap/dll-rb-sentinel_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  *
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies

--- a/c/forester-heap/dll-rb-sentinel_false-unreach-call.i
+++ b/c/forester-heap/dll-rb-sentinel_false-unreach-call.i
@@ -1151,24 +1151,24 @@ int main()
    end->next = null;
    end->colour = BLACK;
   }
-  do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
-  do { if (!(null == end->next)) __VERIFIER_error("assertion failed: " "null == end->next");} while (0);
-  do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
+  do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
+  do { if (!(null == end->next)) __VERIFIER_error();} while (0);
+  do { if (!(null != end)) __VERIFIER_error();} while (0);
  }
 
  end = null;
  end = list;
 
 
- do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(null != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
  while (null != end)
  {
   if (RED == end->colour)
   {
    end = end->next;
-   do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
-   do { if (!(BLACK != end->colour)) __VERIFIER_error("assertion failed: " "BLACK != end->colour");} while (0);
+   do { if (!(null != end)) __VERIFIER_error();} while (0);
+   do { if (!(BLACK != end->colour)) __VERIFIER_error();} while (0);
   }
 
   end = end->next;

--- a/c/forester-heap/dll-rb-sentinel_true-unreach-call.c
+++ b/c/forester-heap/dll-rb-sentinel_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*. Null is modelled by a special node.

--- a/c/forester-heap/dll-rb-sentinel_true-unreach-call.i
+++ b/c/forester-heap/dll-rb-sentinel_true-unreach-call.i
@@ -1158,24 +1158,24 @@ int main()
    end->next = null;
    end->colour = BLACK;
   }
-  do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
-  do { if (!(null == end->next)) __VERIFIER_error("assertion failed: " "null == end->next");} while (0);
-  do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
+  do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
+  do { if (!(null == end->next)) __VERIFIER_error();} while (0);
+  do { if (!(null != end)) __VERIFIER_error();} while (0);
  }
 
  end = null;
  end = list;
 
 
- do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(null != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
  while (null != end)
  {
   if (RED == end->colour)
   {
    end = end->next;
-   do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
-   do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+   do { if (!(null != end)) __VERIFIER_error();} while (0);
+   do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
   }
 
   end = end->next;

--- a/c/forester-heap/dll-reverse_true-unreach-call.c
+++ b/c/forester-heap/dll-reverse_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with all nodes white, except two.
  * One green and red. It holds that the green

--- a/c/forester-heap/dll-reverse_true-unreach-call.i
+++ b/c/forester-heap/dll-reverse_true-unreach-call.i
@@ -1130,10 +1130,10 @@ int main()
  x = head;
  while (x->next != ((void*)0) && __VERIFIER_nondet_int())
  {
-  do { if (!(x != ((void*)0))) __VERIFIER_error("assertion failed: " "x != NULL");} while (0);
+  do { if (!(x != ((void*)0))) __VERIFIER_error();} while (0);
   x = x->next;
  }
- do { if (!(x != ((void*)0))) __VERIFIER_error("assertion failed: " "x != NULL");} while (0);
+ do { if (!(x != ((void*)0))) __VERIFIER_error();} while (0);
 
  x->data = 1;
 
@@ -1169,7 +1169,7 @@ int main()
   int t2 = 0;
   if (t1 == 2)
    t2 = x->next->data;
-  do { if (!(t1 != 2 || t2 == 1)) __VERIFIER_error("assertion failed: " "t1 != RED || t2 == GREEN");} while (0);
+  do { if (!(t1 != 2 || t2 == 1)) __VERIFIER_error();} while (0);
 
 
   if (x->data == 2)

--- a/c/forester-heap/dll-simple-white-blue_false-unreach-call.c
+++ b/c/forester-heap/dll-simple-white-blue_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list consists of one blue node and nondterministic number of white nodes.
  * The blue node is inserted to a nondeterministic position in list.

--- a/c/forester-heap/dll-simple-white-blue_false-unreach-call.i
+++ b/c/forester-heap/dll-simple-white-blue_false-unreach-call.i
@@ -1181,7 +1181,7 @@ int main()
     while (x)
  {
   if (x->data != 1)
-   do { if (!(0)) __VERIFIER_error("assertion failed: " "0");} while (0);
+   do { if (!(0)) __VERIFIER_error();} while (0);
         x = x->next;
     }
 

--- a/c/forester-heap/dll-simple-white-blue_true-unreach-call.c
+++ b/c/forester-heap/dll-simple-white-blue_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list consists of one blue node and nondterministic number of white nodes.
  * The blue node is inserted to a nondeterministic position in list.

--- a/c/forester-heap/dll-simple-white-blue_true-unreach-call.i
+++ b/c/forester-heap/dll-simple-white-blue_true-unreach-call.i
@@ -1181,7 +1181,7 @@ int main()
     while (x)
  {
   if (x->data == 1)
-   do { if (!(0)) __VERIFIER_error("assertion failed: " "0");} while (0);
+   do { if (!(0)) __VERIFIER_error();} while (0);
         x = x->next;
     }
 

--- a/c/forester-heap/dll-sorted_false-unreach-call.c
+++ b/c/forester-heap/dll-sorted_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list containing nodes with integer values 0 and 1.
  * The list is created such way that nodes are sorted by value.

--- a/c/forester-heap/dll-sorted_false-unreach-call.i
+++ b/c/forester-heap/dll-sorted_false-unreach-call.i
@@ -1146,7 +1146,7 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  marked = 0;
 
  while (x->next != ((void*)0) && x->next->data == 0)
@@ -1157,7 +1157,7 @@ int main()
  while (x->next != ((void*)0) && __VERIFIER_nondet_int())
  {
   x = x->next;
-  do { if (!(x->data != 1)) __VERIFIER_error("assertion failed: " "x->data != 1");} while (0);
+  do { if (!(x->data != 1)) __VERIFIER_error();} while (0);
  }
 
  SLL* tmp = malloc(sizeof(SLL));
@@ -1181,15 +1181,15 @@ int main()
  while (x != ((void*)0) && x->data != 1)
  {
   marked = x->data;
-  do { if (!(x->data == 0)) __VERIFIER_error("assertion failed: " "x->data == 0");} while (0);
-  do { if (!(marked == 0)) __VERIFIER_error("assertion failed: " "marked == 0");} while (0);
+  do { if (!(x->data == 0)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 0)) __VERIFIER_error();} while (0);
   x = x->next;
  }
  while (x != ((void*)0))
  {
   marked = x->data;
-  do { if (!(x->data == 1)) __VERIFIER_error("assertion failed: " "x->data == 1");} while (0);
-  do { if (!(marked == 1)) __VERIFIER_error("assertion failed: " "marked == 1");} while (0);
+  do { if (!(x->data == 1)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 1)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 # 114 "dll-sorted_false-unreach-call.c"

--- a/c/forester-heap/dll-sorted_true-unreach-call.c
+++ b/c/forester-heap/dll-sorted_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list containing nodes with integer values 0 and 1.
  * The list is created such way that nodes are sorted by value.

--- a/c/forester-heap/dll-sorted_true-unreach-call.i
+++ b/c/forester-heap/dll-sorted_true-unreach-call.i
@@ -1146,7 +1146,7 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  marked = 0;
 
  while (x->next != ((void*)0) && x->next->data == 0)
@@ -1157,7 +1157,7 @@ int main()
  while (x->next != ((void*)0) && __VERIFIER_nondet_int())
  {
   x = x->next;
-  do { if (!(x->data == 1)) __VERIFIER_error("assertion failed: " "x->data == 1");} while (0);
+  do { if (!(x->data == 1)) __VERIFIER_error();} while (0);
  }
 
  SLL* tmp = malloc(sizeof(SLL));
@@ -1181,15 +1181,15 @@ int main()
  while (x != ((void*)0) && x->data != 1)
  {
   marked = x->data;
-  do { if (!(x->data == 0)) __VERIFIER_error("assertion failed: " "x->data == 0");} while (0);
-  do { if (!(marked == 0)) __VERIFIER_error("assertion failed: " "marked == 0");} while (0);
+  do { if (!(x->data == 0)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 0)) __VERIFIER_error();} while (0);
   x = x->next;
  }
  while (x != ((void*)0))
  {
   marked = x->data;
-  do { if (!(x->data == 1)) __VERIFIER_error("assertion failed: " "x->data == 1");} while (0);
-  do { if (!(marked == 1)) __VERIFIER_error("assertion failed: " "marked == 1");} while (0);
+  do { if (!(x->data == 1)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 1)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 # 114 "dll-sorted_true-unreach-call.c"

--- a/c/forester-heap/dll-token_false-unreach-call.c
+++ b/c/forester-heap/dll-token_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list ended with node marked by a special integer value.
  *

--- a/c/forester-heap/dll-token_false-unreach-call.i
+++ b/c/forester-heap/dll-token_false-unreach-call.i
@@ -1137,7 +1137,7 @@ int main()
   x->next->prev = x;
   x = x->next;
   x->data = 0;
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = 1;
  x->next = malloc(sizeof(SLL));
@@ -1146,16 +1146,16 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (1 != x->data)
  {
-  do { if (!(0 == x->data)) __VERIFIER_error("assertion failed: " "0 == x->data");} while (0);
+  do { if (!(0 == x->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  x = x->next;
- do { if (!(2 != x->data)) __VERIFIER_error("assertion failed: " "2 != x->data");} while (0);
+ do { if (!(2 != x->data)) __VERIFIER_error();} while (0);
 
  x = head;
 
@@ -1165,7 +1165,7 @@ int main()
   x = x->next;
   free(head);
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  free(x->next);
  free(x);
 

--- a/c/forester-heap/dll-token_true-unreach-call.c
+++ b/c/forester-heap/dll-token_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list ended with node marked by a special integer value.
  *

--- a/c/forester-heap/dll-token_true-unreach-call.i
+++ b/c/forester-heap/dll-token_true-unreach-call.i
@@ -1137,7 +1137,7 @@ int main()
   x->next->prev = x;
   x = x->next;
   x->data = 0;
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = 1;
  x->next = malloc(sizeof(SLL));
@@ -1146,16 +1146,16 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (1 != x->data)
  {
-  do { if (!(0 == x->data)) __VERIFIER_error("assertion failed: " "0 == x->data");} while (0);
+  do { if (!(0 == x->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  x = x->next;
- do { if (!(2 == x->data)) __VERIFIER_error("assertion failed: " "2 == x->data");} while (0);
+ do { if (!(2 == x->data)) __VERIFIER_error();} while (0);
 
  x = head;
 
@@ -1165,7 +1165,7 @@ int main()
   x = x->next;
   free(head);
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  free(x->next);
  free(x);
 

--- a/c/forester-heap/sll-01_false-unreach-call.c
+++ b/c/forester-heap/sll-01_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with inner list of length 0 or 1.
  *

--- a/c/forester-heap/sll-01_false-unreach-call.i
+++ b/c/forester-heap/sll-01_false-unreach-call.i
@@ -1123,7 +1123,7 @@ int main()
 
  SLL* list = malloc(sizeof(SLL));
  list->next = ((void*)0);
- do { if (!(list != ((void*)0))) __VERIFIER_error("assertion failed: " "list != NULL");} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "list->inner != NULL || list->inner == NULL");} while (0);;
+ do { if (!(list != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error();} while (0);;
 
  SLL* end = list;
 
@@ -1134,15 +1134,15 @@ int main()
   end->next = malloc(sizeof(SLL));
   end = end->next;
   end->next = ((void*)0);
-  do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-  do { if (!(end != ((void*)0))) __VERIFIER_error("assertion failed: " "end != NULL");} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "end->inner != NULL || end->inner == NULL");} while (0);;
+  do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+  do { if (!(end != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error();} while (0);;
  }
 
  end = ((void*)0);
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
@@ -1154,14 +1154,14 @@ int main()
     len = 1;
    else
     len = 2;
-   do { if (!(((void*)0) != inner)) __VERIFIER_error("assertion failed: " "NULL != inner");} while (0);
-   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error("assertion failed: " "NULL == inner->inner");} while (0);
-   do { if (!(((void*)0) == inner->next)) __VERIFIER_error("assertion failed: " "NULL == inner->next");} while (0);
+   do { if (!(((void*)0) != inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->next)) __VERIFIER_error();} while (0);
    inner = inner->inner;
    if (len == 1)
     inner = inner->inner;
   }
-  do { if (!(len <= 1)) __VERIFIER_error("assertion failed: " "len <= 1");} while (0);
+  do { if (!(len <= 1)) __VERIFIER_error();} while (0);
 
   end = end->next;
  }
@@ -1173,9 +1173,9 @@ int main()
 
   if (((void*)0) != end)
   {
-   do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-   do { if (!(((void*)0) == end->inner)) __VERIFIER_error("assertion failed: " "NULL == end->inner");} while (0);
-   do { if (!(((void*)0) == end->next)) __VERIFIER_error("assertion failed: " "NULL == end->next");} while (0);
+   do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->next)) __VERIFIER_error();} while (0);
    free(end);
    end = ((void*)0);
   }

--- a/c/forester-heap/sll-01_true-unreach-call.c
+++ b/c/forester-heap/sll-01_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with inner list of length 0 or 1.
  *

--- a/c/forester-heap/sll-01_true-unreach-call.i
+++ b/c/forester-heap/sll-01_true-unreach-call.i
@@ -1123,7 +1123,7 @@ int main()
 
  SLL* list = malloc(sizeof(SLL));
  list->next = ((void*)0);
- do { if (!(list != ((void*)0))) __VERIFIER_error("assertion failed: " "list != NULL");} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "list->inner != NULL || list->inner == NULL");} while (0);;
+ do { if (!(list != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { list->inner = ((void*)0); } else { list->inner = malloc(sizeof(SLL)); list->inner->next = ((void*)0); list->inner->inner = ((void*)0); } do { if (!(list->inner != ((void*)0) || list->inner == ((void*)0))) __VERIFIER_error();} while (0);;
 
  SLL* end = list;
 
@@ -1134,15 +1134,15 @@ int main()
   end->next = malloc(sizeof(SLL));
   end = end->next;
   end->next = ((void*)0);
-  do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-  do { if (!(end != ((void*)0))) __VERIFIER_error("assertion failed: " "end != NULL");} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error("assertion failed: " "end->inner != NULL || end->inner == NULL");} while (0);;
+  do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+  do { if (!(end != ((void*)0))) __VERIFIER_error();} while (0); if (__VERIFIER_nondet_int()) { end->inner = ((void*)0); } else { end->inner = malloc(sizeof(SLL)); end->inner->next = ((void*)0); end->inner->inner = ((void*)0); } do { if (!(end->inner != ((void*)0) || end->inner == ((void*)0))) __VERIFIER_error();} while (0);;
  }
 
  end = ((void*)0);
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
@@ -1154,12 +1154,12 @@ int main()
     len = 1;
    else
     len = 2;
-   do { if (!(((void*)0) != inner)) __VERIFIER_error("assertion failed: " "NULL != inner");} while (0);
-   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error("assertion failed: " "NULL == inner->inner");} while (0);
-   do { if (!(((void*)0) == inner->next)) __VERIFIER_error("assertion failed: " "NULL == inner->next");} while (0);
+   do { if (!(((void*)0) != inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == inner->next)) __VERIFIER_error();} while (0);
    inner = inner->inner;
   }
-  do { if (!(len <= 1)) __VERIFIER_error("assertion failed: " "len <= 1");} while (0);
+  do { if (!(len <= 1)) __VERIFIER_error();} while (0);
 
   end = end->next;
  }
@@ -1171,9 +1171,9 @@ int main()
 
   if (((void*)0) != end)
   {
-   do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-   do { if (!(((void*)0) == end->inner)) __VERIFIER_error("assertion failed: " "NULL == end->inner");} while (0);
-   do { if (!(((void*)0) == end->next)) __VERIFIER_error("assertion failed: " "NULL == end->next");} while (0);
+   do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->inner)) __VERIFIER_error();} while (0);
+   do { if (!(((void*)0) == end->next)) __VERIFIER_error();} while (0);
    free(end);
    end = ((void*)0);
   }

--- a/c/forester-heap/sll-buckets_false-unreach-call.c
+++ b/c/forester-heap/sll-buckets_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * There are three buckets -- with id 0, 1 and 2.
  * When a new node is generated a random id from the set {0,1,2}

--- a/c/forester-heap/sll-buckets_false-unreach-call.i
+++ b/c/forester-heap/sll-buckets_false-unreach-call.i
@@ -1153,11 +1153,11 @@ int main()
 
   bcki = bucket;
 
-  do { if (!(bcki != ((void*)0))) __VERIFIER_error("assertion failed: " "bcki != NULL");} while (0);
-  do { if (!(item != ((void*)0))) __VERIFIER_error("assertion failed: " "item != NULL");} while (0);
+  do { if (!(bcki != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(item != ((void*)0))) __VERIFIER_error();} while (0);
   while (bcki->data != item->data)
    bcki = bcki->next;
-  do { if (!(bcki != ((void*)0))) __VERIFIER_error("assertion failed: " "bcki != NULL");} while (0);
+  do { if (!(bcki != ((void*)0))) __VERIFIER_error();} while (0);
 
   if (bcki->list == ((void*)0))
    bcki->list = item;
@@ -1180,10 +1180,10 @@ int main()
   {
    itr = item;
    item = item->next;
-   do { if (!(itr->data != bcki->data)) __VERIFIER_error("assertion failed: " "itr->data != bcki->data");} while (0);
+   do { if (!(itr->data != bcki->data)) __VERIFIER_error();} while (0);
    free(itr);
   }
-  do { if (!(item == ((void*)0))) __VERIFIER_error("assertion failed: " "item == NULL");} while (0);
+  do { if (!(item == ((void*)0))) __VERIFIER_error();} while (0);
   bucket = bcki;
   bcki = bcki->next;
   free(bucket);

--- a/c/forester-heap/sll-buckets_true-unreach-call.c
+++ b/c/forester-heap/sll-buckets_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * There are three buckets -- with id 0, 1 and 2.
  * When a new node is generated a random id from the set {0,1,2}

--- a/c/forester-heap/sll-buckets_true-unreach-call.i
+++ b/c/forester-heap/sll-buckets_true-unreach-call.i
@@ -1153,11 +1153,11 @@ int main()
 
   bcki = bucket;
 
-  do { if (!(bcki != ((void*)0))) __VERIFIER_error("assertion failed: " "bcki != NULL");} while (0);
-  do { if (!(item != ((void*)0))) __VERIFIER_error("assertion failed: " "item != NULL");} while (0);
+  do { if (!(bcki != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(item != ((void*)0))) __VERIFIER_error();} while (0);
   while (bcki->data != item->data)
    bcki = bcki->next;
-  do { if (!(bcki != ((void*)0))) __VERIFIER_error("assertion failed: " "bcki != NULL");} while (0);
+  do { if (!(bcki != ((void*)0))) __VERIFIER_error();} while (0);
 
   if (bcki->list == ((void*)0))
    bcki->list = item;
@@ -1180,10 +1180,10 @@ int main()
   {
    itr = item;
    item = item->next;
-   do { if (!(itr->data == bcki->data)) __VERIFIER_error("assertion failed: " "itr->data == bcki->data");} while (0);
+   do { if (!(itr->data == bcki->data)) __VERIFIER_error();} while (0);
    free(itr);
   }
-  do { if (!(item == ((void*)0))) __VERIFIER_error("assertion failed: " "item == NULL");} while (0);
+  do { if (!(item == ((void*)0))) __VERIFIER_error();} while (0);
   bucket = bcki;
   bcki = bcki->next;
   free(bucket);

--- a/c/forester-heap/sll-circular_false-unreach-call.c
+++ b/c/forester-heap/sll-circular_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A circular list where a head of list is marked
  * by integer value 0. The rest of list forms

--- a/c/forester-heap/sll-circular_false-unreach-call.i
+++ b/c/forester-heap/sll-circular_false-unreach-call.i
@@ -1142,16 +1142,16 @@ int main()
 
   x->data = state;
 
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = state;
 
  x = head->next;
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (x->data != 0)
  {
-  do { if (!(x->next->data != 0 && x->data > x->next->data)) __VERIFIER_error("assertion failed: " "x->next->data != 0 && x->data > x->next->data");} while (0);
+  do { if (!(x->next->data != 0 && x->data > x->next->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/sll-circular_true-unreach-call.c
+++ b/c/forester-heap/sll-circular_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A circular list where a head of list is marked
  * by integer value 0. The rest of list forms

--- a/c/forester-heap/sll-circular_true-unreach-call.i
+++ b/c/forester-heap/sll-circular_true-unreach-call.i
@@ -1142,16 +1142,16 @@ int main()
 
   x->data = state;
 
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = state;
 
  x = head->next;
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (x->data != 0)
  {
-  do { if (!(x->next->data == 0 || x->data <= x->next->data)) __VERIFIER_error("assertion failed: " "x->next->data == 0 || x->data <= x->next->data");} while (0);
+  do { if (!(x->next->data == 0 || x->data <= x->next->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/sll-optional_false-unreach-call.c
+++ b/c/forester-heap/sll-optional_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with nodes which can point to an optional
  * external node. Whether an optional node is allocated

--- a/c/forester-heap/sll-optional_false-unreach-call.i
+++ b/c/forester-heap/sll-optional_false-unreach-call.i
@@ -1127,7 +1127,7 @@ int main()
  x = head;
  while (x != ((void*)0))
  {
-  do { if (!(x->data == 2 && x->opt == x)) __VERIFIER_error("assertion failed: " "x->data == 2 && x->opt == x");} while (0);
+  do { if (!(x->data == 2 && x->opt == x)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/sll-optional_true-unreach-call.c
+++ b/c/forester-heap/sll-optional_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with nodes which can point to an optional
  * external node. Whether an optional node is allocated

--- a/c/forester-heap/sll-optional_true-unreach-call.i
+++ b/c/forester-heap/sll-optional_true-unreach-call.i
@@ -1127,7 +1127,7 @@ int main()
  x = head;
  while (x != ((void*)0))
  {
-  do { if (!((x->data == 2 && x->opt != x && x->opt->next == ((void*)0)) || x->opt == x)) __VERIFIER_error("assertion failed: " "(x->data == 2 && x->opt != x && x->opt->next == NULL) || x->opt == x");} while (0);
+  do { if (!((x->data == 2 && x->opt != x && x->opt->next == ((void*)0)) || x->opt == x)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 

--- a/c/forester-heap/sll-queue_false-unreach-call.c
+++ b/c/forester-heap/sll-queue_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * We create a list with nodes containing the integers 0, 1, 2, and 3.
  * The list can form sequences 0, 01, 012, 0123^*. A particular sequence is created

--- a/c/forester-heap/sll-queue_false-unreach-call.i
+++ b/c/forester-heap/sll-queue_false-unreach-call.i
@@ -1143,36 +1143,36 @@ int main()
    status = 3;
   }
 
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(item != ((void*)0))) __VERIFIER_error("assertion failed: " "item != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(item != ((void*)0))) __VERIFIER_error();} while (0);
  }
 
- do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
+ do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
  if (status == 1)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 2)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 3)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next->data != 3)) __VERIFIER_error("assertion failed: " "head->next->next->next->data != 3");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next->data != 3)) __VERIFIER_error();} while (0);
  }
 
  item = head->next;
 
  while(item && __VERIFIER_nondet_int())
  {
-  do { if (!(!status || item->data > 0)) __VERIFIER_error("assertion failed: " "!status || item->data > 0");} while (0);
+  do { if (!(!status || item->data > 0)) __VERIFIER_error();} while (0);
 # 107 "sll-queue_false-unreach-call.c"
   item = item->next;
  }

--- a/c/forester-heap/sll-queue_true-unreach-call.c
+++ b/c/forester-heap/sll-queue_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * We create a list with nodes containing the integers 0, 1, 2, and 3.
  * The list can form sequences 0, 01, 012, 0123^*. A particular sequence is created

--- a/c/forester-heap/sll-queue_true-unreach-call.i
+++ b/c/forester-heap/sll-queue_true-unreach-call.i
@@ -1143,36 +1143,36 @@ int main()
    status = 3;
   }
 
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(item != ((void*)0))) __VERIFIER_error("assertion failed: " "item != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(item != ((void*)0))) __VERIFIER_error();} while (0);
  }
 
- do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
+ do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
  if (status == 1)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 2)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
  }
  if (status == 3)
  {
-  do { if (!(head != ((void*)0))) __VERIFIER_error("assertion failed: " "head != NULL");} while (0);
-  do { if (!(head->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next != NULL");} while (0);
-  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error("assertion failed: " "head->next->next->next != NULL");} while (0);
-  do { if (!(head->next->next->next->data == 3)) __VERIFIER_error("assertion failed: " "head->next->next->next->data == 3");} while (0);
+  do { if (!(head != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next != ((void*)0))) __VERIFIER_error();} while (0);
+  do { if (!(head->next->next->next->data == 3)) __VERIFIER_error();} while (0);
  }
 
  item = head->next;
 
  while(item && __VERIFIER_nondet_int())
  {
-  do { if (!(!status || item->data > 0)) __VERIFIER_error("assertion failed: " "!status || item->data > 0");} while (0);
+  do { if (!(!status || item->data > 0)) __VERIFIER_error();} while (0);
 # 107 "sll-queue_true-unreach-call.c"
   item = item->next;
  }

--- a/c/forester-heap/sll-rb-cnstr_1_false-unreach-call.c
+++ b/c/forester-heap/sll-rb-cnstr_1_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*

--- a/c/forester-heap/sll-rb-cnstr_1_false-unreach-call.i
+++ b/c/forester-heap/sll-rb-cnstr_1_false-unreach-call.i
@@ -1156,8 +1156,8 @@ int main()
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
@@ -1167,7 +1167,7 @@ int main()
    end = end->next;
   }
 
-  do { if (!(end->next)) __VERIFIER_error("assertion failed: " "end->next");} while (0);
+  do { if (!(end->next)) __VERIFIER_error();} while (0);
   end = end->next;
  }
 

--- a/c/forester-heap/sll-rb-cnstr_1_true-unreach-call.c
+++ b/c/forester-heap/sll-rb-cnstr_1_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*

--- a/c/forester-heap/sll-rb-cnstr_1_true-unreach-call.i
+++ b/c/forester-heap/sll-rb-cnstr_1_true-unreach-call.i
@@ -1156,16 +1156,16 @@ int main()
  end = list;
 
 
- do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
 
  while (((void*)0) != end)
  {
   if (RED == end->colour)
   {
    end = end->next;
-   do { if (!(((void*)0) != end)) __VERIFIER_error("assertion failed: " "NULL != end");} while (0);
-   do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+   do { if (!(((void*)0) != end)) __VERIFIER_error();} while (0);
+   do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
   }
 
   end = end->next;

--- a/c/forester-heap/sll-rb-sentinel_false-unreach-call.c
+++ b/c/forester-heap/sll-rb-sentinel_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*. Null is modelled by a special node.

--- a/c/forester-heap/sll-rb-sentinel_false-unreach-call.i
+++ b/c/forester-heap/sll-rb-sentinel_false-unreach-call.i
@@ -1159,17 +1159,17 @@ int main()
  end = list;
 
 
- do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(null != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
 
  while (null != end)
  {
   if (RED == end->colour)
   {
    end = end->next;
-   do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
-   do { if (!(BLACK != end->colour)) __VERIFIER_error("assertion failed: " "BLACK != end->colour");} while (0);
-   do { if (!(0)) __VERIFIER_error("assertion failed: " "0");} while (0);
+   do { if (!(null != end)) __VERIFIER_error();} while (0);
+   do { if (!(BLACK != end->colour)) __VERIFIER_error();} while (0);
+   do { if (!(0)) __VERIFIER_error();} while (0);
   }
 
   end = end->next;

--- a/c/forester-heap/sll-rb-sentinel_true-unreach-call.c
+++ b/c/forester-heap/sll-rb-sentinel_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /**
  * Red-black list, i.e. a list with coloured nodes (black or red) that satisfies
  * the condition B . (B + RB)*. Null is modelled by a special node.

--- a/c/forester-heap/sll-rb-sentinel_true-unreach-call.i
+++ b/c/forester-heap/sll-rb-sentinel_true-unreach-call.i
@@ -1159,16 +1159,16 @@ int main()
  end = list;
 
 
- do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
- do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+ do { if (!(null != end)) __VERIFIER_error();} while (0);
+ do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
 
  while (null != end)
  {
   if (RED == end->colour)
   {
    end = end->next;
-   do { if (!(null != end)) __VERIFIER_error("assertion failed: " "null != end");} while (0);
-   do { if (!(BLACK == end->colour)) __VERIFIER_error("assertion failed: " "BLACK == end->colour");} while (0);
+   do { if (!(null != end)) __VERIFIER_error();} while (0);
+   do { if (!(BLACK == end->colour)) __VERIFIER_error();} while (0);
   }
 
   end = end->next;

--- a/c/forester-heap/sll-reverse_simple_true-unreach-call.c
+++ b/c/forester-heap/sll-reverse_simple_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list with all nodes white, except two.
  * One green and red. It holds that the green

--- a/c/forester-heap/sll-reverse_simple_true-unreach-call.i
+++ b/c/forester-heap/sll-reverse_simple_true-unreach-call.i
@@ -1128,10 +1128,10 @@ int main()
  x = head;
  while (x->next != ((void*)0) && __VERIFIER_nondet_int())
  {
-  do { if (!(x != ((void*)0))) __VERIFIER_error("assertion failed: " "x != NULL");} while (0);
+  do { if (!(x != ((void*)0))) __VERIFIER_error();} while (0);
   x = x->next;
  }
- do { if (!(x != ((void*)0))) __VERIFIER_error("assertion failed: " "x != NULL");} while (0);
+ do { if (!(x != ((void*)0))) __VERIFIER_error();} while (0);
 
  x->data = 1;
 
@@ -1166,7 +1166,7 @@ int main()
   int t2 = 0;
   if (t1 == 2)
    t2 = x->next->data;
-  do { if (!(t1 != 2 || t2 == 1)) __VERIFIER_error("assertion failed: " "t1 != RED || t2 == GREEN");} while (0);
+  do { if (!(t1 != 2 || t2 == 1)) __VERIFIER_error();} while (0);
 
 
   if (x->data == 2)

--- a/c/forester-heap/sll-simple-white-blue_false-unreach-call.c
+++ b/c/forester-heap/sll-simple-white-blue_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list consists of one blue node and nondterministic number of white nodes.
  * The blue node is inserted to a nondeterministic position in list.

--- a/c/forester-heap/sll-simple-white-blue_false-unreach-call.i
+++ b/c/forester-heap/sll-simple-white-blue_false-unreach-call.i
@@ -1172,7 +1172,7 @@ int main()
     while (x)
  {
   if (x->data != 1)
-   do { if (!(0)) __VERIFIER_error("assertion failed: " "0");} while (0);
+   do { if (!(0)) __VERIFIER_error();} while (0);
         x = x->next;
     }
 

--- a/c/forester-heap/sll-simple-white-blue_true-unreach-call.c
+++ b/c/forester-heap/sll-simple-white-blue_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list consists of one blue node and nondterministic number of white nodes.
  * The blue node is inserted to a nondeterministic position in list.

--- a/c/forester-heap/sll-simple-white-blue_true-unreach-call.i
+++ b/c/forester-heap/sll-simple-white-blue_true-unreach-call.i
@@ -1172,7 +1172,7 @@ int main()
     while (x)
  {
   if (x->data == 1)
-   do { if (!(0)) __VERIFIER_error("assertion failed: " "0");} while (0);
+   do { if (!(0)) __VERIFIER_error();} while (0);
         x = x->next;
     }
 

--- a/c/forester-heap/sll-sorted_false-unreach-call.c
+++ b/c/forester-heap/sll-sorted_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list containing nodes with integer values 0 and 1.
  * The list is created such way that nodes are sorted by value.

--- a/c/forester-heap/sll-sorted_false-unreach-call.i
+++ b/c/forester-heap/sll-sorted_false-unreach-call.i
@@ -1143,7 +1143,7 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  marked = 0;
 
  while (x->next != ((void*)0) && x->next->data == 0)
@@ -1154,7 +1154,7 @@ int main()
  while (x->next != ((void*)0) && __VERIFIER_nondet_int())
  {
   x = x->next;
-  do { if (!(x->data == 1)) __VERIFIER_error("assertion failed: " "x->data == 1");} while (0);
+  do { if (!(x->data == 1)) __VERIFIER_error();} while (0);
  }
 
  SLL* tmp = malloc(sizeof(SLL));
@@ -1174,15 +1174,15 @@ int main()
  while (x != ((void*)0) && x->data != 1)
  {
   marked = x->data;
-  do { if (!(x->data == 0)) __VERIFIER_error("assertion failed: " "x->data == 0");} while (0);
-  do { if (!(marked == 0)) __VERIFIER_error("assertion failed: " "marked == 0");} while (0);
+  do { if (!(x->data == 0)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 0)) __VERIFIER_error();} while (0);
   x = x->next;
  }
  while (x != ((void*)0))
  {
   marked = x->data;
-  do { if (!(x->data != 1)) __VERIFIER_error("assertion failed: " "x->data != 1");} while (0);
-  do { if (!(marked == 1)) __VERIFIER_error("assertion failed: " "marked == 1");} while (0);
+  do { if (!(x->data != 1)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 1)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 # 107 "sll-sorted_false-unreach-call.c"

--- a/c/forester-heap/sll-sorted_true-unreach-call.c
+++ b/c/forester-heap/sll-sorted_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list containing nodes with integer values 0 and 1.
  * The list is created such way that nodes are sorted by value.

--- a/c/forester-heap/sll-sorted_true-unreach-call.i
+++ b/c/forester-heap/sll-sorted_true-unreach-call.i
@@ -1143,19 +1143,19 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  marked = 0;
 
  while (x->next != ((void*)0) && x->next->data == 0)
  {
-  do { if (!(x->data == 0)) __VERIFIER_error("assertion failed: " "x->data == 0");} while (0);
+  do { if (!(x->data == 0)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 
  while (x->next != ((void*)0) && __VERIFIER_nondet_int())
  {
   x = x->next;
-  do { if (!(x->data == 1)) __VERIFIER_error("assertion failed: " "x->data == 1");} while (0);
+  do { if (!(x->data == 1)) __VERIFIER_error();} while (0);
  }
 
  SLL* tmp = malloc(sizeof(SLL));
@@ -1174,15 +1174,15 @@ int main()
  while (x != ((void*)0) && x->data != 1)
  {
   marked = x->data;
-  do { if (!(x->data == 0)) __VERIFIER_error("assertion failed: " "x->data == 0");} while (0);
-  do { if (!(marked == 0)) __VERIFIER_error("assertion failed: " "marked == 0");} while (0);
+  do { if (!(x->data == 0)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 0)) __VERIFIER_error();} while (0);
   x = x->next;
  }
  while (x != ((void*)0))
  {
   marked = x->data;
-  do { if (!(x->data == 1)) __VERIFIER_error("assertion failed: " "x->data == 1");} while (0);
-  do { if (!(marked == 1)) __VERIFIER_error("assertion failed: " "marked == 1");} while (0);
+  do { if (!(x->data == 1)) __VERIFIER_error();} while (0);
+  do { if (!(marked == 1)) __VERIFIER_error();} while (0);
   x = x->next;
  }
 # 107 "sll-sorted_true-unreach-call.c"

--- a/c/forester-heap/sll-token_false-unreach-call.c
+++ b/c/forester-heap/sll-token_false-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list ended with node marked by a special integer value.
  *

--- a/c/forester-heap/sll-token_false-unreach-call.i
+++ b/c/forester-heap/sll-token_false-unreach-call.i
@@ -1134,7 +1134,7 @@ int main()
   x->next = malloc(sizeof(SLL));
   x = x->next;
   x->data = 0;
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = 1;
  x->next = malloc(sizeof(SLL));
@@ -1142,16 +1142,16 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (1 != x->data)
  {
-  do { if (!(0 == x->data)) __VERIFIER_error("assertion failed: " "0 == x->data");} while (0);
+  do { if (!(0 == x->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
- do { if (!(2 == x->data)) __VERIFIER_error("assertion failed: " "2 == x->data");} while (0);
+ do { if (!(2 == x->data)) __VERIFIER_error();} while (0);
  x = x->next;
- do { if (!(2 == x->data)) __VERIFIER_error("assertion failed: " "2 == x->data");} while (0);
+ do { if (!(2 == x->data)) __VERIFIER_error();} while (0);
 
  x = head;
 
@@ -1161,7 +1161,7 @@ int main()
   x = x->next;
   free(head);
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  free(x->next);
  free(x);
 

--- a/c/forester-heap/sll-token_true-unreach-call.c
+++ b/c/forester-heap/sll-token_true-unreach-call.c
@@ -1,4 +1,4 @@
-#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error("assertion failed: " #cond);} while (0)
+#define __VERIFIER_assert(cond) do { if (!(cond)) __VERIFIER_error();} while (0)
 /*
  * A list ended with node marked by a special integer value.
  *

--- a/c/forester-heap/sll-token_true-unreach-call.i
+++ b/c/forester-heap/sll-token_true-unreach-call.i
@@ -1134,7 +1134,7 @@ int main()
   x->next = malloc(sizeof(SLL));
   x = x->next;
   x->data = 0;
-  do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+  do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
  }
  x->data = 1;
  x->next = malloc(sizeof(SLL));
@@ -1142,16 +1142,16 @@ int main()
 
  x = head;
 
- do { if (!(((void*)0) != x)) __VERIFIER_error("assertion failed: " "NULL != x");} while (0);
+ do { if (!(((void*)0) != x)) __VERIFIER_error();} while (0);
 
  while (1 != x->data)
  {
-  do { if (!(0 == x->data)) __VERIFIER_error("assertion failed: " "0 == x->data");} while (0);
+  do { if (!(0 == x->data)) __VERIFIER_error();} while (0);
   x = x->next;
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  x = x->next;
- do { if (!(2 == x->data)) __VERIFIER_error("assertion failed: " "2 == x->data");} while (0);
+ do { if (!(2 == x->data)) __VERIFIER_error();} while (0);
 
  x = head;
 
@@ -1161,7 +1161,7 @@ int main()
   x = x->next;
   free(head);
  }
- do { if (!(1 == x->data)) __VERIFIER_error("assertion failed: " "1 == x->data");} while (0);
+ do { if (!(1 == x->data)) __VERIFIER_error();} while (0);
  free(x->next);
  free(x);
 


### PR DESCRIPTION
I've fixed a problem with the __VERIFIER_error macro parameter.