### PR TITLE
Fix undefinedness of task in signedintegeroverflow-regression

### DIFF
--- a/c/signedintegeroverflow-regression/IntegerPromotion_true-no-overflow.c
+++ b/c/signedintegeroverflow-regression/IntegerPromotion_true-no-overflow.c
@@ -13,6 +13,6 @@ int main() {
 	// which is defined in 6.3.1.3.2 of C11
 	// http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf
 	unsigned short b = a + a + a;
-	printf("value %u",b);
+	printf("value %hu",b);
 	return 0;
 }

--- a/c/signedintegeroverflow-regression/IntegerPromotion_true-no-overflow.c.i
+++ b/c/signedintegeroverflow-regression/IntegerPromotion_true-no-overflow.c.i
@@ -331,6 +331,6 @@ extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)
 int main() {
  short a = 32767;
  unsigned short b = a + a + a;
- printf("value %u",b);
+ printf("value %hu",b);
  return 0;
 }


### PR DESCRIPTION
Use correct printf placeholders for `unsigned short`.