### PR TITLE
Fix undefined behavior in tasks of category Concurrency

### DIFF
--- a/c/ldv-races/race-2_1-container_of_true-unreach-call.c
+++ b/c/ldv-races/race-2_1-container_of_true-unreach-call.c
@@ -3,11 +3,15 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifndef offsetof
 #define offsetof(TYPE, MEMBER) ((unsigned long) &((TYPE *)0)->MEMBER)
+#endif
 
+#ifndef container_of
 #define container_of(ptr, type, member) ({                      \
 	const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
 	(type *)( (char *)__mptr - offsetof(type,member) );})
+#endif
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 int __VERIFIER_nondet_int(void);

--- a/c/ldv-races/race-3_1-container_of-global_true-unreach-call.c
+++ b/c/ldv-races/race-3_1-container_of-global_true-unreach-call.c
@@ -3,11 +3,15 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifndef offsetof
 #define offsetof(TYPE, MEMBER) ((unsigned long) &((TYPE *)0)->MEMBER)
+#endif
 
+#ifndef container_of
 #define container_of(ptr, type, member) ({                      \
 	const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
 	(type *)( (char *)__mptr - offsetof(type,member) );})
+#endif
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 int __VERIFIER_nondet_int(void);

--- a/c/pthread-lit/sssc12_true-unreach-call.c
+++ b/c/pthread-lit/sssc12_true-unreach-call.c
@@ -3,6 +3,7 @@
 // Self-Reflection", SAS 2012
 
 #include <pthread.h>
+#include <stdlib.h>
 #include "assert.h"
 
 int *data;

--- a/c/pthread-lit/sssc12_variant_true-unreach-call.c
+++ b/c/pthread-lit/sssc12_variant_true-unreach-call.c
@@ -3,6 +3,7 @@
 // Self-Reflection", SAS 2012
 
 #include <pthread.h>
+#include <stdlib.h>
 #include "assert.h"
 
 int *data;


### PR DESCRIPTION
One error reported by RV-Match is due to macro `offsetof` being defined multiple times.
Should we fix these by adding `#ifndef` or not? In a real-case scenario, a warning might be more useful than masking the error, IMO.

Other fixes add missing headers to include `malloc`.

