### PR TITLE
Fix declaration of size_t in product-lines to match the one of 32bit systems

### DIFF
--- a/c/product-lines/Makefile
+++ b/c/product-lines/Makefile
@@ -1,7 +1,6 @@
 LEVEL := ../
 
 CLANG_WARNINGS := \
-	-Wno-incompatible-library-redeclaration \
 	-Wno-uninitialized \
 
 include $(LEVEL)/Makefile.config

--- a/c/product-lines/elevator_spec13_product21_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product21_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product22_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product22_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product23_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product23_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product24_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product24_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product29_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product29_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product30_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product30_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product31_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product31_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_product32_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product32_true-unreach-call_false-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec13_productSimulator_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec13_productSimulator_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product03_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product03_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product11_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product19_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product23_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product31_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec14_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product01_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product01_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product03_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product03_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product09_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product11_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product17_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product18_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product19_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product21_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product21_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product23_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product25_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product31_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec1_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product01_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product01_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product03_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product03_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product09_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product11_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product17_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product18_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product19_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product21_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product21_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product23_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product25_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product31_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec2_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product01_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product01_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product03_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product03_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product09_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product11_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product11_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product17_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product18_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product18_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product19_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product19_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product21_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product21_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product22_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product22_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product23_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product25_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product26_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product26_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product27_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product27_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product30_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product30_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec3_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product09_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product11_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product25_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product31_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/elevator_spec9_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product05_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product05_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product09_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product10_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product10_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product11_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product16_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product19_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product21_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product24_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product24_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product25_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product36_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product36_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product37_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product37_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product38_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product38_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_product40_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product40_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec0_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product03_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product03_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product07_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product07_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product08_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product08_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product10_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product10_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product15_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product18_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product18_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product23_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product24_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product24_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product36_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product36_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product37_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product37_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product39_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product39_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_product40_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product40_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec11_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product12_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product12_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product14_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product14_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product15_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product16_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product21_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product28_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product29_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec1_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product13_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product13_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product17_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product17_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product18_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product19_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product19_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product23_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product25_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product25_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product27_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product27_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product28_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product29_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec27_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product13_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product13_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product17_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product17_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product18_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product19_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product19_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product23_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product25_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product25_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product27_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product27_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product29_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec3_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product13_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product13_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product17_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product18_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product19_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product19_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product23_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product24_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product25_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product25_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product27_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product27_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product28_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec4_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product12_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product12_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product14_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product14_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product15_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product16_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product21_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product29_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec6_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product13_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product13_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product17_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product18_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product18_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product19_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product23_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product24_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product24_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product25_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product27_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product28_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product29_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec7_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product12_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product12_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product14_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product14_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product15_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product16_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product21_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product28_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec8_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product12_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product12_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product14_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product14_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product15_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product16_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product20_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product21_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product22_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product26_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product28_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product29_true-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product30_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product31_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product32_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product33_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product34_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product35_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/email_spec9_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_productSimulator_false-unreach-call_true-termination.cil.c
@@ -30,7 +30,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product01_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product01_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product02_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product02_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product03_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product03_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product04_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product04_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product05_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product05_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product06_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product06_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product07_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product07_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product08_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product08_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product09_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product09_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product10_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product10_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product11_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product11_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product12_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product12_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product13_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product13_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product14_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product14_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product15_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product15_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product16_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product16_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product17_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product17_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product18_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product18_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product19_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product19_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product20_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product20_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product21_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product21_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product22_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product22_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product23_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product23_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product24_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product24_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product25_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product25_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product26_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product26_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product27_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product27_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product28_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product28_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product29_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product29_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product30_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product30_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product31_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product31_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product32_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product32_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product33_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product33_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product34_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product34_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product35_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product35_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product36_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product36_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product37_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product37_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product38_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product38_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product39_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product39_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product40_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product40_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product41_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product41_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product42_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product42_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product43_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product43_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product44_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product44_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product45_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product45_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product46_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product46_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product47_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product47_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product48_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product48_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product49_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product49_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product50_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product50_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product51_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product51_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product52_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product52_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product53_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product53_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product54_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product54_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product55_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product55_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product56_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product56_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product57_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product57_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product58_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product58_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product59_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product59_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product60_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product60_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product61_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product61_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product62_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product62_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product63_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product63_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_product64_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_product64_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec1_productSimulator_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec1_productSimulator_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product01_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product01_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product02_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product02_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product03_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product03_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product04_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product04_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product05_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product05_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product06_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product06_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product07_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product07_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product08_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product08_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product09_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product09_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product10_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product10_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product11_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product11_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product12_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product12_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product13_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product13_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product14_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product14_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product15_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product15_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product16_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product16_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product17_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product17_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product18_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product18_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product19_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product19_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product20_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product20_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product21_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product21_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product22_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product22_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product23_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product23_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product24_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product24_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product25_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product25_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product26_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product26_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product27_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product27_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product28_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product28_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product29_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product29_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product30_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product30_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product31_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product31_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product32_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product32_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product33_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product33_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product34_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product34_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product35_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product35_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product36_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product36_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product37_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product37_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product38_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product38_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product39_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product39_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product40_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product40_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product41_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product41_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product42_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product42_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product43_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product43_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product44_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product44_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product45_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product45_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product46_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product46_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product47_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product47_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product48_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product48_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product49_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product49_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product50_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product50_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product51_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product51_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product52_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product52_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product53_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product53_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product54_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product54_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product55_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product55_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product56_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product56_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product57_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product57_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product58_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product58_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product59_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product59_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product60_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product60_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product61_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product61_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product62_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product62_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product63_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product63_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_product64_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_product64_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec2_productSimulator_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec2_productSimulator_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product01_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product01_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product02_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product02_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product03_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product03_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product04_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product04_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product05_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product05_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product06_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product06_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product07_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product07_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product08_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product08_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product09_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product09_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product10_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product10_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product11_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product11_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product12_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product12_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product13_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product13_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product14_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product14_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product15_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product15_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product16_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product16_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product17_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product17_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product18_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product18_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product19_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product19_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product20_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product20_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product21_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product21_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product22_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product22_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product23_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product23_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product24_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product24_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product25_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product25_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product26_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product26_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product27_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product27_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product28_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product28_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product29_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product29_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product30_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product30_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product31_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product31_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product32_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product32_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product33_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product33_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product34_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product34_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product35_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product35_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product36_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product36_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product37_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product37_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product38_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product38_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product39_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product39_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product40_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product40_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product41_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product41_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product42_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product42_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product43_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product43_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product44_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product44_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product45_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product45_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product46_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product46_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product47_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product47_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product48_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product48_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product49_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product49_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product50_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product50_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product51_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product51_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product52_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product52_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product53_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product53_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product54_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product54_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product55_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product55_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product56_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product56_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product57_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product57_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product58_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product58_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product59_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product59_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product60_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product60_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product61_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product61_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product62_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product62_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product63_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product63_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_product64_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_product64_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec3_productSimulator_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec3_productSimulator_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product01_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product01_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product02_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product02_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product03_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product03_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product04_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product04_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product05_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product05_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product06_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product06_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product07_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product07_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product08_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product08_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product09_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product09_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product10_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product10_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product11_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product11_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product12_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product12_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product13_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product13_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product14_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product14_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product15_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product15_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product16_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product16_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product17_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product17_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product18_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product18_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product19_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product19_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product20_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product20_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product21_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product21_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product22_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product22_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product23_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product23_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product24_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product24_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product25_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product25_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product26_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product26_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product27_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product27_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product28_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product28_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product29_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product29_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product30_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product30_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product31_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product31_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product32_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product32_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product33_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product33_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product34_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product34_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product35_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product35_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product36_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product36_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product37_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product37_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product38_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product38_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product39_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product39_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product40_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product40_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product41_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product41_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product42_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product42_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product43_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product43_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product44_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product44_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product45_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product45_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product46_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product46_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product47_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product47_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product48_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product48_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product49_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product49_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product50_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product50_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product51_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product51_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product52_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product52_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product53_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product53_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product54_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product54_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product55_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product55_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product56_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product56_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product57_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product57_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product58_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product58_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product59_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product59_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product60_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product60_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product61_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product61_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product62_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product62_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product63_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product63_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_product64_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_product64_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec4_productSimulator_false-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec4_productSimulator_false-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product01_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product01_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product02_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product02_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product03_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product03_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product04_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product04_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product05_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product05_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product06_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product06_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product07_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product07_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product08_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product08_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product09_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product09_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product10_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product10_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product11_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product11_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product12_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product12_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product13_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product13_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product14_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product14_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product15_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product15_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product16_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product16_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product17_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product17_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product18_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product18_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product19_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product19_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product20_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product20_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product21_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product21_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product22_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product22_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product23_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product23_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product24_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product24_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product25_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product25_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product26_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product26_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product27_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product27_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product28_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product28_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product29_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product29_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product30_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product30_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product31_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product31_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product32_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product32_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product33_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product33_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product34_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product34_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product35_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product35_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product36_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product36_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product37_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product37_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product38_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product38_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product39_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product39_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product40_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product40_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product41_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product41_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product42_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product42_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product43_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product43_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product44_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product44_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product45_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product45_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product46_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product46_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product47_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product47_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product48_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product48_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product49_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product49_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product50_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product50_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product51_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product51_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product52_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product52_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product53_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product53_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product54_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product54_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product55_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product55_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product56_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product56_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product57_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product57_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product58_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product58_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product59_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product59_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product60_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product60_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product61_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product61_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product62_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product62_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product63_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product63_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_product64_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_product64_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;

--- a/c/product-lines/minepump_spec5_productSimulator_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/minepump_spec5_productSimulator_true-unreach-call_false-termination.cil.c
@@ -31,7 +31,7 @@ struct __UTAC__EXCEPTION {
    int pops ;
    struct __UTAC__CFLOW_FUNC *cflowfuncs ;
 };
-typedef unsigned long size_t;
+typedef unsigned int size_t;
 struct __ACC__ERR {
    void *v ;
    struct __ACC__ERR *next ;


### PR DESCRIPTION
This avoids clang warnings about incompatible library redeclarations
with respect to malloc.