### PR TITLE
Fixed undefined behavior due to uninitialized variable

### DIFF
--- a/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.c
+++ b/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define SIZE 100000
 /* 
    Implements a set. Inserts elements from an array of values into the set. Then removes an element from the set and then checks that the removed item is not present in the set.
 */
@@ -20,7 +21,6 @@ int elem_exists( int set [ ] , int size , int value ) {
 
 int main( ) {
   int i, pos, n = 0, found = 0;
-  int SIZE;              // size of the array
   int set[ SIZE ];       // set for storing values
   int values[ SIZE ];    // array of values to be inserted in the array
   int element;           // element to be removed

--- a/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.c
+++ b/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-#define SIZE 100000
+const int SIZE = 100000;
 /* 
    Implements a set. Inserts elements from an array of values into the set. Then removes an element from the set and then checks that the removed item is not present in the set.
 */

--- a/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.i
+++ b/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-#define SIZE 100000
+const int SIZE = 100000;
 int insert( int set [] , int size , int value ) {
   set[ size ] = value;
   return size + 1;

--- a/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.i
+++ b/c/array-industry-pattern/check_removal_from_set_after_insertion_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+#define SIZE 100000
 int insert( int set [] , int size , int value ) {
   set[ size ] = value;
   return size + 1;
@@ -13,7 +14,6 @@ int elem_exists( int set [ ] , int size , int value ) {
 }
 int main( ) {
   int i, pos, n = 0, found = 0;
-  int SIZE;
   int set[ SIZE ];
   int values[ SIZE ];
   int element;


### PR DESCRIPTION
Variable SIZE was not initialized before it was used. I suspect
that SIZE should be a constant set to 100000 like in other
benchmarks in this folder.