### PR TITLE
Fix a few incompatible library declarations in directory loops.

### DIFF
--- a/c/loops/Makefile
+++ b/c/loops/Makefile
@@ -2,7 +2,6 @@ LEVEL := ../
 
 CLANG_WARNINGS := \
 	-Wno-error=tautological-compare \
-	-Wno-error=incompatible-library-redeclaration \
 	-Wno-error=uninitialized \
 
 include $(LEVEL)/Makefile.config

--- a/c/loops/n.c24_false-unreach-call.i
+++ b/c/loops/n.c24_false-unreach-call.i
@@ -1,5 +1,4 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -7,42 +6,41 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 
-extern void *memcpy (void *__restrict __dest,
-       __const void *__restrict __src, size_t __n)
-     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-extern void *memmove (void *__dest, __const void *__src, size_t __n)
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
-extern void *memccpy (void *__restrict __dest, __const void *__restrict __src,
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
         int __c, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-extern int memcmp (__const void *__s1, __const void *__s2, size_t __n)
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern void *memchr (__const void *__s, int __c, size_t __n)
+extern void *memchr (const void *__s, int __c, size_t __n)
       __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
 
 
-extern char *strcpy (char *__restrict __dest, __const char *__restrict __src)
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern char *strncpy (char *__restrict __dest,
-        __const char *__restrict __src, size_t __n)
+        const char *__restrict __src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *strcat (char *__restrict __dest, __const char *__restrict __src)
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *strncat (char *__restrict __dest, __const char *__restrict __src,
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
         size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-extern int strcmp (__const char *__s1, __const char *__s2)
+extern int strcmp (const char *__s1, const char *__s2)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern int strncmp (__const char *__s1, __const char *__s2, size_t __n)
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern int strcoll (__const char *__s1, __const char *__s2)
+extern int strcoll (const char *__s1, const char *__s2)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
 extern size_t strxfrm (char *__restrict __dest,
-         __const char *__restrict __src, size_t __n)
+         const char *__restrict __src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
 
 typedef struct __locale_struct
@@ -54,44 +52,44 @@ typedef struct __locale_struct
   const char *__names[13];
 } *__locale_t;
 typedef __locale_t locale_t;
-extern int strcoll_l (__const char *__s1, __const char *__s2, __locale_t __l)
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
-extern size_t strxfrm_l (char *__dest, __const char *__src, size_t __n,
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
     __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
-extern char *strdup (__const char *__s)
+extern char *strdup (const char *__s)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
-extern char *strndup (__const char *__string, size_t __n)
+extern char *strndup (const char *__string, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
 
-extern char *strchr (__const char *__s, int __c)
+extern char *strchr (const char *__s, int __c)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
-extern char *strrchr (__const char *__s, int __c)
+extern char *strrchr (const char *__s, int __c)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
 
 
-extern size_t strcspn (__const char *__s, __const char *__reject)
+extern size_t strcspn (const char *__s, const char *__reject)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern size_t strspn (__const char *__s, __const char *__accept)
+extern size_t strspn (const char *__s, const char *__accept)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *strpbrk (__const char *__s, __const char *__accept)
+extern char *strpbrk (const char *__s, const char *__accept)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *strstr (__const char *__haystack, __const char *__needle)
+extern char *strstr (const char *__haystack, const char *__needle)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *strtok (char *__restrict __s, __const char *__restrict __delim)
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
 
 extern char *__strtok_r (char *__restrict __s,
-    __const char *__restrict __delim,
+    const char *__restrict __delim,
     char **__restrict __save_ptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
-extern char *strtok_r (char *__restrict __s, __const char *__restrict __delim,
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
          char **__restrict __save_ptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
 
-extern size_t strlen (__const char *__s)
+extern size_t strlen (const char *__s)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
 
-extern size_t strnlen (__const char *__string, size_t __maxlen)
+extern size_t strnlen (const char *__string, size_t __maxlen)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
 
 extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
@@ -99,33 +97,33 @@ extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
 extern int strerror_r (int __errnum, char *__buf, size_t __buflen) __asm__ ("" "__xpg_strerror_r") __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
 extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
 extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-extern void bcopy (__const void *__src, void *__dest, size_t __n)
+extern void bcopy (const void *__src, void *__dest, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-extern int bcmp (__const void *__s1, __const void *__s2, size_t __n)
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *index (__const char *__s, int __c)
+extern char *index (const char *__s, int __c)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
-extern char *rindex (__const char *__s, int __c)
+extern char *rindex (const char *__s, int __c)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
 extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
-extern int strcasecmp (__const char *__s1, __const char *__s2)
+extern int strcasecmp (const char *__s1, const char *__s2)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
-extern int strncasecmp (__const char *__s1, __const char *__s2, size_t __n)
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
 extern char *strsep (char **__restrict __stringp,
-       __const char *__restrict __delim)
+       const char *__restrict __delim)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
-extern char *__stpcpy (char *__restrict __dest, __const char *__restrict __src)
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-extern char *stpcpy (char *__restrict __dest, __const char *__restrict __src)
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern char *__stpncpy (char *__restrict __dest,
-   __const char *__restrict __src, size_t __n)
+   const char *__restrict __src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern char *stpncpy (char *__restrict __dest,
-        __const char *__restrict __src, size_t __n)
+        const char *__restrict __src, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
 extern int __VERIFIER_nondet_int(void);

--- a/c/loops/s3_false-unreach-call.i
+++ b/c/loops/s3_false-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz);
+extern void *malloc(unsigned int sz);
 
 
 

--- a/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.c
+++ b/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.c
@@ -31,7 +31,7 @@ void __VERIFIER_assert(int cond) {
 /* I had size_t being an unsigned long before, but that led to the
  * infamous "Equality without matching types" error when I used a
  * size_t to index into an array. */
-typedef int size_t;
+typedef unsigned int size_t;
 typedef int bool;
 #define true 1
 #define false 0

--- a/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.i
+++ b/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.i
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-typedef int size_t;
+typedef unsigned int size_t;
 typedef int bool;
 char *strchr(const char *s, int c);
 char *strrchr(const char *s, int c);

--- a/c/loops/verisec_OpenSER__cases1_stripFullBoth_arr_false-unreach-call_true-termination.c
+++ b/c/loops/verisec_OpenSER__cases1_stripFullBoth_arr_false-unreach-call_true-termination.c
@@ -31,7 +31,7 @@ void __VERIFIER_assert(int cond) {
 /* I had size_t being an unsigned long before, but that led to the
  * infamous "Equality without matching types" error when I used a
  * size_t to index into an array. */
-typedef int size_t;
+typedef unsigned int size_t;
 typedef int bool;
 #define true 1
 #define false 0

--- a/c/loops/verisec_OpenSER__cases1_stripFullBoth_arr_false-unreach-call_true-termination.i
+++ b/c/loops/verisec_OpenSER__cases1_stripFullBoth_arr_false-unreach-call_true-termination.i
@@ -6,7 +6,7 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-typedef int size_t;
+typedef unsigned int size_t;
 typedef int bool;
 char *strchr(const char *s, int c);
 char *strrchr(const char *s, int c);


### PR DESCRIPTION
For n.c24_false-unreach-call.i, this is fixed by doing a fresh
pre-processing, which changes only extern function declarations.

For the other files, this is fixed by manually correcting the definition
of size_t (which is only used in extern function declarations) to be unsigned
or fixing malloc declarations.

Thus the change should not affect the semantics of the files.