### PR TITLE
Fix a few incorrect malloc declarations in ntdrivers and ssh directories

### DIFF
--- a/c/ntdrivers/floppy_true-unreach-call.i.cil.c
+++ b/c/ntdrivers/floppy_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ntdrivers/parport_false-unreach-call.i.cil.c
+++ b/c/ntdrivers/parport_false-unreach-call.i.cil.c
@@ -1934,7 +1934,7 @@ struct _SCSI_REQUEST_BLOCK;
 #pragma warning(push)
 #pragma warning(disable:4035)
 #pragma warning(pop)
-extern void *malloc(unsigned long sz ) ;
+extern void *malloc(unsigned int sz ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void *memmove(void * , void const   * , size_t  ) ;

--- a/c/ntdrivers/parport_true-unreach-call.i.cil.c
+++ b/c/ntdrivers/parport_true-unreach-call.i.cil.c
@@ -1934,7 +1934,7 @@ struct _SCSI_REQUEST_BLOCK;
 #pragma warning(push)
 #pragma warning(disable:4035)
 #pragma warning(pop)
-extern void *malloc(unsigned long sz ) ;
+extern void *malloc(unsigned int sz ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void *memmove(void * , void const   * , size_t  ) ;

--- a/c/ssh/Makefile
+++ b/c/ssh/Makefile
@@ -1,6 +1,3 @@
 LEVEL := ../
 
-CLANG_WARNINGS := \
-	-Wno-error=incompatible-library-redeclaration \
-
 include $(LEVEL)/Makefile.config

--- a/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);

--- a/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern void *malloc(unsigned long sz );
+extern void *malloc(unsigned int sz );
 extern char __VERIFIER_nondet_char(void);
 extern int __VERIFIER_nondet_int(void);
 extern long __VERIFIER_nondet_long(void);


### PR DESCRIPTION
This changes only extern declarations and should not affect the
semantics of the files.