### PR TITLE
Fixed improper signatures of nondet functions

### DIFF
--- a/c/array-industry-pattern/array_mul_init_true-unreach-call.c
+++ b/c/array-industry-pattern/array_mul_init_true-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 #define SIZE 100000
-unsigned char __VERIFIER_nondet_short();
+short __VERIFIER_nondet_short();
 int main()
 {
 	int a[SIZE];

--- a/c/array-industry-pattern/array_mul_init_true-unreach-call.i
+++ b/c/array-industry-pattern/array_mul_init_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-unsigned char __VERIFIER_nondet_short();
+short __VERIFIER_nondet_short();
 int main()
 {
  int a[100000];

--- a/c/array-industry-pattern/array_of_struct_ptr_mul_init_true-unreach-call.c
+++ b/c/array-industry-pattern/array_of_struct_ptr_mul_init_true-unreach-call.c
@@ -7,8 +7,8 @@ struct S {
 	unsigned short q;		 		  
 } a[SIZE];
 
-//short __VERIFIER_nondet_short();
-unsigned char __VERIFIER_nondet_short();
+short __VERIFIER_nondet_short();
+unsigned char __VERIFIER_nondet_uchar();
 int main()
 {
 	unsigned char k;
@@ -24,7 +24,7 @@ int main()
 	{
 		if ( __VERIFIER_nondet_short())
 		{
-			k = __VERIFIER_nondet_short();
+			k = __VERIFIER_nondet_uchar();
 			a[i].p = k;
 			a[i].q = k * k ;
 		}

--- a/c/array-industry-pattern/array_of_struct_ptr_mul_init_true-unreach-call.i
+++ b/c/array-industry-pattern/array_of_struct_ptr_mul_init_true-unreach-call.i
@@ -4,7 +4,8 @@ struct S {
  unsigned short p;
  unsigned short q;
 } a[100000];
-unsigned char __VERIFIER_nondet_short();
+short __VERIFIER_nondet_short();
+unsigned char __VERIFIER_nondet_uchar();
 int main()
 {
  unsigned char k;
@@ -18,7 +19,7 @@ int main()
  {
   if ( __VERIFIER_nondet_short())
   {
-   k = __VERIFIER_nondet_short();
+   k = __VERIFIER_nondet_uchar();
    a[i].p = k;
    a[i].q = k * k ;
   }

--- a/c/array-industry-pattern/array_single_elem_init_false-unreach-call.c
+++ b/c/array-industry-pattern/array_single_elem_init_false-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 #define SIZE 100000
-int __VERIFIER_nondet();
+int __VERIFIER_nondet_int();
 int main()
 {
 
@@ -13,7 +13,7 @@ int main()
 	//init and update
 	for (i = 0; i < SIZE; i++)
 	{
-		int q = __VERIFIER_nondet();
+		int q = __VERIFIER_nondet_int();
 		a[i] = 0;
 		if (q == 0)
 		{

--- a/c/array-industry-pattern/array_single_elem_init_false-unreach-call.i
+++ b/c/array-industry-pattern/array_single_elem_init_false-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-int __VERIFIER_nondet();
+int __VERIFIER_nondet_int();
 int main()
 {
  int i;
@@ -9,7 +9,7 @@ int main()
  int c[100000];
  for (i = 0; i < 100000; i++)
  {
-  int q = __VERIFIER_nondet();
+  int q = __VERIFIER_nondet_int();
   a[i] = 0;
   if (q == 0)
   {


### PR DESCRIPTION
In these benchmarks nondet functions had improper signatures.
I fixed these issues to the best of my understanding of these
benchmarks.