### PR TITLE
Fixed undefinedness for bitvector category.

### DIFF
--- a/c/bitvector/byte_add_1_true-unreach-call.c
+++ b/c/bitvector/byte_add_1_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -105,6 +105,7 @@ int main()
     unsigned int a, b, r;
 
     a = 234770789;
+    b = __VERIFIER_nondet_uint();
 
     r = mp_add(a, b);
 

--- a/c/bitvector/byte_add_2_true-unreach-call.c
+++ b/c/bitvector/byte_add_2_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -104,6 +104,7 @@ int main()
 {
     unsigned int a, b, r;
 
+    a = __VERIFIER_nondet_uint();
     b = 234770789;
 
     r = mp_add(a, b);

--- a/c/bitvector/interleave_bits_true-unreach-call.c
+++ b/c/bitvector/interleave_bits_true-unreach-call.c
@@ -1,6 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 extern int __VERIFIER_nondet_int(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -14,8 +15,8 @@ int main()
 {
     /* Interleave bits of x and y, so that all of the */
     /* bits of x are in the even positions and y in the odd; */
-    unsigned short x;
-    unsigned short y;
+    unsigned short x = __VERIFIER_nondet_ushort();
+    unsigned short y = __VERIFIER_nondet_ushort();
 
     unsigned int xx;
     unsigned int yy;

--- a/c/bitvector/num_conversion_2_true-unreach-call.c
+++ b/c/bitvector/num_conversion_2_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned char __VERIFIER_nondet_uchar(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -15,6 +15,7 @@ int main()
     unsigned char y;
     unsigned char c;
 
+    x = __VERIFIER_nondet_uchar();
     y = 0;
     c = 0;
     while (c < (unsigned char)8) {

--- a/c/bitvector/parity_true-unreach-call.c
+++ b/c/bitvector/parity_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -12,7 +12,7 @@ void __VERIFIER_assert(int cond) {
 
 int main()
 {
-    unsigned int v;
+    unsigned int v = __VERIFIER_nondet_uint();
     unsigned int v1;
     unsigned int v2;
     char parity1;

--- a/c/bitvector/s3_clnt_1_true-unreach-call.BV.c.cil.c
+++ b/c/bitvector/s3_clnt_1_true-unreach-call.BV.c.cil.c
@@ -21,7 +21,7 @@ int ssl3_connect(void)
   int s__debug  = __VERIFIER_nondet_int();
   int s__shutdown ;
   int s__ctx__info_callback  = __VERIFIER_nondet_int();
-  int s__ctx__stats__sess_connect_renegotiate ;
+  int s__ctx__stats__sess_connect_renegotiate = __VERIFIER_nondet_int();
   int s__ctx__stats__sess_connect ;
   int s__ctx__stats__sess_hit  = __VERIFIER_nondet_int();
   int s__ctx__stats__sess_connect_good  = __VERIFIER_nondet_int();

--- a/c/bitvector/s3_clnt_2_true-unreach-call.BV.c.cil.c
+++ b/c/bitvector/s3_clnt_2_true-unreach-call.BV.c.cil.c
@@ -21,7 +21,7 @@ int ssl3_connect(void)
   int s__debug  = __VERIFIER_nondet_int();
   int s__shutdown ;
   int s__ctx__info_callback  = __VERIFIER_nondet_int();
-  int s__ctx__stats__sess_connect_renegotiate ;
+  int s__ctx__stats__sess_connect_renegotiate = __VERIFIER_nondet_int();
   int s__ctx__stats__sess_connect ;
   int s__ctx__stats__sess_hit  = __VERIFIER_nondet_int();
   int s__ctx__stats__sess_connect_good  = __VERIFIER_nondet_int();

--- a/c/bitvector/s3_clnt_3_true-unreach-call.BV.c.cil.c
+++ b/c/bitvector/s3_clnt_3_true-unreach-call.BV.c.cil.c
@@ -21,7 +21,7 @@ int ssl3_connect(void)
   int s__debug  = __VERIFIER_nondet_int();
   int s__shutdown ;
   int s__ctx__info_callback  = __VERIFIER_nondet_int();
-  int s__ctx__stats__sess_connect_renegotiate ;
+  int s__ctx__stats__sess_connect_renegotiate = __VERIFIER_nondet_int();
   int s__ctx__stats__sess_connect ;
   int s__ctx__stats__sess_hit  = __VERIFIER_nondet_int();
   int s__ctx__stats__sess_connect_good  = __VERIFIER_nondet_int();


### PR DESCRIPTION
Initialize variables with nondet values, if they were previously used uninitialized.

For bitvector/interleave_bits_true-unreach-call.c ,
RV-Match reports undefinedness due to a bitwise left shift
for which the right operand is "equal or bigger" than
the bit size of the left operand. (Line 28).
To my understanding, this is a false positive since GNU C only defines
this operation undefined if the right operand is "bigger"
than the bit size of the left operand.
(https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Bit-Shifting)

In the given case .. << (i + 1), i is always smaller than 32,
so assuming a 32 bit machine model, the operation is defined
due to i+1 <= 32.