### PR TITLE
Removed definitions of __VERIFIER_atomic_begin and _end functions

### DIFF
--- a/c/pthread-ext/06_ticket_true-unreach-call.c
+++ b/c/pthread-ext/06_ticket_true-unreach-call.c
@@ -1,6 +1,5 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-ext/06_ticket_true-unreach-call.c
+++ b/c/pthread-ext/06_ticket_true-unreach-call.c
@@ -1,8 +1,8 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 //Ticket lock with proportional backoff
 //

--- a/c/pthread-ext/06_ticket_true-unreach-call.i
+++ b/c/pthread-ext/06_ticket_true-unreach-call.i
@@ -1,6 +1,5 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-ext/06_ticket_true-unreach-call.i
+++ b/c/pthread-ext/06_ticket_true-unreach-call.i
@@ -1,8 +1,8 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;

--- a/c/pthread-lit/LICENSE.txt
+++ b/c/pthread-lit/LICENSE.txt
@@ -1,1 +1,202 @@
-../LICENSE.Apache-2.0.txt
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/c/pthread-lit/assert.h
+++ b/c/pthread-lit/assert.h
@@ -7,6 +7,6 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/assert.h
+++ b/c/pthread-lit/assert.h
@@ -6,7 +6,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fk2012_true-unreach-call.i
+++ b/c/pthread-lit/fk2012_true-unreach-call.i
@@ -2,8 +2,8 @@ extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 extern void __VERIFIER_assume(int);
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern int __VERIFIER_nondet_int(void);
 typedef long unsigned int size_t;
 typedef int wchar_t;

--- a/c/pthread-lit/fk2012_true-unreach-call.i
+++ b/c/pthread-lit/fk2012_true-unreach-call.i
@@ -1,7 +1,6 @@
 extern void __VERIFIER_error(void) __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 extern void __VERIFIER_assume(int);
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 extern int __VERIFIER_nondet_int(void);

--- a/c/pthread-lit/fkp2013_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_false-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fkp2013_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_false-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int x;
 void* thr1(void* arg) {

--- a/c/pthread-lit/fkp2013_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_true-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fkp2013_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_true-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int x;
 void* thr1(void* arg) {

--- a/c/pthread-lit/fkp2013_variant_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_false-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int x;
 volatile int n;

--- a/c/pthread-lit/fkp2013_variant_false-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_false-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fkp2013_variant_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_true-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int x;
 volatile int n;

--- a/c/pthread-lit/fkp2013_variant_true-unreach-call.i
+++ b/c/pthread-lit/fkp2013_variant_true-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fkp2014_true-unreach-call.i
+++ b/c/pthread-lit/fkp2014_true-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/fkp2014_true-unreach-call.i
+++ b/c/pthread-lit/fkp2014_true-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int s;
 volatile int t;

--- a/c/pthread-lit/qw2004_false-unreach-call.i
+++ b/c/pthread-lit/qw2004_false-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/qw2004_false-unreach-call.i
+++ b/c/pthread-lit/qw2004_false-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_true-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/qw2004_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_true-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.i
@@ -654,7 +654,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/qw2004_variant_true-unreach-call.i
+++ b/c/pthread-lit/qw2004_variant_true-unreach-call.i
@@ -655,8 +655,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 volatile int stoppingFlag;
 volatile int pendingIo;

--- a/c/pthread-lit/sssc12_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_true-unreach-call.i
@@ -656,7 +656,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/sssc12_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_true-unreach-call.i
@@ -657,8 +657,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 int *data;
 volatile int len;

--- a/c/pthread-lit/sssc12_variant_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_variant_true-unreach-call.i
@@ -656,7 +656,6 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();

--- a/c/pthread-lit/sssc12_variant_true-unreach-call.i
+++ b/c/pthread-lit/sssc12_variant_true-unreach-call.i
@@ -657,8 +657,8 @@ void __VERIFIER_assert(int cond) {
   return;
 }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 int __VERIFIER_nondet_int();
 int *data;
 volatile int len;

--- a/c/pthread-wmm/mix000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix000_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix000_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix000_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix000_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix000_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix001_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix001_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix001_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix001_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix001_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix002_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix002_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix002_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix002_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix002_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.opt.0.1_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.opt.0_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix003_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix003_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix003_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix003_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix003_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix004_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix004_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix004_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix004_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix004_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix005_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix005_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix005_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix005_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix005_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix006_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix006_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix006_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix006_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix006_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix007_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix007_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix007_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix007_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix007_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix008_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix008_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix008_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix008_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix008_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix009_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix009_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix009_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix009_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix009_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix010_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix010_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix010_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix010_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix010_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix011_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix011_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix011_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix011_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix011_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix012_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix012_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix012_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix012_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix012_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix013_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix013_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix013_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix013_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix013_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix014_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix014_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix014_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix014_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix014_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix015_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix015_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix015_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix015_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix015_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix016_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix016_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix016_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix016_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix016_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix017_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix017_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix017_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix017_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix017_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix018_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix018_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix018_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix018_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix018_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix019_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix019_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix019_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix019_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix019_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix020_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix020_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix020_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix020_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix020_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix021_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix021_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix021_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix021_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix021_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix022_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix022_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix022_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix022_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix022_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix023_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix023_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix023_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix023_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix023_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix024_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix024_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix024_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix024_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix024_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix025_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix025_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix025_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix025_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix025_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix026_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix026_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix026_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix026_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix026_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix027_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix027_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix027_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix027_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix027_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix028_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix028_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix028_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix028_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix028_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix029_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix029_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix029_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix029_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix029_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix030_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix030_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix030_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix030_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix030_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix031_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix031_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix031_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix031_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix031_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix032_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix032_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix032_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix032_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix032_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix033_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix033_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix033_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix033_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix033_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix034_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix034_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix034_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix034_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix034_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix035_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix035_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix035_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix035_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix035_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix036_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix036_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix036_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix036_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix036_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix037_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix037_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix037_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix037_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix037_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix038_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix038_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix038_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix038_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix038_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix039_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix039_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix039_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix039_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix039_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix040_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix040_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix040_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix040_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix040_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix041_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix041_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix041_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix041_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix041_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix042_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix042_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix042_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix042_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix042_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix043_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix043_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix043_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix043_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix043_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix044_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix044_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix044_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix044_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix044_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix045_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix045_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix045_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix045_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix045_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix046_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix046_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix046_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix046_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix046_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix047_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix047_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix047_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix047_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix047_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix048_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix048_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix048_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix048_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix048_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix049_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix049_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix049_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix049_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix049_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix050_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix050_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix050_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix050_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix050_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix051_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix051_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix051_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix051_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix051_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix052_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix052_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix052_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix052_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix052_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix053_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix053_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix053_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix053_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix053_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix054_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix054_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix054_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix054_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix054_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix055_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix055_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix055_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix055_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix055_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix056_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix056_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix056_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix056_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix056_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/mix057_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/mix057_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/mix057_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/mix057_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/mix057_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr000_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/podwr001_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi000_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi000_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi000_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi001_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_power.oepc_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_power.opt_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_power.opt_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_power.opt_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_power.opt_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_pso.oepc_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_pso.opt_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_rmo.oepc_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_rmo.opt_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_tso.oepc_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi002_tso.opt_true-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi003_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/rfi003_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/rfi003_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi004_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi005_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi006_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_tso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi007_tso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi008_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi009_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_tso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/rfi010_tso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe000_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe000_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe000_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe000_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe000_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe000_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe001_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe001_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe001_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe001_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe001_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe001_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe001_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe001_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe001_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe002_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe002_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe002_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe002_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe002_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe002_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe002_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe002_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe002_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe003_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe003_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe003_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe003_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe003_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe003_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe003_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe003_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe003_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe004_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe004_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe004_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe004_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe004_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe004_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe004_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe004_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe004_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe005_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe005_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe005_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe005_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe005_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe005_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe005_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe005_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe005_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe006_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe006_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe006_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe006_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe006_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe006_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe007_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe007_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe007_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe007_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe007_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe007_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe008_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe008_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe008_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe008_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe008_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe008_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe008_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe008_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe008_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe009_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe009_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe009_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe009_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe009_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe009_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe010_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe010_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe010_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe010_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe010_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe010_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe010_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe010_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe010_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe011_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe011_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe011_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe011_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe011_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe011_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe011_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe011_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe011_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe012_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe012_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe012_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe012_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe012_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe012_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe012_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe012_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe012_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe013_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe013_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe013_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe013_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe013_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe013_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe013_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe013_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe013_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe014_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe014_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe014_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe014_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe014_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe014_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe015_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe015_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe015_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe015_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe015_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe015_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe016_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe016_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe016_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe016_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe016_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe016_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe017_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe017_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe017_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe017_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe017_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe017_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe017_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe017_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe017_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe018_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe018_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe018_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe018_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe018_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe018_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe019_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe019_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe019_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe019_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe019_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe019_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe020_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe020_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe020_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe020_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe020_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe020_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe021_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe021_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe021_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe021_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe021_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe021_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe021_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe021_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe021_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe022_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe022_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe022_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe022_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe022_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe022_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe022_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe022_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe022_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe023_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe023_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe023_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe023_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe023_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe023_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe023_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe023_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe023_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe024_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe024_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe024_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe024_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe024_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe024_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe024_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe024_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe024_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe025_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe025_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe025_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe025_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe025_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe025_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe026_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe026_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe026_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe026_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe026_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe026_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe026_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe026_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe026_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe027_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe027_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe027_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe027_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe027_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe027_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe028_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe028_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe028_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe028_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe028_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe028_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe029_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe029_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe029_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe029_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe029_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe029_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe029_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe029_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe029_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe030_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe030_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe030_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe030_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe030_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe030_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe030_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe030_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe030_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe031_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe031_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe031_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe031_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe031_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe031_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe031_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe031_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe031_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe032_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe032_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe032_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe032_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe032_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe032_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe032_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe032_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe032_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_power.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_power.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_power.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_power.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_pso.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_pso.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_pso.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_pso.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_pso.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe033_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe033_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe033_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe033_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe033_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe033_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe033_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe033_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe033_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_power.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_power.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_power.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_power.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_pso.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_pso.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_pso.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_pso.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_pso.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_pso.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_pso.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_rmo.oepc_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/safe034_rmo.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe034_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe034_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe034_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe034_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe034_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe034_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe034_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe034_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_power.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_power.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_power.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_power.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_power.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_power.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_power.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_power.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_rmo.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_rmo.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe035_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe035_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe035_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe035_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe035_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_power.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_power.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_power.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_power.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_power.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_power.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_power.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_power.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_rmo.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_rmo.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe036_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe036_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe036_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe036_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe036_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_power.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_power.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_power.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_power.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_power.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_power.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_power.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_power.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_power.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_power.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_power.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_power.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_rmo.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_rmo.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/safe037_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/safe037_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/safe037_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/safe037_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/safe037_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin000_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin000_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin000_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin000_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin000_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin000_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin001_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin001_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin001_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin001_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin001_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin001_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_power.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_power.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_power.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_power.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_power.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_power.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_power.opt_false-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_power.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_power.opt_false-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_power.opt_false-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_power.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_power.opt_false-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_pso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_pso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_pso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_pso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_pso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_pso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_pso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_rmo.oepc_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.c
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.c
+++ b/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.c
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.i
@@ -3,7 +3,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.i
+++ b/c/pthread-wmm/thin002_rmo.opt_false-unreach-call.i
@@ -4,8 +4,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_tso.oepc_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)

--- a/c/pthread-wmm/thin002_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_tso.opt_true-unreach-call.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_tso.opt_true-unreach-call.c
+++ b/c/pthread-wmm/thin002_tso.opt_true-unreach-call.c
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <assert.h>
 #include <pthread.h>

--- a/c/pthread-wmm/thin002_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_tso.opt_true-unreach-call.i
@@ -2,7 +2,6 @@ extern void __VERIFIER_assume(int);
 extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
-int __global_lock;
 extern void __VERIFIER_atomic_begin();
 extern void __VERIFIER_atomic_end();
 

--- a/c/pthread-wmm/thin002_tso.opt_true-unreach-call.i
+++ b/c/pthread-wmm/thin002_tso.opt_true-unreach-call.i
@@ -3,8 +3,8 @@ extern void * __VERIFIER_nondet_pointer(void);
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error(); }; return; }
 int __global_lock;
-void __VERIFIER_atomic_begin() { __VERIFIER_assume(__global_lock==0); __global_lock=1; return; }
-void __VERIFIER_atomic_end() { __VERIFIER_assume(__global_lock==1); __global_lock=0; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __assert_fail (const char *__assertion, const char *__file,
       unsigned int __line, const char *__function)


### PR DESCRIPTION
As per SV-COMP rules, these functions are modeling functions and
each verifier should be free to define them however it wants.
Hence, no bodies should be provided for these functions. They
are analogous to __VERIFIER_nondet_X functions in that sense.