### PR TITLE
Fix declaration of size_t in array-industry-pattern benchmarks.

### DIFF
--- a/c/array-industry-pattern/Makefile
+++ b/c/array-industry-pattern/Makefile
@@ -1,7 +1,6 @@
 LEVEL := ../
 
 CLANG_WARNINGS := \
-	-Wno-error=incompatible-library-redeclaration \
 	-Wno-error=uninitialized \
 
 include $(LEVEL)/Makefile.config

--- a/c/array-industry-pattern/array_of_struct_ptr_cond_init_true-unreach-call.c
+++ b/c/array-industry-pattern/array_of_struct_ptr_cond_init_true-unreach-call.c
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }

--- a/c/array-industry-pattern/array_of_struct_ptr_cond_init_true-unreach-call.i
+++ b/c/array-industry-pattern/array_of_struct_ptr_cond_init_true-unreach-call.i
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }

--- a/c/array-industry-pattern/array_of_struct_ptr_flag_init_true-unreach-call.c
+++ b/c/array-industry-pattern/array_of_struct_ptr_flag_init_true-unreach-call.c
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }

--- a/c/array-industry-pattern/array_of_struct_ptr_flag_init_true-unreach-call.i
+++ b/c/array-industry-pattern/array_of_struct_ptr_flag_init_true-unreach-call.i
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }

--- a/c/array-industry-pattern/array_of_struct_ptr_monotonic_true-unreach-call.c
+++ b/c/array-industry-pattern/array_of_struct_ptr_monotonic_true-unreach-call.c
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);

--- a/c/array-industry-pattern/array_of_struct_ptr_monotonic_true-unreach-call.i
+++ b/c/array-industry-pattern/array_of_struct_ptr_monotonic_true-unreach-call.i
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);

--- a/c/array-industry-pattern/array_ptr_partial_init_true-unreach-call.c
+++ b/c/array-industry-pattern/array_ptr_partial_init_true-unreach-call.c
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }

--- a/c/array-industry-pattern/array_ptr_partial_init_true-unreach-call.i
+++ b/c/array-industry-pattern/array_ptr_partial_init_true-unreach-call.i
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }

--- a/c/array-industry-pattern/array_ptr_single_elem_init_true-unreach-call.c
+++ b/c/array-industry-pattern/array_ptr_single_elem_init_true-unreach-call.c
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);

--- a/c/array-industry-pattern/array_ptr_single_elem_init_true-unreach-call.i
+++ b/c/array-industry-pattern/array_ptr_single_elem_init_true-unreach-call.i
@@ -1,4 +1,4 @@
-typedef long unsigned int size_t;
+typedef unsigned int size_t;
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);


### PR DESCRIPTION
It was declared as unsigned long int, but it needs to be unsigned int
because the files are in a 32 bit category.
size_t is only used for the declaration of malloc in these benchmarks.