### PR TITLE
Fix wrong benchmark

### DIFF
--- a/c/bitvector/sum02_false-unreach-call.c
+++ b/c/bitvector/sum02_false-unreach-call.c
@@ -1,0 +1,17 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+extern unsigned int __VERIFIER_nondet_uint();
+int main() { 
+  unsigned int i, n=__VERIFIER_nondet_uint(), sn=0;
+  for(i=0; i<=n; i++) {
+    sn = sn + i;
+  }
+  __VERIFIER_assert(sn==(n*(n+1))/2 || sn == 0);
+}

--- a/c/bitvector/sum02_false-unreach-call.i
+++ b/c/bitvector/sum02_false-unreach-call.i
@@ -1,0 +1,17 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+extern unsigned int __VERIFIER_nondet_uint();
+int main() {
+  unsigned int i, n=__VERIFIER_nondet_uint(), sn=0;
+  for(i=0; i<=n; i++) {
+    sn = sn + i;
+  }
+  __VERIFIER_assert(sn==(n*(n+1))/2 || sn == 0);
+}

--- a/c/bitvector/sum02_true-unreach-call.c
+++ b/c/bitvector/sum02_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,6 +10,7 @@ void __VERIFIER_assert(int cond) {
 extern unsigned int __VERIFIER_nondet_uint();
 int main() { 
   unsigned int i, n=__VERIFIER_nondet_uint(), sn=0;
+  __VERIFIER_assume(-1000 <= n && n <= 1000);
   for(i=0; i<=n; i++) {
     sn = sn + i;
   }

--- a/c/bitvector/sum02_true-unreach-call.i
+++ b/c/bitvector/sum02_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,6 +10,7 @@ void __VERIFIER_assert(int cond) {
 extern unsigned int __VERIFIER_nondet_uint();
 int main() {
   unsigned int i, n=__VERIFIER_nondet_uint(), sn=0;
+  __VERIFIER_assume(-1000 <= n && n <= 1000);
   for(i=0; i<=n; i++) {
     sn = sn + i;
   }


### PR DESCRIPTION
Based on the fixes from commit bcc887.

Although this doesn't lead to UB, the assertion will eventually fail when sn wrap around.

Signed-off-by: Mikhail Ramalho <mikhail.ramalho@gmail.com>