### PR TITLE
Replaced __VERIFIER_nondet_U8 with __VERIFIER_nondet_uchar

### DIFF
--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
@@ -179,7 +179,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -237,8 +237,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -338,7 +338,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
@@ -183,7 +183,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -241,8 +241,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -342,7 +342,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
@@ -186,7 +186,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -244,8 +244,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -345,7 +345,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
@@ -194,7 +194,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -252,8 +252,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -353,7 +353,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M1.c
@@ -192,7 +192,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -255,8 +255,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -361,7 +361,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M4.c
@@ -196,7 +196,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -259,8 +259,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -365,7 +365,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M1.c
@@ -192,7 +192,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -255,8 +255,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -353,7 +353,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M4.c
@@ -196,7 +196,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -259,8 +259,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -357,7 +357,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
@@ -181,7 +181,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -239,8 +239,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
@@ -185,7 +185,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -243,8 +243,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -344,7 +344,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M1.c
@@ -192,7 +192,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -255,8 +255,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -353,7 +353,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M4.c
@@ -196,7 +196,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -259,8 +259,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -357,7 +357,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_ctm_false-unreach-call.2.c
+++ b/c/seq-mthreaded/rekcba_ctm_false-unreach-call.2.c
@@ -105,7 +105,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[28]  ;
 char _i___startrek_current_priority_[28]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -142,7 +142,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -215,7 +215,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -229,7 +229,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -243,7 +243,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -279,7 +279,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -295,7 +295,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -311,7 +311,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -349,7 +349,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_ctm_false-unreach-call.3.c
+++ b/c/seq-mthreaded/rekcba_ctm_false-unreach-call.3.c
@@ -105,7 +105,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[42]  ;
 char _i___startrek_current_priority_[42]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -142,7 +142,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -215,7 +215,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -229,7 +229,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -243,7 +243,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -279,7 +279,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -295,7 +295,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -311,7 +311,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -349,7 +349,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_ctm_true-unreach-call.1.c
+++ b/c/seq-mthreaded/rekcba_ctm_true-unreach-call.1.c
@@ -105,7 +105,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[28]  ;
 char _i___startrek_current_priority_[28]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -142,7 +142,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -215,7 +215,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -229,7 +229,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -243,7 +243,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -279,7 +279,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -295,7 +295,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -311,7 +311,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -349,7 +349,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_ctm_true-unreach-call.2.c
+++ b/c/seq-mthreaded/rekcba_ctm_true-unreach-call.2.c
@@ -105,7 +105,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[28]  ;
 char _i___startrek_current_priority_[28]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -142,7 +142,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -215,7 +215,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -229,7 +229,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -243,7 +243,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -279,7 +279,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -295,7 +295,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -311,7 +311,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -349,7 +349,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_ctm_true-unreach-call.3.c
+++ b/c/seq-mthreaded/rekcba_ctm_true-unreach-call.3.c
@@ -105,7 +105,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[42]  ;
 char _i___startrek_current_priority_[42]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -142,7 +142,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -215,7 +215,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -229,7 +229,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -243,7 +243,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -279,7 +279,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -295,7 +295,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -311,7 +311,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -349,7 +349,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_ctm_true-unreach-call.4.c
+++ b/c/seq-mthreaded/rekcba_ctm_true-unreach-call.4.c
@@ -106,7 +106,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[56]  ;
 char _i___startrek_current_priority_[56]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -143,7 +143,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -216,7 +216,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -230,7 +230,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -244,7 +244,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -280,7 +280,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -296,7 +296,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -312,7 +312,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -350,7 +350,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
@@ -173,7 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -222,8 +222,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -319,7 +319,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
@@ -173,7 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -222,8 +222,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -319,7 +319,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
@@ -180,7 +180,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -234,8 +234,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -338,7 +338,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
@@ -184,7 +184,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -238,8 +238,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -342,7 +342,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
@@ -173,7 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -222,8 +222,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -319,7 +319,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
@@ -173,7 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -222,8 +222,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -319,7 +319,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
@@ -178,7 +178,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -227,8 +227,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -325,7 +325,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
@@ -182,7 +182,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -231,8 +231,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -329,7 +329,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
@@ -180,7 +180,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -234,8 +234,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -338,7 +338,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
@@ -184,7 +184,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[108]  ;
@@ -238,8 +238,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -342,7 +342,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
@@ -174,7 +174,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -232,8 +232,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -333,7 +333,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M4.c
@@ -174,7 +174,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -232,8 +232,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -333,7 +333,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
@@ -180,7 +180,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -238,8 +238,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -339,7 +339,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M4.c
@@ -180,7 +180,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -238,8 +238,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -339,7 +339,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M1.c
@@ -187,7 +187,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -250,8 +250,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -348,7 +348,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M4.c
@@ -187,7 +187,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -250,8 +250,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -348,7 +348,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
@@ -176,7 +176,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -234,8 +234,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -335,7 +335,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M4.c
@@ -176,7 +176,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -234,8 +234,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -335,7 +335,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M1.c
@@ -187,7 +187,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -250,8 +250,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -348,7 +348,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M4.c
@@ -187,7 +187,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -250,8 +250,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -348,7 +348,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M1.c
@@ -187,7 +187,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -250,8 +250,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -356,7 +356,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M4.c
@@ -187,7 +187,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -250,8 +250,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -356,7 +356,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_ctm_false-unreach-call.2.c
+++ b/c/seq-mthreaded/rekh_ctm_false-unreach-call.2.c
@@ -96,7 +96,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[7]  ;
 char _i___startrek_current_priority_[7]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -133,7 +133,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -206,7 +206,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -220,7 +220,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -234,7 +234,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -270,7 +270,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -286,7 +286,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -302,7 +302,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_ctm_false-unreach-call.3.c
+++ b/c/seq-mthreaded/rekh_ctm_false-unreach-call.3.c
@@ -96,7 +96,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[7]  ;
 char _i___startrek_current_priority_[7]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -133,7 +133,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -206,7 +206,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -220,7 +220,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -234,7 +234,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -270,7 +270,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -286,7 +286,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -302,7 +302,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_ctm_true-unreach-call.1.c
+++ b/c/seq-mthreaded/rekh_ctm_true-unreach-call.1.c
@@ -96,7 +96,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[7]  ;
 char _i___startrek_current_priority_[7]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -133,7 +133,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -206,7 +206,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -220,7 +220,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -234,7 +234,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -270,7 +270,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -286,7 +286,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -302,7 +302,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_ctm_true-unreach-call.2.c
+++ b/c/seq-mthreaded/rekh_ctm_true-unreach-call.2.c
@@ -96,7 +96,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[7]  ;
 char _i___startrek_current_priority_[7]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -133,7 +133,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -206,7 +206,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -220,7 +220,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -234,7 +234,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -270,7 +270,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -286,7 +286,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -302,7 +302,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_ctm_true-unreach-call.3.c
+++ b/c/seq-mthreaded/rekh_ctm_true-unreach-call.3.c
@@ -96,7 +96,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[7]  ;
 char _i___startrek_current_priority_[7]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -133,7 +133,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -206,7 +206,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -220,7 +220,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -234,7 +234,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -270,7 +270,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -286,7 +286,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -302,7 +302,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_ctm_true-unreach-call.4.c
+++ b/c/seq-mthreaded/rekh_ctm_true-unreach-call.4.c
@@ -96,7 +96,7 @@ __inline static void __startrek_write___startrek_current_priority(char arg ) ;
 char ___startrek_current_priority_[7]  ;
 char _i___startrek_current_priority_[7]  ;
 char __startrek_hidden___startrek_current_priority  =    0;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 extern _Bool __VERIFIER_nondet_bool() ;
 __inline static int __startrek_read_R_count(void) ;
 __inline static void __startrek_write_R_count(int arg ) ;
@@ -133,7 +133,7 @@ int calibrate(void)
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }
@@ -206,7 +206,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 0: 
   prev_speed = __startrek_read_R_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp = __startrek_read_R_count();
     if (prev_speed > 0) {
       tmp___0 = diff;
@@ -220,7 +220,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 1: 
   prev_speed = __startrek_read_W_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___1 = __startrek_read_W_count();
     if (prev_speed > 0) {
       tmp___2 = diff;
@@ -234,7 +234,7 @@ void nxt_motor_set_speed(unsigned int n , int speed , _Bool b )
   case 2: 
   prev_speed = __startrek_read_T_speed();
   if (prev_speed != 0) {
-    diff = __VERIFIER_nondet_U8();
+    diff = __VERIFIER_nondet_uchar();
     tmp___3 = __startrek_read_T_count();
     if (prev_speed > 0) {
       tmp___4 = diff;
@@ -270,7 +270,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -286,7 +286,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -302,7 +302,7 @@ int nxt_motor_get_count(unsigned int n )
   if ((int )speed == 0) {
     return (count);
   } else {
-    delta = __VERIFIER_nondet_U8();
+    delta = __VERIFIER_nondet_uchar();
     if (count + (int )speed > 0) {
       new_count = delta;
     } else {
@@ -340,7 +340,7 @@ unsigned char ecrobot_get_nxtcolorsensor_light(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
@@ -169,7 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -218,8 +218,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -315,7 +315,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M4.c
@@ -169,7 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -218,8 +218,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -315,7 +315,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
@@ -175,7 +175,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -229,8 +229,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -333,7 +333,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M4.c
@@ -175,7 +175,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -229,8 +229,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -333,7 +333,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
@@ -169,7 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -218,8 +218,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -315,7 +315,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M4.c
@@ -169,7 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -218,8 +218,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -315,7 +315,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
@@ -173,7 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -222,8 +222,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -320,7 +320,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M4.c
@@ -173,7 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -222,8 +222,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -320,7 +320,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
@@ -175,7 +175,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -229,8 +229,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -333,7 +333,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M4.c
@@ -175,7 +175,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
 }
 extern unsigned int __VERIFIER_nondet_U32() ;
 extern char __VERIFIER_nondet_S8() ;
-extern unsigned char __VERIFIER_nondet_U8() ;
+extern unsigned char __VERIFIER_nondet_uchar() ;
 __inline static unsigned char __startrek_read_nxtway_gs_mode(void) ;
 __inline static void __startrek_write_nxtway_gs_mode(unsigned char arg ) ;
 unsigned char _nxtway_gs_mode_[27]  ;
@@ -229,8 +229,8 @@ void ecrobot_read_bt_packet(unsigned char *bt_receive_buf , unsigned char sz )
 
 
   {
-  *(bt_receive_buf + 0) = __VERIFIER_nondet_U8();
-  *(bt_receive_buf + 1) = __VERIFIER_nondet_U8();
+  *(bt_receive_buf + 0) = __VERIFIER_nondet_uchar();
+  *(bt_receive_buf + 1) = __VERIFIER_nondet_uchar();
   return;
 }
 }
@@ -333,7 +333,7 @@ unsigned char ecrobot_get_sonar_sensor(unsigned char port )
   unsigned char tmp ;
 
   {
-  tmp = __VERIFIER_nondet_U8();
+  tmp = __VERIFIER_nondet_uchar();
   return (tmp);
 }
 }


### PR DESCRIPTION
Function `__VERIFIER_nondet_U8` is not defined in SV-COMP rules.
Instead, I switched to using `__VERIFIER_nonder_uchar` instead.