### PR TITLE
Fix an issue with overflows in several tasks in seq-mthreaded

### DIFF
--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,21 +93,21 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -118,7 +119,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -161,7 +162,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -204,7 +205,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -507,21 +508,21 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -119,7 +119,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -162,7 +165,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -205,7 +211,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -119,7 +119,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 1;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -162,7 +165,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -205,7 +211,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,21 +93,21 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -118,7 +119,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -161,7 +162,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -204,7 +205,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -531,21 +532,21 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -119,7 +119,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -162,7 +165,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -205,7 +211,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,21 +93,21 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -118,7 +119,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -161,7 +162,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -204,7 +205,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -531,21 +532,21 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -119,7 +119,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -162,7 +165,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -205,7 +211,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,21 +93,21 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -118,7 +119,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -161,7 +162,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -204,7 +205,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -531,21 +532,21 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -99,7 +99,6 @@ char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
-_Bool newmax1  ;
 char id2  ;
 unsigned char r2  ;
 char st2  ;
@@ -107,7 +106,6 @@ char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
-_Bool newmax2  ;
 char id3  ;
 unsigned char r3  ;
 char st3  ;
@@ -115,24 +113,18 @@ char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
-_Bool newmax3  ;
 void node1(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 2;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
-        newmax = (_Bool)1;
       }
     }
     if (ep31) {
@@ -140,29 +132,23 @@ void node1(void)
       p31_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
-        newmax = (_Bool)1;
       }
     }
-    newmax1 = newmax;
     if ((int )r1 == 2) {
       if ((int )max1 == (int )id1) {
-        nl1 = (char)1;
-      } else {
         st1 = (char)1;
+      } else {
+        nl1 = (char)1;
       }
     }
     mode1 = (_Bool)0;
   } else {
     if ((int )r1 < 2) {
       if (ep12) {
-        if (newmax1) {
-          p12_new = max1 != nomsg && p12_new == nomsg ? max1 : p12_new;
-        }
+        p12_new = max1 != nomsg && p12_new == nomsg ? max1 : p12_new;
       }
       if (ep13) {
-        if (newmax1) {
-          p13_new = max1 != nomsg && p13_new == nomsg ? max1 : p13_new;
-        }
+        p13_new = max1 != nomsg && p13_new == nomsg ? max1 : p13_new;
       }
     }
     mode1 = (_Bool)1;
@@ -172,21 +158,16 @@ void node1(void)
 }
 void node2(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode2) {
-    if (r2 == 255) {
-      r2 = 2;
-    }
-    r2 = r2 + 1;
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
-        newmax = (_Bool)1;
       }
     }
     if (ep32) {
@@ -194,10 +175,8 @@ void node2(void)
       p32_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
-        newmax = (_Bool)1;
       }
     }
-    newmax2 = newmax;
     if ((int )r2 == 2) {
       if ((int )max2 == (int )id2) {
         st2 = (char)1;
@@ -209,14 +188,10 @@ void node2(void)
   } else {
     if ((int )r2 < 2) {
       if (ep21) {
-        if (newmax2) {
-          p21_new = max2 != nomsg && p21_new == nomsg ? max2 : p21_new;
-        }
+        p21_new = max2 != nomsg && p21_new == nomsg ? max2 : p21_new;
       }
       if (ep23) {
-        if (newmax2) {
-          p23_new = max2 != nomsg && p23_new == nomsg ? max2 : p23_new;
-        }
+        p23_new = max2 != nomsg && p23_new == nomsg ? max2 : p23_new;
       }
     }
     mode2 = (_Bool)1;
@@ -226,21 +201,16 @@ void node2(void)
 }
 void node3(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode3) {
-    if (r3 == 255) {
-      r3 = 2;
-    }
-    r3 = r3 + 1;
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
-        newmax = (_Bool)1;
       }
     }
     if (ep23) {
@@ -248,10 +218,8 @@ void node3(void)
       p23_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
-        newmax = (_Bool)1;
       }
     }
-    newmax3 = newmax;
     if ((int )r3 == 2) {
       if ((int )max3 == (int )id3) {
         st3 = (char)1;
@@ -263,14 +231,10 @@ void node3(void)
   } else {
     if ((int )r3 < 2) {
       if (ep31) {
-        if (newmax3) {
-          p31_new = max3 != nomsg && p31_new == nomsg ? max3 : p31_new;
-        }
+        p31_new = max3 != nomsg && p31_new == nomsg ? max3 : p31_new;
       }
       if (ep32) {
-        if (newmax3) {
-          p32_new = max3 != nomsg && p32_new == nomsg ? max3 : p32_new;
-        }
+        p32_new = max3 != nomsg && p32_new == nomsg ? max3 : p32_new;
       }
     }
     mode3 = (_Bool)1;
@@ -413,19 +377,7 @@ int init(void)
                                                   if ((int )mode1 == 0) {
                                                     if ((int )mode2 == 0) {
                                                       if ((int )mode3 == 0) {
-                                                        if (newmax1) {
-                                                          if (newmax2) {
-                                                            if (newmax3) {
-                                                              tmp___5 = 1;
-                                                            } else {
-                                                              tmp___5 = 0;
-                                                            }
-                                                          } else {
-                                                            tmp___5 = 0;
-                                                          }
-                                                        } else {
-                                                          tmp___5 = 0;
-                                                        }
+                                                        tmp___5 = 1;
                                                       } else {
                                                         tmp___5 = 0;
                                                       }
@@ -586,7 +538,6 @@ int main(void)
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
-  newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
   r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
@@ -594,7 +545,6 @@ int main(void)
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
-  newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
   r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
@@ -602,7 +552,6 @@ int main(void)
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
-  newmax3 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p12_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -119,7 +119,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -162,7 +165,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -205,7 +211,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,21 +93,21 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -118,7 +119,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -161,7 +162,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -204,7 +205,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -531,21 +532,21 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,28 +117,28 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -149,7 +150,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -202,7 +203,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -255,7 +256,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -308,7 +309,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1141,28 +1142,28 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -150,7 +150,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -203,7 +206,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -256,7 +262,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -309,7 +318,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,28 +117,28 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -149,7 +150,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -202,7 +203,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -255,7 +256,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -308,7 +309,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1189,28 +1190,28 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -150,7 +150,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -203,7 +206,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -256,7 +262,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -309,7 +318,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,28 +117,28 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -149,7 +150,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -202,7 +203,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -255,7 +256,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -308,7 +309,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1189,28 +1190,28 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -150,7 +150,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -203,7 +206,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -256,7 +262,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -309,7 +318,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,28 +117,28 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -149,7 +150,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -202,7 +203,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -255,7 +256,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -308,7 +309,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1189,28 +1190,28 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -150,10 +150,7 @@ void node1(void)
 
   {
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -206,10 +203,7 @@ void node2(void)
 
   {
   if (mode2) {
-    if (r2 == 255) {
-      r2 = 3;
-    }
-    r2 = r2 + 1;
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -262,10 +256,7 @@ void node3(void)
 
   {
   if (mode3) {
-    if (r3 == 255) {
-      r3 = 3;
-    }
-    r3 = r3 + 1;
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -318,10 +309,7 @@ void node4(void)
 
   {
   if (mode4) {
-    if (r4 == 255) {
-      r4 = 3;
-    }
-    r4 = r4 + 1;
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -964,23 +952,71 @@ int init(void)
                         if ((int )r2 == 0) {
                           if ((int )r3 == 0) {
                             if ((int )r4 == 0) {
-                              if ((int )max1 == (int )id1) {
-                                if ((int )max2 == (int )id2) {
-                                  if ((int )max3 == (int )id3) {
-                                    if ((int )max4 == (int )id4) {
-                                      if ((int )st1 == 0) {
-                                        if ((int )st2 == 0) {
-                                          if ((int )st3 == 0) {
-                                            if ((int )st4 == 0) {
-                                              if ((int )nl1 == 0) {
-                                                if ((int )nl2 == 0) {
-                                                  if ((int )nl3 == 0) {
-                                                    if ((int )nl4 == 0) {
-                                                      if ((int )mode1 == 0) {
-                                                        if ((int )mode2 == 0) {
-                                                          if ((int )mode3 == 0) {
-                                                            if ((int )mode4 == 0) {
-                                                              tmp___23 = 1;
+                              if (r123) {
+                                if (r133) {
+                                  if (r143) {
+                                    if (r213) {
+                                      if (r233) {
+                                        if (r243) {
+                                          if (r313) {
+                                            if (r323) {
+                                              if (r343) {
+                                                if (r413) {
+                                                  if (r423) {
+                                                    if (r433) {
+                                                      if ((int )max1 == (int )id1) {
+                                                        if ((int )max2 == (int )id2) {
+                                                          if ((int )max3 == (int )id3) {
+                                                            if ((int )max4 == (int )id4) {
+                                                              if ((int )st1 == 0) {
+                                                                if ((int )st2 == 0) {
+                                                                  if ((int )st3 == 0) {
+                                                                    if ((int )st4 == 0) {
+                                                                      if ((int )nl1 == 0) {
+                                                                        if ((int )nl2 == 0) {
+                                                                          if ((int )nl3 == 0) {
+                                                                            if ((int )nl4 == 0) {
+                                                                              if ((int )mode1 == 0) {
+                                                                                if ((int )mode2 == 0) {
+                                                                                  if ((int )mode3 == 0) {
+                                                                                    if ((int )mode4 == 0) {
+                                                                                      tmp___23 = 1;
+                                                                                    } else {
+                                                                                      tmp___23 = 0;
+                                                                                    }
+                                                                                  } else {
+                                                                                    tmp___23 = 0;
+                                                                                  }
+                                                                                } else {
+                                                                                  tmp___23 = 0;
+                                                                                }
+                                                                              } else {
+                                                                                tmp___23 = 0;
+                                                                              }
+                                                                            } else {
+                                                                              tmp___23 = 0;
+                                                                            }
+                                                                          } else {
+                                                                            tmp___23 = 0;
+                                                                          }
+                                                                        } else {
+                                                                          tmp___23 = 0;
+                                                                        }
+                                                                      } else {
+                                                                        tmp___23 = 0;
+                                                                      }
+                                                                    } else {
+                                                                      tmp___23 = 0;
+                                                                    }
+                                                                  } else {
+                                                                    tmp___23 = 0;
+                                                                  }
+                                                                } else {
+                                                                  tmp___23 = 0;
+                                                                }
+                                                              } else {
+                                                                tmp___23 = 0;
+                                                              }
                                                             } else {
                                                               tmp___23 = 0;
                                                             }

--- a/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -150,7 +150,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -203,7 +206,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -256,7 +262,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -309,7 +318,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,28 +117,28 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -149,7 +150,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -202,7 +203,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -255,7 +256,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -308,7 +309,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1189,28 +1190,28 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -189,7 +189,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -252,7 +255,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -315,7 +321,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -378,7 +387,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -441,7 +453,10 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,35 +149,35 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -188,7 +189,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -251,7 +252,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -314,7 +315,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -377,7 +378,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -440,7 +441,7 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2660,35 +2661,35 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,35 +149,35 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -188,7 +189,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -251,7 +252,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -314,7 +315,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -377,7 +378,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -440,7 +441,7 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2740,35 +2741,35 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -189,7 +189,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -252,7 +255,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -315,7 +321,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -378,7 +387,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -441,7 +453,10 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,35 +149,35 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -188,7 +189,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -251,7 +252,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -314,7 +315,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -377,7 +378,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -440,7 +441,7 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2740,35 +2741,35 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -189,7 +189,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -252,7 +255,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -315,7 +321,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -378,7 +387,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -441,7 +453,10 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,35 +149,35 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -188,7 +189,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -251,7 +252,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -314,7 +315,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -377,7 +378,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -440,7 +441,7 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2740,35 +2741,35 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -189,7 +189,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -252,7 +255,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -315,7 +321,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -378,7 +387,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -441,7 +453,10 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -155,7 +155,6 @@ char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
-_Bool newmax1  ;
 char id2  ;
 unsigned char r2  ;
 char st2  ;
@@ -163,7 +162,6 @@ char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
-_Bool newmax2  ;
 char id3  ;
 unsigned char r3  ;
 char st3  ;
@@ -171,7 +169,6 @@ char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
-_Bool newmax3  ;
 char id4  ;
 unsigned char r4  ;
 char st4  ;
@@ -179,7 +176,6 @@ char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
-_Bool newmax4  ;
 char id5  ;
 unsigned char r5  ;
 char st5  ;
@@ -187,24 +183,18 @@ char nl5  ;
 char m5  ;
 char max5  ;
 _Bool mode5  ;
-_Bool newmax5  ;
 void node1(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 4;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
-        newmax = (_Bool)1;
       }
     }
     if (ep31) {
@@ -212,7 +202,6 @@ void node1(void)
       p31_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
-        newmax = (_Bool)1;
       }
     }
     if (ep41) {
@@ -220,7 +209,6 @@ void node1(void)
       p41_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
-        newmax = (_Bool)1;
       }
     }
     if (ep51) {
@@ -228,10 +216,8 @@ void node1(void)
       p51_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
-        newmax = (_Bool)1;
       }
     }
-    newmax1 = newmax;
     if ((int )r1 == 4) {
       if ((int )max1 == (int )id1) {
         st1 = (char)1;
@@ -243,24 +229,16 @@ void node1(void)
   } else {
     if ((int )r1 < 4) {
       if (ep12) {
-        if (newmax1) {
-          p12_new = max1 != nomsg && p12_new == nomsg ? max1 : p12_new;
-        }
+        p12_new = max1 != nomsg && p12_new == nomsg ? max1 : p12_new;
       }
       if (ep13) {
-        if (newmax1) {
-          p13_new = max1 != nomsg && p13_new == nomsg ? max1 : p13_new;
-        }
+        p13_new = max1 != nomsg && p13_new == nomsg ? max1 : p13_new;
       }
       if (ep14) {
-        if (newmax1) {
-          p14_new = max1 != nomsg && p14_new == nomsg ? max1 : p14_new;
-        }
+        p14_new = max1 != nomsg && p14_new == nomsg ? max1 : p14_new;
       }
       if (ep15) {
-        if (newmax1) {
-          p15_new = max1 != nomsg && p15_new == nomsg ? max1 : p15_new;
-        }
+        p15_new = max1 != nomsg && p15_new == nomsg ? max1 : p15_new;
       }
     }
     mode1 = (_Bool)1;
@@ -270,21 +248,16 @@ void node1(void)
 }
 void node2(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode2) {
-    if (r2 == 255) {
-      r2 = 4;
-    }
-    r2 = r2 + 1;
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
-        newmax = (_Bool)1;
       }
     }
     if (ep32) {
@@ -292,7 +265,6 @@ void node2(void)
       p32_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
-        newmax = (_Bool)1;
       }
     }
     if (ep42) {
@@ -300,7 +272,6 @@ void node2(void)
       p42_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
-        newmax = (_Bool)1;
       }
     }
     if (ep52) {
@@ -308,10 +279,8 @@ void node2(void)
       p52_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
-        newmax = (_Bool)1;
       }
     }
-    newmax2 = newmax;
     if ((int )r2 == 4) {
       if ((int )max2 == (int )id2) {
         st2 = (char)1;
@@ -323,24 +292,16 @@ void node2(void)
   } else {
     if ((int )r2 < 4) {
       if (ep21) {
-        if (newmax2) {
-          p21_new = max2 != nomsg && p21_new == nomsg ? max2 : p21_new;
-        }
+        p21_new = max2 != nomsg && p21_new == nomsg ? max2 : p21_new;
       }
       if (ep23) {
-        if (newmax2) {
-          p23_new = max2 != nomsg && p23_new == nomsg ? max2 : p23_new;
-        }
+        p23_new = max2 != nomsg && p23_new == nomsg ? max2 : p23_new;
       }
       if (ep24) {
-        if (newmax2) {
-          p24_new = max2 != nomsg && p24_new == nomsg ? max2 : p24_new;
-        }
+        p24_new = max2 != nomsg && p24_new == nomsg ? max2 : p24_new;
       }
       if (ep25) {
-        if (newmax2) {
-          p25_new = max2 != nomsg && p25_new == nomsg ? max2 : p25_new;
-        }
+        p25_new = max2 != nomsg && p25_new == nomsg ? max2 : p25_new;
       }
     }
     mode2 = (_Bool)1;
@@ -350,21 +311,16 @@ void node2(void)
 }
 void node3(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode3) {
-    if (r3 == 255) {
-      r3 = 4;
-    }
-    r3 = r3 + 1;
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
-        newmax = (_Bool)1;
       }
     }
     if (ep23) {
@@ -372,7 +328,6 @@ void node3(void)
       p23_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
-        newmax = (_Bool)1;
       }
     }
     if (ep43) {
@@ -380,7 +335,6 @@ void node3(void)
       p43_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
-        newmax = (_Bool)1;
       }
     }
     if (ep53) {
@@ -388,10 +342,8 @@ void node3(void)
       p53_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
-        newmax = (_Bool)1;
       }
     }
-    newmax3 = newmax;
     if ((int )r3 == 4) {
       if ((int )max3 == (int )id3) {
         st3 = (char)1;
@@ -403,24 +355,16 @@ void node3(void)
   } else {
     if ((int )r3 < 4) {
       if (ep31) {
-        if (newmax3) {
-          p31_new = max3 != nomsg && p31_new == nomsg ? max3 : p31_new;
-        }
+        p31_new = max3 != nomsg && p31_new == nomsg ? max3 : p31_new;
       }
       if (ep32) {
-        if (newmax3) {
-          p32_new = max3 != nomsg && p32_new == nomsg ? max3 : p32_new;
-        }
+        p32_new = max3 != nomsg && p32_new == nomsg ? max3 : p32_new;
       }
       if (ep34) {
-        if (newmax3) {
-          p34_new = max3 != nomsg && p34_new == nomsg ? max3 : p34_new;
-        }
+        p34_new = max3 != nomsg && p34_new == nomsg ? max3 : p34_new;
       }
       if (ep35) {
-        if (newmax3) {
-          p35_new = max3 != nomsg && p35_new == nomsg ? max3 : p35_new;
-        }
+        p35_new = max3 != nomsg && p35_new == nomsg ? max3 : p35_new;
       }
     }
     mode3 = (_Bool)1;
@@ -430,21 +374,16 @@ void node3(void)
 }
 void node4(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode4) {
-    if (r4 == 255) {
-      r4 = 4;
-    }
-    r4 = r4 + 1;
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
-        newmax = (_Bool)1;
       }
     }
     if (ep24) {
@@ -452,7 +391,6 @@ void node4(void)
       p24_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
-        newmax = (_Bool)1;
       }
     }
     if (ep34) {
@@ -460,7 +398,6 @@ void node4(void)
       p34_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
-        newmax = (_Bool)1;
       }
     }
     if (ep54) {
@@ -468,10 +405,8 @@ void node4(void)
       p54_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
-        newmax = (_Bool)1;
       }
     }
-    newmax4 = newmax;
     if ((int )r4 == 4) {
       if ((int )max4 == (int )id4) {
         st4 = (char)1;
@@ -483,24 +418,16 @@ void node4(void)
   } else {
     if ((int )r4 < 4) {
       if (ep41) {
-        if (newmax4) {
-          p41_new = max4 != nomsg && p41_new == nomsg ? max4 : p41_new;
-        }
+        p41_new = max4 != nomsg && p41_new == nomsg ? max4 : p41_new;
       }
       if (ep42) {
-        if (newmax4) {
-          p42_new = max4 != nomsg && p42_new == nomsg ? max4 : p42_new;
-        }
+        p42_new = max4 != nomsg && p42_new == nomsg ? max4 : p42_new;
       }
       if (ep43) {
-        if (newmax4) {
-          p43_new = max4 != nomsg && p43_new == nomsg ? max4 : p43_new;
-        }
+        p43_new = max4 != nomsg && p43_new == nomsg ? max4 : p43_new;
       }
       if (ep45) {
-        if (newmax4) {
-          p45_new = max4 != nomsg && p45_new == nomsg ? max4 : p45_new;
-        }
+        p45_new = max4 != nomsg && p45_new == nomsg ? max4 : p45_new;
       }
     }
     mode4 = (_Bool)1;
@@ -510,21 +437,16 @@ void node4(void)
 }
 void node5(void) 
 { 
-  _Bool newmax ;
+
 
   {
-  newmax = (_Bool)0;
   if (mode5) {
-    if (r5 == 255) {
-      r5 = 4;
-    }
-    r5 = r5 + 1;
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
       if ((int )m5 > (int )max5) {
         max5 = m5;
-        newmax = (_Bool)1;
       }
     }
     if (ep25) {
@@ -532,7 +454,6 @@ void node5(void)
       p25_old = nomsg;
       if ((int )m5 > (int )max5) {
         max5 = m5;
-        newmax = (_Bool)1;
       }
     }
     if (ep35) {
@@ -540,7 +461,6 @@ void node5(void)
       p35_old = nomsg;
       if ((int )m5 > (int )max5) {
         max5 = m5;
-        newmax = (_Bool)1;
       }
     }
     if (ep45) {
@@ -548,10 +468,8 @@ void node5(void)
       p45_old = nomsg;
       if ((int )m5 > (int )max5) {
         max5 = m5;
-        newmax = (_Bool)1;
       }
     }
-    newmax5 = newmax;
     if ((int )r5 == 4) {
       if ((int )max5 == (int )id5) {
         st5 = (char)1;
@@ -563,24 +481,16 @@ void node5(void)
   } else {
     if ((int )r5 < 4) {
       if (ep51) {
-        if (newmax5) {
-          p51_new = max5 != nomsg && p51_new == nomsg ? max5 : p51_new;
-        }
+        p51_new = max5 != nomsg && p51_new == nomsg ? max5 : p51_new;
       }
       if (ep52) {
-        if (newmax5) {
-          p52_new = max5 != nomsg && p52_new == nomsg ? max5 : p52_new;
-        }
+        p52_new = max5 != nomsg && p52_new == nomsg ? max5 : p52_new;
       }
       if (ep53) {
-        if (newmax5) {
-          p53_new = max5 != nomsg && p53_new == nomsg ? max5 : p53_new;
-        }
+        p53_new = max5 != nomsg && p53_new == nomsg ? max5 : p53_new;
       }
       if (ep54) {
-        if (newmax5) {
-          p54_new = max5 != nomsg && p54_new == nomsg ? max5 : p54_new;
-        }
+        p54_new = max5 != nomsg && p54_new == nomsg ? max5 : p54_new;
       }
     }
     mode5 = (_Bool)1;
@@ -2555,27 +2465,7 @@ int init(void)
                                                                                                                     if ((int )mode3 == 0) {
                                                                                                                       if ((int )mode4 == 0) {
                                                                                                                         if ((int )mode5 == 0) {
-                                                                                                                          if (newmax1) {
-                                                                                                                            if (newmax2) {
-                                                                                                                              if (newmax3) {
-                                                                                                                                if (newmax4) {
-                                                                                                                                  if (newmax5) {
-                                                                                                                                    tmp___59 = 1;
-                                                                                                                                  } else {
-                                                                                                                                    tmp___59 = 0;
-                                                                                                                                  }
-                                                                                                                                } else {
-                                                                                                                                  tmp___59 = 0;
-                                                                                                                                }
-                                                                                                                              } else {
-                                                                                                                                tmp___59 = 0;
-                                                                                                                              }
-                                                                                                                            } else {
-                                                                                                                              tmp___59 = 0;
-                                                                                                                            }
-                                                                                                                          } else {
-                                                                                                                            tmp___59 = 0;
-                                                                                                                          }
+                                                                                                                          tmp___59 = 1;
                                                                                                                         } else {
                                                                                                                           tmp___59 = 0;
                                                                                                                         }
@@ -2857,7 +2747,6 @@ int main(void)
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
-  newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
   r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
@@ -2865,7 +2754,6 @@ int main(void)
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
-  newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
   r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
@@ -2873,7 +2761,6 @@ int main(void)
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
-  newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
   r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
@@ -2881,7 +2768,6 @@ int main(void)
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
-  newmax4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
   r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
@@ -2889,7 +2775,6 @@ int main(void)
   m5 = __VERIFIER_nondet_char();
   max5 = __VERIFIER_nondet_char();
   mode5 = __VERIFIER_nondet_bool();
-  newmax5 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p12_old = nomsg;

--- a/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,35 +149,35 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -188,7 +189,7 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -251,7 +252,7 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -314,7 +315,7 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -377,7 +378,7 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -440,7 +441,7 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2740,35 +2741,35 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -189,7 +189,10 @@ void node1(void)
 
   {
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -252,7 +255,10 @@ void node2(void)
 
   {
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -315,7 +321,10 @@ void node3(void)
 
   {
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -378,7 +387,10 @@ void node4(void)
 
   {
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -441,7 +453,10 @@ void node5(void)
 
   {
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -100,7 +100,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -303,7 +303,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -100,7 +100,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -100,7 +100,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -100,7 +100,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -298,7 +298,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -76,6 +78,7 @@ char id1  ;
 char st1  ;
 msg_t send1  ;
 _Bool mode1  ;
+_Bool alive1  ;
 port_t p2  ;
 char p2_old ;
 char p2_new ;
@@ -83,6 +86,7 @@ char id2  ;
 char st2  ;
 msg_t send2  ;
 _Bool mode2  ;
+_Bool alive2  ;
 port_t p3  ;
 char p3_old ;
 char p3_new ;
@@ -90,13 +94,7 @@ char id3  ;
 char st3  ;
 msg_t send3  ;
 _Bool mode3  ;
-port_t p4  ;
-char p4_old ;
-char p4_new ;
-char id4  ;
-char st4  ;
-msg_t send4  ;
-_Bool mode4  ;
+_Bool alive3  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -104,25 +102,29 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
-    m1 = p4_old;
-    p4_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p3_old;
+    p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
-      if ((int )m1 > (int )id1) {
-        send1 = m1;
-      } else
-      if ((int )m1 == (int )id1) {
-        st1 = (char)1;
+      if (alive1) {
+        if ((int )m1 > (int )id1) {
+          send1 = m1;
+        } else
+        if ((int )m1 == (int )id1) {
+          st1 = (char)1;
+        }
       } else {
         send1 = m1;
       }
     }
     mode1 = (_Bool)0;
   } else {
-    p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    if (alive1) {
+      p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    } else
+    if ((int )send1 != (int )id1) {
+      p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    }
     mode1 = (_Bool)1;
   }
   return;
@@ -138,16 +140,25 @@ void node2(void)
     m2 = p1_old;
     p1_old = nomsg;
     if ((int )m2 != (int )nomsg) {
-      if ((int )m2 > (int )id2) {
+      if (alive2) {
+        if ((int )m2 > (int )id2) {
+          send2 = m2;
+        } else
+        if ((int )m2 == (int )id2) {
+          st2 = (char)1;
+        }
+      } else {
         send2 = m2;
-      } else
-      if ((int )m2 == (int )id2) {
-        st2 = (char)1;
       }
     }
     mode2 = (_Bool)0;
   } else {
-    p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    if (alive2) {
+      p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    } else
+    if ((int )send2 != (int )id2) {
+      p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    }
     mode2 = (_Bool)1;
   }
   return;
@@ -163,94 +174,54 @@ void node3(void)
     m3 = p2_old;
     p2_old = nomsg;
     if ((int )m3 != (int )nomsg) {
-      if ((int )m3 > (int )id3) {
+      if (alive3) {
+        if ((int )m3 > (int )id3) {
+          send3 = m3;
+        } else
+        if ((int )m3 == (int )id3) {
+          st3 = (char)1;
+        }
+      } else {
         send3 = m3;
-      } else
-      if ((int )m3 == (int )id3) {
-        st3 = (char)1;
       }
     }
     mode3 = (_Bool)0;
   } else {
-    p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    if (alive3) {
+      p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    } else
+    if ((int )send3 != (int )id3) {
+      p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    }
     mode3 = (_Bool)1;
   }
   return;
 }
 }
-void node4(void) 
-{ 
-  msg_t m4 ;
-
-  {
-  m4 = nomsg;
-  if (mode4) {
-    m4 = p3_old;
-    p3_old = nomsg;
-    if ((int )m4 != (int )nomsg) {
-      if ((int )m4 > (int )id4) {
-        send4 = m4;
-      } else
-      if ((int )m4 == (int )id4) {
-        st4 = (char)1;
-      }
-    }
-    mode4 = (_Bool)0;
-  } else {
-    p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
-    mode4 = (_Bool)1;
-  }
-  return;
-}
-}
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
+void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;
 
   {
   if ((int )r1 == 0) {
-    if ((int )id1 >= 0) {
-      if ((int )st1 == 0) {
-        if ((int )send1 == (int )id1) {
-          if ((int )mode1 == 0) {
-            if ((int )id2 >= 0) {
-              if ((int )st2 == 0) {
-                if ((int )send2 == (int )id2) {
-                  if ((int )mode2 == 0) {
-                    if ((int )id3 >= 0) {
-                      if ((int )st3 == 0) {
-                        if ((int )send3 == (int )id3) {
-                          if ((int )mode3 == 0) {
-                            if ((int )id4 >= 0) {
-                              if ((int )st4 == 0) {
-                                if ((int )send4 == (int )id4) {
-                                  if ((int )mode4 == 0) {
-                                    if ((int )id1 != (int )id2) {
-                                      if ((int )id1 != (int )id3) {
-                                        if ((int )id1 != (int )id4) {
-                                          if ((int )id2 != (int )id3) {
-                                            if ((int )id2 != (int )id4) {
-                                              if ((int )id3 != (int )id4) {
-                                                tmp = 1;
-                                              } else {
-                                                tmp = 0;
-                                              }
-                                            } else {
-                                              tmp = 0;
-                                            }
-                                          } else {
-                                            tmp = 0;
-                                          }
-                                        } else {
-                                          tmp = 0;
-                                        }
-                                      } else {
-                                        tmp = 0;
-                                      }
-                                    } else {
-                                      tmp = 0;
-                                    }
+    if (((int )alive1 + (int )alive2) + (int )alive3 >= 1) {
+      if ((int )id1 >= 0) {
+        if ((int )st1 == 0) {
+          if ((int )send1 == (int )id1) {
+            if ((int )mode1 == 0) {
+              if ((int )id2 >= 0) {
+                if ((int )st2 == 0) {
+                  if ((int )send2 == (int )id2) {
+                    if ((int )mode2 == 0) {
+                      if ((int )id3 >= 0) {
+                        if ((int )st3 == 0) {
+                          if ((int )send3 == (int )id3) {
+                            if ((int )mode3 == 0) {
+                              if ((int )id1 != (int )id2) {
+                                if ((int )id1 != (int )id3) {
+                                  if ((int )id2 != (int )id3) {
+                                    tmp = 1;
                                   } else {
                                     tmp = 0;
                                   }
@@ -310,20 +281,12 @@ int check(void)
   int tmp ;
 
   {
-  if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 >= 4) {
-      goto _L;
+  if (((int )st1 + (int )st2) + (int )st3 <= 1) {
+    if ((int )r1 < 3) {
+      tmp = 1;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 0) {
-      _L: /* CIL Label */ 
-      if ((int )r1 < 4) {
-        tmp = 1;
-      } else
-      if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
-        tmp = 1;
-      } else {
-        tmp = 0;
-      }
+    if (((int )st1 + (int )st2) + (int )st3 == 1) {
+      tmp = 1;
     } else {
       tmp = 0;
     }
@@ -345,18 +308,17 @@ int main(void)
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
+  alive1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
   st2 = __VERIFIER_nondet_char();
   send2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
+  alive2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
   st3 = __VERIFIER_nondet_char();
   send3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
-  id4 = __VERIFIER_nondet_char();
-  st4 = __VERIFIER_nondet_char();
-  send4 = __VERIFIER_nondet_char();
-  mode4 = __VERIFIER_nondet_bool();
+  alive3 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -365,23 +327,18 @@ int main(void)
   p2_new = nomsg;
   p3_old = nomsg;
   p3_new = nomsg;
-  p4_old = nomsg;
-  p4_new = nomsg;
   i2 = 0;
   while (1) {
     {
     node1();
     node2();
     node3();
-    node4();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
     p2_new = nomsg;
     p3_old = p3_new;
     p3_new = nomsg;
-    p4_old = p4_new;
-    p4_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -100,7 +100,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -301,7 +301,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -100,7 +100,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -108,7 +108,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -373,7 +373,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -108,7 +108,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -108,7 +108,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -368,7 +368,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -76,6 +78,7 @@ char id1  ;
 char st1  ;
 msg_t send1  ;
 _Bool mode1  ;
+_Bool alive1  ;
 port_t p2  ;
 char p2_old ;
 char p2_new ;
@@ -83,6 +86,7 @@ char id2  ;
 char st2  ;
 msg_t send2  ;
 _Bool mode2  ;
+_Bool alive2  ;
 port_t p3  ;
 char p3_old ;
 char p3_new ;
@@ -90,6 +94,7 @@ char id3  ;
 char st3  ;
 msg_t send3  ;
 _Bool mode3  ;
+_Bool alive3  ;
 port_t p4  ;
 char p4_old ;
 char p4_new ;
@@ -97,6 +102,7 @@ char id4  ;
 char st4  ;
 msg_t send4  ;
 _Bool mode4  ;
+_Bool alive4  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -104,25 +110,29 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
-      if ((int )m1 > (int )id1) {
-        send1 = m1;
-      } else
-      if ((int )m1 == (int )id1) {
-        st1 = (char)1;
+      if (alive1) {
+        if ((int )m1 > (int )id1) {
+          send1 = m1;
+        } else
+        if ((int )m1 == (int )id1) {
+          st1 = (char)1;
+        }
       } else {
         send1 = m1;
       }
     }
     mode1 = (_Bool)0;
   } else {
-    p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    if (alive1) {
+      p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    } else
+    if ((int )send1 != (int )id1) {
+      p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    }
     mode1 = (_Bool)1;
   }
   return;
@@ -138,16 +148,25 @@ void node2(void)
     m2 = p1_old;
     p1_old = nomsg;
     if ((int )m2 != (int )nomsg) {
-      if ((int )m2 > (int )id2) {
+      if (alive2) {
+        if ((int )m2 > (int )id2) {
+          send2 = m2;
+        } else
+        if ((int )m2 == (int )id2) {
+          st2 = (char)1;
+        }
+      } else {
         send2 = m2;
-      } else
-      if ((int )m2 == (int )id2) {
-        st2 = (char)1;
       }
     }
     mode2 = (_Bool)0;
   } else {
-    p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    if (alive2) {
+      p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    } else
+    if ((int )send2 != (int )id2) {
+      p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    }
     mode2 = (_Bool)1;
   }
   return;
@@ -163,16 +182,25 @@ void node3(void)
     m3 = p2_old;
     p2_old = nomsg;
     if ((int )m3 != (int )nomsg) {
-      if ((int )m3 > (int )id3) {
+      if (alive3) {
+        if ((int )m3 > (int )id3) {
+          send3 = m3;
+        } else
+        if ((int )m3 == (int )id3) {
+          st3 = (char)1;
+        }
+      } else {
         send3 = m3;
-      } else
-      if ((int )m3 == (int )id3) {
-        st3 = (char)1;
       }
     }
     mode3 = (_Bool)0;
   } else {
-    p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    if (alive3) {
+      p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    } else
+    if ((int )send3 != (int )id3) {
+      p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    }
     mode3 = (_Bool)1;
   }
   return;
@@ -188,16 +216,25 @@ void node4(void)
     m4 = p3_old;
     p3_old = nomsg;
     if ((int )m4 != (int )nomsg) {
-      if ((int )m4 > (int )id4) {
+      if (alive4) {
+        if ((int )m4 > (int )id4) {
+          send4 = m4;
+        } else
+        if ((int )m4 == (int )id4) {
+          st4 = (char)1;
+        }
+      } else {
         send4 = m4;
-      } else
-      if ((int )m4 == (int )id4) {
-        st4 = (char)1;
       }
     }
     mode4 = (_Bool)0;
   } else {
-    p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
+    if (alive4) {
+      p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
+    } else
+    if ((int )send4 != (int )id4) {
+      p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
+    }
     mode4 = (_Bool)1;
   }
   return;
@@ -210,29 +247,33 @@ int init(void)
 
   {
   if ((int )r1 == 0) {
-    if ((int )id1 >= 0) {
-      if ((int )st1 == 0) {
-        if ((int )send1 == (int )id1) {
-          if ((int )mode1 == 0) {
-            if ((int )id2 >= 0) {
-              if ((int )st2 == 0) {
-                if ((int )send2 == (int )id2) {
-                  if ((int )mode2 == 0) {
-                    if ((int )id3 >= 0) {
-                      if ((int )st3 == 0) {
-                        if ((int )send3 == (int )id3) {
-                          if ((int )mode3 == 0) {
-                            if ((int )id4 >= 0) {
-                              if ((int )st4 == 0) {
-                                if ((int )send4 == (int )id4) {
-                                  if ((int )mode4 == 0) {
-                                    if ((int )id1 != (int )id2) {
-                                      if ((int )id1 != (int )id3) {
-                                        if ((int )id1 != (int )id4) {
-                                          if ((int )id2 != (int )id3) {
-                                            if ((int )id2 != (int )id4) {
-                                              if ((int )id3 != (int )id4) {
-                                                tmp = 1;
+    if ((((int )alive1 + (int )alive2) + (int )alive3) + (int )alive4 >= 1) {
+      if ((int )id1 >= 0) {
+        if ((int )st1 == 0) {
+          if ((int )send1 == (int )id1) {
+            if ((int )mode1 == 0) {
+              if ((int )id2 >= 0) {
+                if ((int )st2 == 0) {
+                  if ((int )send2 == (int )id2) {
+                    if ((int )mode2 == 0) {
+                      if ((int )id3 >= 0) {
+                        if ((int )st3 == 0) {
+                          if ((int )send3 == (int )id3) {
+                            if ((int )mode3 == 0) {
+                              if ((int )id4 >= 0) {
+                                if ((int )st4 == 0) {
+                                  if ((int )send4 == (int )id4) {
+                                    if ((int )mode4 == 0) {
+                                      if ((int )id1 != (int )id2) {
+                                        if ((int )id1 != (int )id3) {
+                                          if ((int )id1 != (int )id4) {
+                                            if ((int )id2 != (int )id3) {
+                                              if ((int )id2 != (int )id4) {
+                                                if ((int )id3 != (int )id4) {
+                                                  tmp = 1;
+                                                } else {
+                                                  tmp = 0;
+                                                }
                                               } else {
                                                 tmp = 0;
                                               }
@@ -311,19 +352,11 @@ int check(void)
 
   {
   if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 >= 4) {
-      goto _L;
+    if ((int )r1 < 4) {
+      tmp = 1;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 0) {
-      _L: /* CIL Label */ 
-      if ((int )r1 < 4) {
-        tmp = 1;
-      } else
-      if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
-        tmp = 1;
-      } else {
-        tmp = 0;
-      }
+    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
+      tmp = 1;
     } else {
       tmp = 0;
     }
@@ -345,18 +378,22 @@ int main(void)
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
+  alive1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
   st2 = __VERIFIER_nondet_char();
   send2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
+  alive2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
   st3 = __VERIFIER_nondet_char();
   send3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
+  alive3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
   st4 = __VERIFIER_nondet_char();
   send4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
+  alive4 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -108,7 +108,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -108,7 +108,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -371,7 +371,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -116,7 +116,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -448,7 +448,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -116,7 +116,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -116,7 +116,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -443,7 +443,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -116,7 +116,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -76,6 +78,7 @@ char id1  ;
 char st1  ;
 msg_t send1  ;
 _Bool mode1  ;
+_Bool alive1  ;
 port_t p2  ;
 char p2_old ;
 char p2_new ;
@@ -83,6 +86,7 @@ char id2  ;
 char st2  ;
 msg_t send2  ;
 _Bool mode2  ;
+_Bool alive2  ;
 port_t p3  ;
 char p3_old ;
 char p3_new ;
@@ -90,6 +94,7 @@ char id3  ;
 char st3  ;
 msg_t send3  ;
 _Bool mode3  ;
+_Bool alive3  ;
 port_t p4  ;
 char p4_old ;
 char p4_new ;
@@ -97,6 +102,15 @@ char id4  ;
 char st4  ;
 msg_t send4  ;
 _Bool mode4  ;
+_Bool alive4  ;
+port_t p5  ;
+char p5_old ;
+char p5_new ;
+char id5  ;
+char st5  ;
+msg_t send5  ;
+_Bool mode5  ;
+_Bool alive5  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -104,25 +118,29 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
-    m1 = p4_old;
-    p4_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p5_old;
+    p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
-      if ((int )m1 > (int )id1) {
-        send1 = m1;
-      } else
-      if ((int )m1 == (int )id1) {
-        st1 = (char)1;
+      if (alive1) {
+        if ((int )m1 > (int )id1) {
+          send1 = m1;
+        } else
+        if ((int )m1 == (int )id1) {
+          st1 = (char)1;
+        }
       } else {
         send1 = m1;
       }
     }
     mode1 = (_Bool)0;
   } else {
-    p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    if (alive1) {
+      p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    } else
+    if ((int )send1 != (int )id1) {
+      p1_new = send1 != nomsg && p1_new == nomsg ? send1 : p1_new;
+    }
     mode1 = (_Bool)1;
   }
   return;
@@ -138,16 +156,25 @@ void node2(void)
     m2 = p1_old;
     p1_old = nomsg;
     if ((int )m2 != (int )nomsg) {
-      if ((int )m2 > (int )id2) {
+      if (alive2) {
+        if ((int )m2 > (int )id2) {
+          send2 = m2;
+        } else
+        if ((int )m2 == (int )id2) {
+          st2 = (char)1;
+        }
+      } else {
         send2 = m2;
-      } else
-      if ((int )m2 == (int )id2) {
-        st2 = (char)1;
       }
     }
     mode2 = (_Bool)0;
   } else {
-    p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    if (alive2) {
+      p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    } else
+    if ((int )send2 != (int )id2) {
+      p2_new = send2 != nomsg && p2_new == nomsg ? send2 : p2_new;
+    }
     mode2 = (_Bool)1;
   }
   return;
@@ -163,16 +190,25 @@ void node3(void)
     m3 = p2_old;
     p2_old = nomsg;
     if ((int )m3 != (int )nomsg) {
-      if ((int )m3 > (int )id3) {
+      if (alive3) {
+        if ((int )m3 > (int )id3) {
+          send3 = m3;
+        } else
+        if ((int )m3 == (int )id3) {
+          st3 = (char)1;
+        }
+      } else {
         send3 = m3;
-      } else
-      if ((int )m3 == (int )id3) {
-        st3 = (char)1;
       }
     }
     mode3 = (_Bool)0;
   } else {
-    p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    if (alive3) {
+      p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    } else
+    if ((int )send3 != (int )id3) {
+      p3_new = send3 != nomsg && p3_new == nomsg ? send3 : p3_new;
+    }
     mode3 = (_Bool)1;
   }
   return;
@@ -188,51 +224,131 @@ void node4(void)
     m4 = p3_old;
     p3_old = nomsg;
     if ((int )m4 != (int )nomsg) {
-      if ((int )m4 > (int )id4) {
+      if (alive4) {
+        if ((int )m4 > (int )id4) {
+          send4 = m4;
+        } else
+        if ((int )m4 == (int )id4) {
+          st4 = (char)1;
+        }
+      } else {
         send4 = m4;
-      } else
-      if ((int )m4 == (int )id4) {
-        st4 = (char)1;
       }
     }
     mode4 = (_Bool)0;
   } else {
-    p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
+    if (alive4) {
+      p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
+    } else
+    if ((int )send4 != (int )id4) {
+      p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
+    }
     mode4 = (_Bool)1;
   }
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
+void node5(void) 
+{ 
+  msg_t m5 ;
+
+  {
+  m5 = nomsg;
+  if (mode5) {
+    m5 = p4_old;
+    p4_old = nomsg;
+    if ((int )m5 != (int )nomsg) {
+      if (alive5) {
+        if ((int )m5 > (int )id5) {
+          send5 = m5;
+        } else
+        if ((int )m5 == (int )id5) {
+          st5 = (char)1;
+        }
+      } else {
+        send5 = m5;
+      }
+    }
+    mode5 = (_Bool)0;
+  } else {
+    if (alive5) {
+      p5_new = send5 != nomsg && p5_new == nomsg ? send5 : p5_new;
+    } else
+    if ((int )send5 != (int )id5) {
+      p5_new = send5 != nomsg && p5_new == nomsg ? send5 : p5_new;
+    }
+    mode5 = (_Bool)1;
+  }
+  return;
+}
+}
+void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
+        & node5};
 int init(void) 
 { 
   int tmp ;
 
   {
   if ((int )r1 == 0) {
-    if ((int )id1 >= 0) {
-      if ((int )st1 == 0) {
-        if ((int )send1 == (int )id1) {
-          if ((int )mode1 == 0) {
-            if ((int )id2 >= 0) {
-              if ((int )st2 == 0) {
-                if ((int )send2 == (int )id2) {
-                  if ((int )mode2 == 0) {
-                    if ((int )id3 >= 0) {
-                      if ((int )st3 == 0) {
-                        if ((int )send3 == (int )id3) {
-                          if ((int )mode3 == 0) {
-                            if ((int )id4 >= 0) {
-                              if ((int )st4 == 0) {
-                                if ((int )send4 == (int )id4) {
-                                  if ((int )mode4 == 0) {
-                                    if ((int )id1 != (int )id2) {
-                                      if ((int )id1 != (int )id3) {
-                                        if ((int )id1 != (int )id4) {
-                                          if ((int )id2 != (int )id3) {
-                                            if ((int )id2 != (int )id4) {
-                                              if ((int )id3 != (int )id4) {
-                                                tmp = 1;
+    if (((((int )alive1 + (int )alive2) + (int )alive3) + (int )alive4) + (int )alive5 >= 1) {
+      if ((int )id1 >= 0) {
+        if ((int )st1 == 0) {
+          if ((int )send1 == (int )id1) {
+            if ((int )mode1 == 0) {
+              if ((int )id2 >= 0) {
+                if ((int )st2 == 0) {
+                  if ((int )send2 == (int )id2) {
+                    if ((int )mode2 == 0) {
+                      if ((int )id3 >= 0) {
+                        if ((int )st3 == 0) {
+                          if ((int )send3 == (int )id3) {
+                            if ((int )mode3 == 0) {
+                              if ((int )id4 >= 0) {
+                                if ((int )st4 == 0) {
+                                  if ((int )send4 == (int )id4) {
+                                    if ((int )mode4 == 0) {
+                                      if ((int )id5 >= 0) {
+                                        if ((int )st5 == 0) {
+                                          if ((int )send5 == (int )id5) {
+                                            if ((int )mode5 == 0) {
+                                              if ((int )id1 != (int )id2) {
+                                                if ((int )id1 != (int )id3) {
+                                                  if ((int )id1 != (int )id4) {
+                                                    if ((int )id1 != (int )id5) {
+                                                      if ((int )id2 != (int )id3) {
+                                                        if ((int )id2 != (int )id4) {
+                                                          if ((int )id2 != (int )id5) {
+                                                            if ((int )id3 != (int )id4) {
+                                                              if ((int )id3 != (int )id5) {
+                                                                if ((int )id4 != (int )id5) {
+                                                                  tmp = 1;
+                                                                } else {
+                                                                  tmp = 0;
+                                                                }
+                                                              } else {
+                                                                tmp = 0;
+                                                              }
+                                                            } else {
+                                                              tmp = 0;
+                                                            }
+                                                          } else {
+                                                            tmp = 0;
+                                                          }
+                                                        } else {
+                                                          tmp = 0;
+                                                        }
+                                                      } else {
+                                                        tmp = 0;
+                                                      }
+                                                    } else {
+                                                      tmp = 0;
+                                                    }
+                                                  } else {
+                                                    tmp = 0;
+                                                  }
+                                                } else {
+                                                  tmp = 0;
+                                                }
                                               } else {
                                                 tmp = 0;
                                               }
@@ -310,20 +426,12 @@ int check(void)
   int tmp ;
 
   {
-  if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 >= 4) {
-      goto _L;
+  if (((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5 <= 1) {
+    if ((int )r1 < 5) {
+      tmp = 1;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 0) {
-      _L: /* CIL Label */ 
-      if ((int )r1 < 4) {
-        tmp = 1;
-      } else
-      if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
-        tmp = 1;
-      } else {
-        tmp = 0;
-      }
+    if (((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5 == 1) {
+      tmp = 1;
     } else {
       tmp = 0;
     }
@@ -345,18 +453,27 @@ int main(void)
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
+  alive1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
   st2 = __VERIFIER_nondet_char();
   send2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
+  alive2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
   st3 = __VERIFIER_nondet_char();
   send3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
+  alive3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
   st4 = __VERIFIER_nondet_char();
   send4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
+  alive4 = __VERIFIER_nondet_bool();
+  id5 = __VERIFIER_nondet_char();
+  st5 = __VERIFIER_nondet_char();
+  send5 = __VERIFIER_nondet_char();
+  mode5 = __VERIFIER_nondet_bool();
+  alive5 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -367,6 +484,8 @@ int main(void)
   p3_new = nomsg;
   p4_old = nomsg;
   p4_new = nomsg;
+  p5_old = nomsg;
+  p5_new = nomsg;
   i2 = 0;
   while (1) {
     {
@@ -374,6 +493,7 @@ int main(void)
     node2();
     node3();
     node4();
+    node5();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
@@ -382,6 +502,8 @@ int main(void)
     p3_new = nomsg;
     p4_old = p4_new;
     p4_new = nomsg;
+    p5_old = p5_new;
+    p5_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -116,7 +116,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -446,7 +446,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -116,7 +116,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -124,7 +124,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 5;
+    }
+    r1 = r1 + 1;
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -124,7 +124,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -526,7 +526,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -124,7 +124,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -521,7 +521,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -124,7 +124,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 5;
+    }
+    r1 = r1 + 1;
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -101,6 +103,22 @@ char st4  ;
 msg_t send4  ;
 _Bool mode4  ;
 _Bool alive4  ;
+port_t p5  ;
+char p5_old ;
+char p5_new ;
+char id5  ;
+char st5  ;
+msg_t send5  ;
+_Bool mode5  ;
+_Bool alive5  ;
+port_t p6  ;
+char p6_old ;
+char p6_new ;
+char id6  ;
+char st6  ;
+msg_t send6  ;
+_Bool mode6  ;
+_Bool alive6  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -108,12 +126,9 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
-    m1 = p4_old;
-    p4_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p6_old;
+    p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
       if (alive1) {
         if ((int )m1 > (int )id1) {
@@ -121,8 +136,6 @@ void node1(void)
         } else
         if ((int )m1 == (int )id1) {
           st1 = (char)1;
-        } else {
-          send1 = m1;
         }
       } else {
         send1 = m1;
@@ -243,14 +256,83 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
+void node5(void) 
+{ 
+  msg_t m5 ;
+
+  {
+  m5 = nomsg;
+  if (mode5) {
+    m5 = p4_old;
+    p4_old = nomsg;
+    if ((int )m5 != (int )nomsg) {
+      if (alive5) {
+        if ((int )m5 > (int )id5) {
+          send5 = m5;
+        } else
+        if ((int )m5 == (int )id5) {
+          st5 = (char)1;
+        }
+      } else {
+        send5 = m5;
+      }
+    }
+    mode5 = (_Bool)0;
+  } else {
+    if (alive5) {
+      p5_new = send5 != nomsg && p5_new == nomsg ? send5 : p5_new;
+    } else
+    if ((int )send5 != (int )id5) {
+      p5_new = send5 != nomsg && p5_new == nomsg ? send5 : p5_new;
+    }
+    mode5 = (_Bool)1;
+  }
+  return;
+}
+}
+void node6(void) 
+{ 
+  msg_t m6 ;
+
+  {
+  m6 = nomsg;
+  if (mode6) {
+    m6 = p5_old;
+    p5_old = nomsg;
+    if ((int )m6 != (int )nomsg) {
+      if (alive6) {
+        if ((int )m6 > (int )id6) {
+          send6 = m6;
+        } else
+        if ((int )m6 == (int )id6) {
+          st6 = (char)1;
+        }
+      } else {
+        send6 = m6;
+      }
+    }
+    mode6 = (_Bool)0;
+  } else {
+    if (alive6) {
+      p6_new = send6 != nomsg && p6_new == nomsg ? send6 : p6_new;
+    } else
+    if ((int )send6 != (int )id6) {
+      p6_new = send6 != nomsg && p6_new == nomsg ? send6 : p6_new;
+    }
+    mode6 = (_Bool)1;
+  }
+  return;
+}
+}
+void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
+        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;
 
   {
   if ((int )r1 == 0) {
-    if ((((int )alive1 + (int )alive2) + (int )alive3) + (int )alive4 >= 1) {
+    if ((((((int )alive1 + (int )alive2) + (int )alive3) + (int )alive4) + (int )alive5) + (int )alive6 >= 1) {
       if ((int )id1 >= 0) {
         if ((int )st1 == 0) {
           if ((int )send1 == (int )id1) {
@@ -267,13 +349,81 @@ int init(void)
                                 if ((int )st4 == 0) {
                                   if ((int )send4 == (int )id4) {
                                     if ((int )mode4 == 0) {
-                                      if ((int )id1 != (int )id2) {
-                                        if ((int )id1 != (int )id3) {
-                                          if ((int )id1 != (int )id4) {
-                                            if ((int )id2 != (int )id3) {
-                                              if ((int )id2 != (int )id4) {
-                                                if ((int )id3 != (int )id4) {
-                                                  tmp = 1;
+                                      if ((int )id5 >= 0) {
+                                        if ((int )st5 == 0) {
+                                          if ((int )send5 == (int )id5) {
+                                            if ((int )mode5 == 0) {
+                                              if ((int )id6 >= 0) {
+                                                if ((int )st6 == 0) {
+                                                  if ((int )send6 == (int )id6) {
+                                                    if ((int )mode6 == 0) {
+                                                      if ((int )id1 != (int )id2) {
+                                                        if ((int )id1 != (int )id3) {
+                                                          if ((int )id1 != (int )id4) {
+                                                            if ((int )id1 != (int )id5) {
+                                                              if ((int )id1 != (int )id6) {
+                                                                if ((int )id2 != (int )id3) {
+                                                                  if ((int )id2 != (int )id4) {
+                                                                    if ((int )id2 != (int )id5) {
+                                                                      if ((int )id2 != (int )id6) {
+                                                                        if ((int )id3 != (int )id4) {
+                                                                          if ((int )id3 != (int )id5) {
+                                                                            if ((int )id3 != (int )id6) {
+                                                                              if ((int )id4 != (int )id5) {
+                                                                                if ((int )id4 != (int )id6) {
+                                                                                  if ((int )id5 != (int )id6) {
+                                                                                    tmp = 1;
+                                                                                  } else {
+                                                                                    tmp = 0;
+                                                                                  }
+                                                                                } else {
+                                                                                  tmp = 0;
+                                                                                }
+                                                                              } else {
+                                                                                tmp = 0;
+                                                                              }
+                                                                            } else {
+                                                                              tmp = 0;
+                                                                            }
+                                                                          } else {
+                                                                            tmp = 0;
+                                                                          }
+                                                                        } else {
+                                                                          tmp = 0;
+                                                                        }
+                                                                      } else {
+                                                                        tmp = 0;
+                                                                      }
+                                                                    } else {
+                                                                      tmp = 0;
+                                                                    }
+                                                                  } else {
+                                                                    tmp = 0;
+                                                                  }
+                                                                } else {
+                                                                  tmp = 0;
+                                                                }
+                                                              } else {
+                                                                tmp = 0;
+                                                              }
+                                                            } else {
+                                                              tmp = 0;
+                                                            }
+                                                          } else {
+                                                            tmp = 0;
+                                                          }
+                                                        } else {
+                                                          tmp = 0;
+                                                        }
+                                                      } else {
+                                                        tmp = 0;
+                                                      }
+                                                    } else {
+                                                      tmp = 0;
+                                                    }
+                                                  } else {
+                                                    tmp = 0;
+                                                  }
                                                 } else {
                                                   tmp = 0;
                                                 }
@@ -354,11 +504,11 @@ int check(void)
   int tmp ;
 
   {
-  if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 < 4) {
+  if ((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6 <= 1) {
+    if ((int )r1 < 6) {
       tmp = 1;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
+    if ((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6 == 1) {
       tmp = 1;
     } else {
       tmp = 0;
@@ -397,6 +547,16 @@ int main(void)
   send4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
   alive4 = __VERIFIER_nondet_bool();
+  id5 = __VERIFIER_nondet_char();
+  st5 = __VERIFIER_nondet_char();
+  send5 = __VERIFIER_nondet_char();
+  mode5 = __VERIFIER_nondet_bool();
+  alive5 = __VERIFIER_nondet_bool();
+  id6 = __VERIFIER_nondet_char();
+  st6 = __VERIFIER_nondet_char();
+  send6 = __VERIFIER_nondet_char();
+  mode6 = __VERIFIER_nondet_bool();
+  alive6 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -407,6 +567,10 @@ int main(void)
   p3_new = nomsg;
   p4_old = nomsg;
   p4_new = nomsg;
+  p5_old = nomsg;
+  p5_new = nomsg;
+  p6_old = nomsg;
+  p6_new = nomsg;
   i2 = 0;
   while (1) {
     {
@@ -414,6 +578,8 @@ int main(void)
     node2();
     node3();
     node4();
+    node5();
+    node6();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
@@ -422,6 +588,10 @@ int main(void)
     p3_new = nomsg;
     p4_old = p4_new;
     p4_new = nomsg;
+    p5_old = p5_new;
+    p5_new = nomsg;
+    p6_old = p6_new;
+    p6_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -124,7 +124,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -524,7 +524,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr-var-start-time.6_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -124,7 +124,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 5;
+    }
+    r1 = r1 + 1;
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -97,7 +97,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -97,7 +97,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -277,7 +277,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -90,13 +92,6 @@ char id3  ;
 char st3  ;
 msg_t send3  ;
 _Bool mode3  ;
-port_t p4  ;
-char p4_old ;
-char p4_new ;
-char id4  ;
-char st4  ;
-msg_t send4  ;
-_Bool mode4  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -104,20 +99,15 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
-    m1 = p4_old;
-    p4_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p3_old;
+    p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
       if ((int )m1 > (int )id1) {
         send1 = m1;
       } else
       if ((int )m1 == (int )id1) {
         st1 = (char)1;
-      } else {
-        send1 = m1;
       }
     }
     mode1 = (_Bool)0;
@@ -178,32 +168,7 @@ void node3(void)
   return;
 }
 }
-void node4(void) 
-{ 
-  msg_t m4 ;
-
-  {
-  m4 = nomsg;
-  if (mode4) {
-    m4 = p3_old;
-    p3_old = nomsg;
-    if ((int )m4 != (int )nomsg) {
-      if ((int )m4 > (int )id4) {
-        send4 = m4;
-      } else
-      if ((int )m4 == (int )id4) {
-        st4 = (char)1;
-      }
-    }
-    mode4 = (_Bool)0;
-  } else {
-    p4_new = send4 != nomsg && p4_new == nomsg ? send4 : p4_new;
-    mode4 = (_Bool)1;
-  }
-  return;
-}
-}
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
+void (*nodes[3])(void)  = {      & node1,      & node2,      & node3};
 int init(void) 
 { 
   int tmp ;
@@ -222,38 +187,10 @@ int init(void)
                       if ((int )st3 == 0) {
                         if ((int )send3 == (int )id3) {
                           if ((int )mode3 == 0) {
-                            if ((int )id4 >= 0) {
-                              if ((int )st4 == 0) {
-                                if ((int )send4 == (int )id4) {
-                                  if ((int )mode4 == 0) {
-                                    if ((int )id1 != (int )id2) {
-                                      if ((int )id1 != (int )id3) {
-                                        if ((int )id1 != (int )id4) {
-                                          if ((int )id2 != (int )id3) {
-                                            if ((int )id2 != (int )id4) {
-                                              if ((int )id3 != (int )id4) {
-                                                tmp = 1;
-                                              } else {
-                                                tmp = 0;
-                                              }
-                                            } else {
-                                              tmp = 0;
-                                            }
-                                          } else {
-                                            tmp = 0;
-                                          }
-                                        } else {
-                                          tmp = 0;
-                                        }
-                                      } else {
-                                        tmp = 0;
-                                      }
-                                    } else {
-                                      tmp = 0;
-                                    }
-                                  } else {
-                                    tmp = 0;
-                                  }
+                            if ((int )id1 != (int )id2) {
+                              if ((int )id1 != (int )id3) {
+                                if ((int )id2 != (int )id3) {
+                                  tmp = 1;
                                 } else {
                                   tmp = 0;
                                 }
@@ -310,16 +247,16 @@ int check(void)
   int tmp ;
 
   {
-  if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 >= 4) {
+  if (((int )st1 + (int )st2) + (int )st3 <= 1) {
+    if ((int )r1 >= 3) {
       goto _L;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 0) {
+    if (((int )st1 + (int )st2) + (int )st3 == 0) {
       _L: /* CIL Label */ 
-      if ((int )r1 < 4) {
+      if ((int )r1 < 3) {
         tmp = 1;
       } else
-      if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
+      if (((int )st1 + (int )st2) + (int )st3 == 1) {
         tmp = 1;
       } else {
         tmp = 0;
@@ -353,10 +290,6 @@ int main(void)
   st3 = __VERIFIER_nondet_char();
   send3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
-  id4 = __VERIFIER_nondet_char();
-  st4 = __VERIFIER_nondet_char();
-  send4 = __VERIFIER_nondet_char();
-  mode4 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -365,23 +298,18 @@ int main(void)
   p2_new = nomsg;
   p3_old = nomsg;
   p3_new = nomsg;
-  p4_old = nomsg;
-  p4_new = nomsg;
   i2 = 0;
   while (1) {
     {
     node1();
     node2();
     node3();
-    node4();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
     p2_new = nomsg;
     p3_old = p3_new;
     p3_new = nomsg;
-    p4_old = p4_new;
-    p4_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -97,7 +97,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -97,7 +97,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p3_old;
     p3_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -275,7 +275,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -104,7 +104,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -337,7 +337,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -104,10 +106,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -116,8 +115,6 @@ void node1(void)
       } else
       if ((int )m1 == (int )id1) {
         st1 = (char)1;
-      } else {
-        send1 = m1;
       }
     }
     mode1 = (_Bool)0;

--- a/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -104,7 +104,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -335,7 +335,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -104,7 +104,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     m1 = p4_old;
     p4_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -111,7 +111,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -111,7 +111,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -402,7 +402,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -97,6 +99,13 @@ char id4  ;
 char st4  ;
 msg_t send4  ;
 _Bool mode4  ;
+port_t p5  ;
+char p5_old ;
+char p5_new ;
+char id5  ;
+char st5  ;
+msg_t send5  ;
+_Bool mode5  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -104,20 +113,15 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
-    m1 = p4_old;
-    p4_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p5_old;
+    p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
       if ((int )m1 > (int )id1) {
         send1 = m1;
       } else
       if ((int )m1 == (int )id1) {
         st1 = (char)1;
-      } else {
-        send1 = m1;
       }
     }
     mode1 = (_Bool)0;
@@ -203,7 +207,33 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
+void node5(void) 
+{ 
+  msg_t m5 ;
+
+  {
+  m5 = nomsg;
+  if (mode5) {
+    m5 = p4_old;
+    p4_old = nomsg;
+    if ((int )m5 != (int )nomsg) {
+      if ((int )m5 > (int )id5) {
+        send5 = m5;
+      } else
+      if ((int )m5 == (int )id5) {
+        st5 = (char)1;
+      }
+    }
+    mode5 = (_Bool)0;
+  } else {
+    p5_new = send5 != nomsg && p5_new == nomsg ? send5 : p5_new;
+    mode5 = (_Bool)1;
+  }
+  return;
+}
+}
+void (*nodes[5])(void)  = {      & node1,      & node2,      & node3,      & node4, 
+        & node5};
 int init(void) 
 { 
   int tmp ;
@@ -226,13 +256,45 @@ int init(void)
                               if ((int )st4 == 0) {
                                 if ((int )send4 == (int )id4) {
                                   if ((int )mode4 == 0) {
-                                    if ((int )id1 != (int )id2) {
-                                      if ((int )id1 != (int )id3) {
-                                        if ((int )id1 != (int )id4) {
-                                          if ((int )id2 != (int )id3) {
-                                            if ((int )id2 != (int )id4) {
-                                              if ((int )id3 != (int )id4) {
-                                                tmp = 1;
+                                    if ((int )id5 >= 0) {
+                                      if ((int )st5 == 0) {
+                                        if ((int )send5 == (int )id5) {
+                                          if ((int )mode5 == 0) {
+                                            if ((int )id1 != (int )id2) {
+                                              if ((int )id1 != (int )id3) {
+                                                if ((int )id1 != (int )id4) {
+                                                  if ((int )id1 != (int )id5) {
+                                                    if ((int )id2 != (int )id3) {
+                                                      if ((int )id2 != (int )id4) {
+                                                        if ((int )id2 != (int )id5) {
+                                                          if ((int )id3 != (int )id4) {
+                                                            if ((int )id3 != (int )id5) {
+                                                              if ((int )id4 != (int )id5) {
+                                                                tmp = 1;
+                                                              } else {
+                                                                tmp = 0;
+                                                              }
+                                                            } else {
+                                                              tmp = 0;
+                                                            }
+                                                          } else {
+                                                            tmp = 0;
+                                                          }
+                                                        } else {
+                                                          tmp = 0;
+                                                        }
+                                                      } else {
+                                                        tmp = 0;
+                                                      }
+                                                    } else {
+                                                      tmp = 0;
+                                                    }
+                                                  } else {
+                                                    tmp = 0;
+                                                  }
+                                                } else {
+                                                  tmp = 0;
+                                                }
                                               } else {
                                                 tmp = 0;
                                               }
@@ -310,16 +372,16 @@ int check(void)
   int tmp ;
 
   {
-  if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 >= 4) {
+  if (((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5 <= 1) {
+    if ((int )r1 >= 5) {
       goto _L;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 0) {
+    if (((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5 == 0) {
       _L: /* CIL Label */ 
-      if ((int )r1 < 4) {
+      if ((int )r1 < 5) {
         tmp = 1;
       } else
-      if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
+      if (((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5 == 1) {
         tmp = 1;
       } else {
         tmp = 0;
@@ -357,6 +419,10 @@ int main(void)
   st4 = __VERIFIER_nondet_char();
   send4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
+  id5 = __VERIFIER_nondet_char();
+  st5 = __VERIFIER_nondet_char();
+  send5 = __VERIFIER_nondet_char();
+  mode5 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -367,6 +433,8 @@ int main(void)
   p3_new = nomsg;
   p4_old = nomsg;
   p4_new = nomsg;
+  p5_old = nomsg;
+  p5_new = nomsg;
   i2 = 0;
   while (1) {
     {
@@ -374,6 +442,7 @@ int main(void)
     node2();
     node3();
     node4();
+    node5();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
@@ -382,6 +451,8 @@ int main(void)
     p3_new = nomsg;
     p4_old = p4_new;
     p4_new = nomsg;
+    p5_old = p5_new;
+    p5_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -111,7 +111,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -111,7 +111,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p5_old;
     p5_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -400,7 +400,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -118,7 +118,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 5;
+    }
+    r1 = r1 + 1;
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -118,7 +118,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -470,7 +470,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.6_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -97,6 +99,20 @@ char id4  ;
 char st4  ;
 msg_t send4  ;
 _Bool mode4  ;
+port_t p5  ;
+char p5_old ;
+char p5_new ;
+char id5  ;
+char st5  ;
+msg_t send5  ;
+_Bool mode5  ;
+port_t p6  ;
+char p6_old ;
+char p6_new ;
+char id6  ;
+char st6  ;
+msg_t send6  ;
+_Bool mode6  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -104,20 +120,15 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
-    m1 = p4_old;
-    p4_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p6_old;
+    p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
       if ((int )m1 > (int )id1) {
         send1 = m1;
       } else
       if ((int )m1 == (int )id1) {
         st1 = (char)1;
-      } else {
-        send1 = m1;
       }
     }
     mode1 = (_Bool)0;
@@ -203,7 +214,58 @@ void node4(void)
   return;
 }
 }
-void (*nodes[4])(void)  = {      & node1,      & node2,      & node3,      & node4};
+void node5(void) 
+{ 
+  msg_t m5 ;
+
+  {
+  m5 = nomsg;
+  if (mode5) {
+    m5 = p4_old;
+    p4_old = nomsg;
+    if ((int )m5 != (int )nomsg) {
+      if ((int )m5 > (int )id5) {
+        send5 = m5;
+      } else
+      if ((int )m5 == (int )id5) {
+        st5 = (char)1;
+      }
+    }
+    mode5 = (_Bool)0;
+  } else {
+    p5_new = send5 != nomsg && p5_new == nomsg ? send5 : p5_new;
+    mode5 = (_Bool)1;
+  }
+  return;
+}
+}
+void node6(void) 
+{ 
+  msg_t m6 ;
+
+  {
+  m6 = nomsg;
+  if (mode6) {
+    m6 = p5_old;
+    p5_old = nomsg;
+    if ((int )m6 != (int )nomsg) {
+      if ((int )m6 > (int )id6) {
+        send6 = m6;
+      } else
+      if ((int )m6 == (int )id6) {
+        st6 = (char)1;
+      }
+    }
+    mode6 = (_Bool)0;
+  } else {
+    p6_new = send6 != nomsg && p6_new == nomsg ? send6 : p6_new;
+    mode6 = (_Bool)1;
+  }
+  return;
+}
+}
+void (*nodes[6])(void)  = {      & node1,      & node2,      & node3,      & node4, 
+        & node5,      & node6};
 int init(void) 
 { 
   int tmp ;
@@ -226,13 +288,81 @@ int init(void)
                               if ((int )st4 == 0) {
                                 if ((int )send4 == (int )id4) {
                                   if ((int )mode4 == 0) {
-                                    if ((int )id1 != (int )id2) {
-                                      if ((int )id1 != (int )id3) {
-                                        if ((int )id1 != (int )id4) {
-                                          if ((int )id2 != (int )id3) {
-                                            if ((int )id2 != (int )id4) {
-                                              if ((int )id3 != (int )id4) {
-                                                tmp = 1;
+                                    if ((int )id5 >= 0) {
+                                      if ((int )st5 == 0) {
+                                        if ((int )send5 == (int )id5) {
+                                          if ((int )mode5 == 0) {
+                                            if ((int )id6 >= 0) {
+                                              if ((int )st6 == 0) {
+                                                if ((int )send6 == (int )id6) {
+                                                  if ((int )mode6 == 0) {
+                                                    if ((int )id1 != (int )id2) {
+                                                      if ((int )id1 != (int )id3) {
+                                                        if ((int )id1 != (int )id4) {
+                                                          if ((int )id1 != (int )id5) {
+                                                            if ((int )id1 != (int )id6) {
+                                                              if ((int )id2 != (int )id3) {
+                                                                if ((int )id2 != (int )id4) {
+                                                                  if ((int )id2 != (int )id5) {
+                                                                    if ((int )id2 != (int )id6) {
+                                                                      if ((int )id3 != (int )id4) {
+                                                                        if ((int )id3 != (int )id5) {
+                                                                          if ((int )id3 != (int )id6) {
+                                                                            if ((int )id4 != (int )id5) {
+                                                                              if ((int )id4 != (int )id6) {
+                                                                                if ((int )id5 != (int )id6) {
+                                                                                  tmp = 1;
+                                                                                } else {
+                                                                                  tmp = 0;
+                                                                                }
+                                                                              } else {
+                                                                                tmp = 0;
+                                                                              }
+                                                                            } else {
+                                                                              tmp = 0;
+                                                                            }
+                                                                          } else {
+                                                                            tmp = 0;
+                                                                          }
+                                                                        } else {
+                                                                          tmp = 0;
+                                                                        }
+                                                                      } else {
+                                                                        tmp = 0;
+                                                                      }
+                                                                    } else {
+                                                                      tmp = 0;
+                                                                    }
+                                                                  } else {
+                                                                    tmp = 0;
+                                                                  }
+                                                                } else {
+                                                                  tmp = 0;
+                                                                }
+                                                              } else {
+                                                                tmp = 0;
+                                                              }
+                                                            } else {
+                                                              tmp = 0;
+                                                            }
+                                                          } else {
+                                                            tmp = 0;
+                                                          }
+                                                        } else {
+                                                          tmp = 0;
+                                                        }
+                                                      } else {
+                                                        tmp = 0;
+                                                      }
+                                                    } else {
+                                                      tmp = 0;
+                                                    }
+                                                  } else {
+                                                    tmp = 0;
+                                                  }
+                                                } else {
+                                                  tmp = 0;
+                                                }
                                               } else {
                                                 tmp = 0;
                                               }
@@ -310,16 +440,16 @@ int check(void)
   int tmp ;
 
   {
-  if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 <= 1) {
-    if ((int )r1 >= 4) {
+  if ((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6 <= 1) {
+    if ((int )r1 >= 6) {
       goto _L;
     } else
-    if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 0) {
+    if ((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6 == 0) {
       _L: /* CIL Label */ 
-      if ((int )r1 < 4) {
+      if ((int )r1 < 6) {
         tmp = 1;
       } else
-      if ((((int )st1 + (int )st2) + (int )st3) + (int )st4 == 1) {
+      if ((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6 == 1) {
         tmp = 1;
       } else {
         tmp = 0;
@@ -357,6 +487,14 @@ int main(void)
   st4 = __VERIFIER_nondet_char();
   send4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
+  id5 = __VERIFIER_nondet_char();
+  st5 = __VERIFIER_nondet_char();
+  send5 = __VERIFIER_nondet_char();
+  mode5 = __VERIFIER_nondet_bool();
+  id6 = __VERIFIER_nondet_char();
+  st6 = __VERIFIER_nondet_char();
+  send6 = __VERIFIER_nondet_char();
+  mode6 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -367,6 +505,10 @@ int main(void)
   p3_new = nomsg;
   p4_old = nomsg;
   p4_new = nomsg;
+  p5_old = nomsg;
+  p5_new = nomsg;
+  p6_old = nomsg;
+  p6_new = nomsg;
   i2 = 0;
   while (1) {
     {
@@ -374,6 +516,8 @@ int main(void)
     node2();
     node3();
     node4();
+    node5();
+    node6();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
@@ -382,6 +526,10 @@ int main(void)
     p3_new = nomsg;
     p4_old = p4_new;
     p4_new = nomsg;
+    p5_old = p5_new;
+    p5_new = nomsg;
+    p6_old = p6_new;
+    p6_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -118,7 +118,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 5;
+    }
+    r1 = r1 + 1;
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.6_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -118,7 +118,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p6_old;
     p6_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -468,7 +468,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -125,7 +125,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 6;
+    }
+    r1 = r1 + 1;
     m1 = p7_old;
     p7_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -125,7 +125,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p7_old;
     p7_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -542,7 +542,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.7_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -118,13 +120,6 @@ char id7  ;
 char st7  ;
 msg_t send7  ;
 _Bool mode7  ;
-port_t p8  ;
-char p8_old ;
-char p8_new ;
-char id8  ;
-char st8  ;
-msg_t send8  ;
-_Bool mode8  ;
 void node1(void) 
 { 
   msg_t m1 ;
@@ -132,12 +127,9 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 7;
-    }
-    r1 = r1 + 1;
-    m1 = p8_old;
-    p8_old = nomsg;
+    r1 = (unsigned char )((int )r1 + 1);
+    m1 = p7_old;
+    p7_old = nomsg;
     if ((int )m1 != (int )nomsg) {
       if ((int )m1 > (int )id1) {
         send1 = m1;
@@ -304,34 +296,8 @@ void node7(void)
   return;
 }
 }
-void node8(void) 
-{ 
-  msg_t m8 ;
-
-  {
-  m8 = nomsg;
-  if (mode8) {
-    m8 = p7_old;
-    p7_old = nomsg;
-    if ((int )m8 != (int )nomsg) {
-      if ((int )m8 > (int )id8) {
-        send8 = m8;
-      } else
-      if ((int )m8 == (int )id8) {
-        st8 = (char)1;
-      }
-    }
-    mode8 = (_Bool)0;
-  } else {
-    p8_new = send8 != nomsg && p8_new == nomsg ? send8 : p8_new;
-    mode8 = (_Bool)1;
-  }
-  return;
-}
-}
-void (*nodes[8])(void)  = 
-  {      & node1,      & node2,      & node3,      & node4, 
-        & node5,      & node6,      & node7,      & node8};
+void (*nodes[7])(void)  = {      & node1,      & node2,      & node3,      & node4, 
+        & node5,      & node6,      & node7};
 int init(void) 
 { 
   int tmp ;
@@ -366,72 +332,28 @@ int init(void)
                                                       if ((int )st7 == 0) {
                                                         if ((int )send7 == (int )id7) {
                                                           if ((int )mode7 == 0) {
-                                                            if ((int )id8 >= 0) {
-                                                              if ((int )st8 == 0) {
-                                                                if ((int )send8 == (int )id8) {
-                                                                  if ((int )mode8 == 0) {
-                                                                    if ((int )id1 != (int )id2) {
-                                                                      if ((int )id1 != (int )id3) {
-                                                                        if ((int )id1 != (int )id4) {
-                                                                          if ((int )id1 != (int )id5) {
-                                                                            if ((int )id1 != (int )id6) {
-                                                                              if ((int )id1 != (int )id7) {
-                                                                                if ((int )id1 != (int )id8) {
-                                                                                  if ((int )id2 != (int )id3) {
-                                                                                    if ((int )id2 != (int )id4) {
-                                                                                      if ((int )id2 != (int )id5) {
-                                                                                        if ((int )id2 != (int )id6) {
-                                                                                          if ((int )id2 != (int )id7) {
-                                                                                            if ((int )id2 != (int )id8) {
-                                                                                              if ((int )id3 != (int )id4) {
-                                                                                                if ((int )id3 != (int )id5) {
-                                                                                                  if ((int )id3 != (int )id6) {
-                                                                                                    if ((int )id3 != (int )id7) {
-                                                                                                      if ((int )id3 != (int )id8) {
-                                                                                                        if ((int )id4 != (int )id5) {
-                                                                                                          if ((int )id4 != (int )id6) {
-                                                                                                            if ((int )id4 != (int )id7) {
-                                                                                                              if ((int )id4 != (int )id8) {
-                                                                                                                if ((int )id5 != (int )id6) {
-                                                                                                                  if ((int )id5 != (int )id7) {
-                                                                                                                    if ((int )id5 != (int )id8) {
-                                                                                                                      if ((int )id6 != (int )id7) {
-                                                                                                                        if ((int )id6 != (int )id8) {
-                                                                                                                          if ((int )id7 != (int )id8) {
-                                                                                                                            tmp = 1;
-                                                                                                                          } else {
-                                                                                                                            tmp = 0;
-                                                                                                                          }
-                                                                                                                        } else {
-                                                                                                                          tmp = 0;
-                                                                                                                        }
-                                                                                                                      } else {
-                                                                                                                        tmp = 0;
-                                                                                                                      }
-                                                                                                                    } else {
-                                                                                                                      tmp = 0;
-                                                                                                                    }
-                                                                                                                  } else {
-                                                                                                                    tmp = 0;
-                                                                                                                  }
-                                                                                                                } else {
-                                                                                                                  tmp = 0;
-                                                                                                                }
-                                                                                                              } else {
-                                                                                                                tmp = 0;
-                                                                                                              }
-                                                                                                            } else {
-                                                                                                              tmp = 0;
-                                                                                                            }
-                                                                                                          } else {
-                                                                                                            tmp = 0;
-                                                                                                          }
-                                                                                                        } else {
-                                                                                                          tmp = 0;
-                                                                                                        }
-                                                                                                      } else {
-                                                                                                        tmp = 0;
-                                                                                                      }
+                                                            if ((int )id1 != (int )id2) {
+                                                              if ((int )id1 != (int )id3) {
+                                                                if ((int )id1 != (int )id4) {
+                                                                  if ((int )id1 != (int )id5) {
+                                                                    if ((int )id1 != (int )id6) {
+                                                                      if ((int )id1 != (int )id7) {
+                                                                        if ((int )id2 != (int )id3) {
+                                                                          if ((int )id2 != (int )id4) {
+                                                                            if ((int )id2 != (int )id5) {
+                                                                              if ((int )id2 != (int )id6) {
+                                                                                if ((int )id2 != (int )id7) {
+                                                                                  if ((int )id3 != (int )id4) {
+                                                                                    if ((int )id3 != (int )id5) {
+                                                                                      if ((int )id3 != (int )id6) {
+                                                                                        if ((int )id3 != (int )id7) {
+                                                                                          if ((int )id4 != (int )id5) {
+                                                                                            if ((int )id4 != (int )id6) {
+                                                                                              if ((int )id4 != (int )id7) {
+                                                                                                if ((int )id5 != (int )id6) {
+                                                                                                  if ((int )id5 != (int )id7) {
+                                                                                                    if ((int )id6 != (int )id7) {
+                                                                                                      tmp = 1;
                                                                                                     } else {
                                                                                                       tmp = 0;
                                                                                                     }
@@ -590,16 +512,16 @@ int check(void)
   int tmp ;
 
   {
-  if ((((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6) + (int )st7) + (int )st8 <= 1) {
-    if ((int )r1 >= 8) {
+  if (((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6) + (int )st7 <= 1) {
+    if ((int )r1 >= 7) {
       goto _L;
     } else
-    if ((((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6) + (int )st7) + (int )st8 == 0) {
+    if (((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6) + (int )st7 == 0) {
       _L: /* CIL Label */ 
-      if ((int )r1 < 8) {
+      if ((int )r1 < 7) {
         tmp = 1;
       } else
-      if ((((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6) + (int )st7) + (int )st8 == 1) {
+      if (((((((int )st1 + (int )st2) + (int )st3) + (int )st4) + (int )st5) + (int )st6) + (int )st7 == 1) {
         tmp = 1;
       } else {
         tmp = 0;
@@ -649,10 +571,6 @@ int main(void)
   st7 = __VERIFIER_nondet_char();
   send7 = __VERIFIER_nondet_char();
   mode7 = __VERIFIER_nondet_bool();
-  id8 = __VERIFIER_nondet_char();
-  st8 = __VERIFIER_nondet_char();
-  send8 = __VERIFIER_nondet_char();
-  mode8 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p1_old = nomsg;
@@ -669,8 +587,6 @@ int main(void)
   p6_new = nomsg;
   p7_old = nomsg;
   p7_new = nomsg;
-  p8_old = nomsg;
-  p8_new = nomsg;
   i2 = 0;
   while (1) {
     {
@@ -681,7 +597,6 @@ int main(void)
     node5();
     node6();
     node7();
-    node8();
     p1_old = p1_new;
     p1_new = nomsg;
     p2_old = p2_new;
@@ -696,8 +611,6 @@ int main(void)
     p6_new = nomsg;
     p7_old = p7_new;
     p7_new = nomsg;
-    p8_old = p8_new;
-    p8_new = nomsg;
     c1 = check();
     assert(c1);
     }

--- a/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -125,7 +125,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 6;
+    }
+    r1 = r1 + 1;
     m1 = p7_old;
     p7_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.7_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -125,7 +125,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p7_old;
     p7_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -540,7 +540,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -132,7 +132,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p8_old;
     p8_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -619,7 +619,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -132,7 +132,10 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 7;
+    }
+    r1 = r1 + 1;
     m1 = p8_old;
     p8_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.8_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -61,6 +61,8 @@ DM-0000575
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
 unsigned char __VERIFIER_nondet_uchar(void) ;
+char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -132,10 +134,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 7;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p8_old;
     p8_old = nomsg;
     if ((int )m1 != (int )nomsg) {

--- a/c/seq-mthreaded/pals_lcr.8_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_lcr.8_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -60,7 +60,7 @@ DM-0000575
 
 _Bool __VERIFIER_nondet_bool(void) ;
 char __VERIFIER_nondet_char(void) ;
-char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
 typedef char msg_t;
@@ -68,7 +68,7 @@ typedef int port_t;
 extern void read(port_t p , msg_t m ) ;
 extern void write(port_t p , msg_t m ) ;
 msg_t nomsg  =    (msg_t )-1;
-char r1  ;
+unsigned char r1  ;
 port_t p1  ;
 char p1_old ;
 char p1_new ;
@@ -132,7 +132,7 @@ void node1(void)
   {
   m1 = nomsg;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     m1 = p8_old;
     p8_old = nomsg;
     if ((int )m1 != (int )nomsg) {
@@ -617,7 +617,7 @@ int main(void)
 
   {
   c1 = 0;
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   id1 = __VERIFIER_nondet_char();
   st1 = __VERIFIER_nondet_char();
   send1 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -123,7 +123,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -174,7 +177,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -225,7 +231,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,7 +93,7 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -100,7 +101,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -108,7 +109,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -122,7 +123,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -173,7 +174,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -224,7 +225,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -546,7 +547,7 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -554,7 +555,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -562,7 +563,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -123,7 +123,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -174,7 +177,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -225,7 +231,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,7 +93,7 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -100,7 +101,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -108,7 +109,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -122,7 +123,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -173,7 +174,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -224,7 +225,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -570,7 +571,7 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -578,7 +579,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -586,7 +587,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,7 +93,7 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -100,7 +101,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -108,7 +109,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -122,7 +123,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -173,7 +174,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -224,7 +225,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -570,7 +571,7 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -578,7 +579,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -586,7 +587,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -123,7 +123,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -174,7 +177,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -225,7 +231,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,7 +93,7 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -100,7 +101,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -108,7 +109,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -122,7 +123,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -173,7 +174,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -224,7 +225,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -570,7 +571,7 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -578,7 +579,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -586,7 +587,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -123,10 +123,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 2;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -146,9 +143,9 @@ void node1(void)
     newmax1 = newmax;
     if ((int )r1 == 2) {
       if ((int )max1 == (int )id1) {
-        nl1 = (char)1;
-      } else {
         st1 = (char)1;
+      } else {
+        nl1 = (char)1;
       }
     }
     mode1 = (_Bool)0;
@@ -177,10 +174,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    if (r2 == 255) {
-      r2 = 2;
-    }
-    r2 = r2 + 1;
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -231,10 +225,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    if (r3 == 255) {
-      r3 = 2;
-    }
-    r3 = r3 + 1;
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -123,7 +123,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 2;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -174,7 +177,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 2;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -225,7 +231,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 2;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.3_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -92,7 +93,7 @@ char p32_old ;
 char p32_new ;
 _Bool ep32  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -100,7 +101,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -108,7 +109,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -122,7 +123,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -173,7 +174,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -224,7 +225,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -570,7 +571,7 @@ int main(void)
   ep31 = __VERIFIER_nondet_bool();
   ep32 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -578,7 +579,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -586,7 +587,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,7 +117,7 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -124,7 +125,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -132,7 +133,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -140,7 +141,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -154,7 +155,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -218,7 +219,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -282,7 +283,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -346,7 +347,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1205,7 +1206,7 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -1213,7 +1214,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -1221,7 +1222,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -1229,7 +1230,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -155,7 +155,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -219,7 +222,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -283,7 +289,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -347,7 +356,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,7 +117,7 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -124,7 +125,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -132,7 +133,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -140,7 +141,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -154,7 +155,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -218,7 +219,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -282,7 +283,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -346,7 +347,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1253,7 +1254,7 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -1261,7 +1262,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -1269,7 +1270,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -1277,7 +1278,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -155,7 +155,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -219,7 +222,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -283,7 +289,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -347,7 +356,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,7 +117,7 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -124,7 +125,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -132,7 +133,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -140,7 +141,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -154,7 +155,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -218,7 +219,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -282,7 +283,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -346,7 +347,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1253,7 +1254,7 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -1261,7 +1262,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -1269,7 +1270,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -1277,7 +1278,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -155,7 +155,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -219,7 +222,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -283,7 +289,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -347,7 +356,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,7 +117,7 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -124,7 +125,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -132,7 +133,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -140,7 +141,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -154,7 +155,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -218,7 +219,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -282,7 +283,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -346,7 +347,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1253,7 +1254,7 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -1261,7 +1262,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -1269,7 +1270,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -1277,7 +1278,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -155,7 +155,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -219,7 +222,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -283,7 +289,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -347,7 +356,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -123,6 +123,7 @@ char nl1  ;
 char m1  ;
 char max1  ;
 _Bool mode1  ;
+_Bool newmax1  ;
 char id2  ;
 unsigned char r2  ;
 char st2  ;
@@ -130,6 +131,7 @@ char nl2  ;
 char m2  ;
 char max2  ;
 _Bool mode2  ;
+_Bool newmax2  ;
 char id3  ;
 unsigned char r3  ;
 char st3  ;
@@ -137,6 +139,7 @@ char nl3  ;
 char m3  ;
 char max3  ;
 _Bool mode3  ;
+_Bool newmax3  ;
 char id4  ;
 unsigned char r4  ;
 char st4  ;
@@ -144,21 +147,21 @@ char nl4  ;
 char m4  ;
 char max4  ;
 _Bool mode4  ;
+_Bool newmax4  ;
 void node1(void) 
 { 
-
+  _Bool newmax ;
 
   {
+  newmax = (_Bool)0;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 3;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
+        newmax = (_Bool)1;
       }
     }
     if (ep31) {
@@ -166,6 +169,7 @@ void node1(void)
       p31_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
+        newmax = (_Bool)1;
       }
     }
     if (ep41) {
@@ -173,8 +177,10 @@ void node1(void)
       p41_old = nomsg;
       if ((int )m1 > (int )max1) {
         max1 = m1;
+        newmax = (_Bool)1;
       }
     }
+    newmax1 = newmax;
     if ((int )r1 == 3) {
       if ((int )max1 == (int )id1) {
         st1 = (char)1;
@@ -186,13 +192,19 @@ void node1(void)
   } else {
     if ((int )r1 < 3) {
       if (ep12) {
-        p12_new = max1 != nomsg && p12_new == nomsg ? max1 : p12_new;
+        if (newmax1) {
+          p12_new = max1 != nomsg && p12_new == nomsg ? max1 : p12_new;
+        }
       }
       if (ep13) {
-        p13_new = max1 != nomsg && p13_new == nomsg ? max1 : p13_new;
+        if (newmax1) {
+          p13_new = max1 != nomsg && p13_new == nomsg ? max1 : p13_new;
+        }
       }
       if (ep14) {
-        p14_new = max1 != nomsg && p14_new == nomsg ? max1 : p14_new;
+        if (newmax1) {
+          p14_new = max1 != nomsg && p14_new == nomsg ? max1 : p14_new;
+        }
       }
     }
     mode1 = (_Bool)1;
@@ -202,19 +214,18 @@ void node1(void)
 }
 void node2(void) 
 { 
-
+  _Bool newmax ;
 
   {
+  newmax = (_Bool)0;
   if (mode2) {
-    if (r2 == 255) {
-      r2 = 3;
-    }
-    r2 = r2 + 1;
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
+        newmax = (_Bool)1;
       }
     }
     if (ep32) {
@@ -222,6 +233,7 @@ void node2(void)
       p32_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
+        newmax = (_Bool)1;
       }
     }
     if (ep42) {
@@ -229,8 +241,10 @@ void node2(void)
       p42_old = nomsg;
       if ((int )m2 > (int )max2) {
         max2 = m2;
+        newmax = (_Bool)1;
       }
     }
+    newmax2 = newmax;
     if ((int )r2 == 3) {
       if ((int )max2 == (int )id2) {
         st2 = (char)1;
@@ -242,13 +256,19 @@ void node2(void)
   } else {
     if ((int )r2 < 3) {
       if (ep21) {
-        p21_new = max2 != nomsg && p21_new == nomsg ? max2 : p21_new;
+        if (newmax2) {
+          p21_new = max2 != nomsg && p21_new == nomsg ? max2 : p21_new;
+        }
       }
       if (ep23) {
-        p23_new = max2 != nomsg && p23_new == nomsg ? max2 : p23_new;
+        if (newmax2) {
+          p23_new = max2 != nomsg && p23_new == nomsg ? max2 : p23_new;
+        }
       }
       if (ep24) {
-        p24_new = max2 != nomsg && p24_new == nomsg ? max2 : p24_new;
+        if (newmax2) {
+          p24_new = max2 != nomsg && p24_new == nomsg ? max2 : p24_new;
+        }
       }
     }
     mode2 = (_Bool)1;
@@ -258,19 +278,18 @@ void node2(void)
 }
 void node3(void) 
 { 
-
+  _Bool newmax ;
 
   {
+  newmax = (_Bool)0;
   if (mode3) {
-    if (r3 == 255) {
-      r3 = 3;
-    }
-    r3 = r3 + 1;
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
+        newmax = (_Bool)1;
       }
     }
     if (ep23) {
@@ -278,6 +297,7 @@ void node3(void)
       p23_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
+        newmax = (_Bool)1;
       }
     }
     if (ep43) {
@@ -285,8 +305,10 @@ void node3(void)
       p43_old = nomsg;
       if ((int )m3 > (int )max3) {
         max3 = m3;
+        newmax = (_Bool)1;
       }
     }
+    newmax3 = newmax;
     if ((int )r3 == 3) {
       if ((int )max3 == (int )id3) {
         st3 = (char)1;
@@ -298,13 +320,19 @@ void node3(void)
   } else {
     if ((int )r3 < 3) {
       if (ep31) {
-        p31_new = max3 != nomsg && p31_new == nomsg ? max3 : p31_new;
+        if (newmax3) {
+          p31_new = max3 != nomsg && p31_new == nomsg ? max3 : p31_new;
+        }
       }
       if (ep32) {
-        p32_new = max3 != nomsg && p32_new == nomsg ? max3 : p32_new;
+        if (newmax3) {
+          p32_new = max3 != nomsg && p32_new == nomsg ? max3 : p32_new;
+        }
       }
       if (ep34) {
-        p34_new = max3 != nomsg && p34_new == nomsg ? max3 : p34_new;
+        if (newmax3) {
+          p34_new = max3 != nomsg && p34_new == nomsg ? max3 : p34_new;
+        }
       }
     }
     mode3 = (_Bool)1;
@@ -314,19 +342,18 @@ void node3(void)
 }
 void node4(void) 
 { 
-
+  _Bool newmax ;
 
   {
+  newmax = (_Bool)0;
   if (mode4) {
-    if (r4 == 255) {
-      r4 = 3;
-    }
-    r4 = r4 + 1;
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
+        newmax = (_Bool)1;
       }
     }
     if (ep24) {
@@ -334,6 +361,7 @@ void node4(void)
       p24_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
+        newmax = (_Bool)1;
       }
     }
     if (ep34) {
@@ -341,8 +369,10 @@ void node4(void)
       p34_old = nomsg;
       if ((int )m4 > (int )max4) {
         max4 = m4;
+        newmax = (_Bool)1;
       }
     }
+    newmax4 = newmax;
     if ((int )r4 == 3) {
       if ((int )max4 == (int )id4) {
         st4 = (char)1;
@@ -354,13 +384,19 @@ void node4(void)
   } else {
     if ((int )r4 < 3) {
       if (ep41) {
-        p41_new = max4 != nomsg && p41_new == nomsg ? max4 : p41_new;
+        if (newmax4) {
+          p41_new = max4 != nomsg && p41_new == nomsg ? max4 : p41_new;
+        }
       }
       if (ep42) {
-        p42_new = max4 != nomsg && p42_new == nomsg ? max4 : p42_new;
+        if (newmax4) {
+          p42_new = max4 != nomsg && p42_new == nomsg ? max4 : p42_new;
+        }
       }
       if (ep43) {
-        p43_new = max4 != nomsg && p43_new == nomsg ? max4 : p43_new;
+        if (newmax4) {
+          p43_new = max4 != nomsg && p43_new == nomsg ? max4 : p43_new;
+        }
       }
     }
     mode4 = (_Bool)1;
@@ -964,23 +1000,87 @@ int init(void)
                         if ((int )r2 == 0) {
                           if ((int )r3 == 0) {
                             if ((int )r4 == 0) {
-                              if ((int )max1 == (int )id1) {
-                                if ((int )max2 == (int )id2) {
-                                  if ((int )max3 == (int )id3) {
-                                    if ((int )max4 == (int )id4) {
-                                      if ((int )st1 == 0) {
-                                        if ((int )st2 == 0) {
-                                          if ((int )st3 == 0) {
-                                            if ((int )st4 == 0) {
-                                              if ((int )nl1 == 0) {
-                                                if ((int )nl2 == 0) {
-                                                  if ((int )nl3 == 0) {
-                                                    if ((int )nl4 == 0) {
-                                                      if ((int )mode1 == 0) {
-                                                        if ((int )mode2 == 0) {
-                                                          if ((int )mode3 == 0) {
-                                                            if ((int )mode4 == 0) {
-                                                              tmp___23 = 1;
+                              if (r123) {
+                                if (r133) {
+                                  if (r143) {
+                                    if (r213) {
+                                      if (r233) {
+                                        if (r243) {
+                                          if (r313) {
+                                            if (r323) {
+                                              if (r343) {
+                                                if (r413) {
+                                                  if (r423) {
+                                                    if (r433) {
+                                                      if ((int )max1 == (int )id1) {
+                                                        if ((int )max2 == (int )id2) {
+                                                          if ((int )max3 == (int )id3) {
+                                                            if ((int )max4 == (int )id4) {
+                                                              if ((int )st1 == 0) {
+                                                                if ((int )st2 == 0) {
+                                                                  if ((int )st3 == 0) {
+                                                                    if ((int )st4 == 0) {
+                                                                      if ((int )nl1 == 0) {
+                                                                        if ((int )nl2 == 0) {
+                                                                          if ((int )nl3 == 0) {
+                                                                            if ((int )nl4 == 0) {
+                                                                              if ((int )mode1 == 0) {
+                                                                                if ((int )mode2 == 0) {
+                                                                                  if ((int )mode3 == 0) {
+                                                                                    if ((int )mode4 == 0) {
+                                                                                      if (newmax1) {
+                                                                                        if (newmax2) {
+                                                                                          if (newmax3) {
+                                                                                            if (newmax4) {
+                                                                                              tmp___23 = 1;
+                                                                                            } else {
+                                                                                              tmp___23 = 0;
+                                                                                            }
+                                                                                          } else {
+                                                                                            tmp___23 = 0;
+                                                                                          }
+                                                                                        } else {
+                                                                                          tmp___23 = 0;
+                                                                                        }
+                                                                                      } else {
+                                                                                        tmp___23 = 0;
+                                                                                      }
+                                                                                    } else {
+                                                                                      tmp___23 = 0;
+                                                                                    }
+                                                                                  } else {
+                                                                                    tmp___23 = 0;
+                                                                                  }
+                                                                                } else {
+                                                                                  tmp___23 = 0;
+                                                                                }
+                                                                              } else {
+                                                                                tmp___23 = 0;
+                                                                              }
+                                                                            } else {
+                                                                              tmp___23 = 0;
+                                                                            }
+                                                                          } else {
+                                                                            tmp___23 = 0;
+                                                                          }
+                                                                        } else {
+                                                                          tmp___23 = 0;
+                                                                        }
+                                                                      } else {
+                                                                        tmp___23 = 0;
+                                                                      }
+                                                                    } else {
+                                                                      tmp___23 = 0;
+                                                                    }
+                                                                  } else {
+                                                                    tmp___23 = 0;
+                                                                  }
+                                                                } else {
+                                                                  tmp___23 = 0;
+                                                                }
+                                                              } else {
+                                                                tmp___23 = 0;
+                                                              }
                                                             } else {
                                                               tmp___23 = 0;
                                                             }
@@ -1160,6 +1260,7 @@ int main(void)
   m1 = __VERIFIER_nondet_char();
   max1 = __VERIFIER_nondet_char();
   mode1 = __VERIFIER_nondet_bool();
+  newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
   r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
@@ -1167,6 +1268,7 @@ int main(void)
   m2 = __VERIFIER_nondet_char();
   max2 = __VERIFIER_nondet_char();
   mode2 = __VERIFIER_nondet_bool();
+  newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
   r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
@@ -1174,6 +1276,7 @@ int main(void)
   m3 = __VERIFIER_nondet_char();
   max3 = __VERIFIER_nondet_char();
   mode3 = __VERIFIER_nondet_bool();
+  newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
   r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
@@ -1181,6 +1284,7 @@ int main(void)
   m4 = __VERIFIER_nondet_char();
   max4 = __VERIFIER_nondet_char();
   mode4 = __VERIFIER_nondet_bool();
+  newmax4 = __VERIFIER_nondet_bool();
   i2 = init();
   __VERIFIER_assume(i2);
   p12_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -155,7 +155,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 3;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -219,7 +222,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 3;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -283,7 +289,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 3;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -347,7 +356,13 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    if (r4 == 255) {
+      r4 = 3;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.4_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -116,7 +117,7 @@ char p43_old ;
 char p43_new ;
 _Bool ep43  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -124,7 +125,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -132,7 +133,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -140,7 +141,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -154,7 +155,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -218,7 +219,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -282,7 +283,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -346,7 +347,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -1253,7 +1254,7 @@ int main(void)
   ep42 = __VERIFIER_nondet_bool();
   ep43 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -1261,7 +1262,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -1269,7 +1270,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -1277,7 +1278,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -195,7 +195,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -272,7 +275,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -349,7 +355,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -426,7 +435,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -503,7 +515,10 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.1.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,7 +149,7 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -156,7 +157,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -164,7 +165,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -172,7 +173,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -180,7 +181,7 @@ char max4  ;
 _Bool mode4  ;
 _Bool newmax4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -194,7 +195,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -271,7 +272,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -348,7 +349,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -425,7 +426,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -502,7 +503,7 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2755,7 +2756,7 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -2763,7 +2764,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -2771,7 +2772,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -2779,7 +2780,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
@@ -2787,7 +2788,7 @@ int main(void)
   mode4 = __VERIFIER_nondet_bool();
   newmax4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -195,7 +195,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -272,7 +275,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -349,7 +355,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -426,7 +435,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -503,7 +515,10 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.2.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,7 +149,7 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -156,7 +157,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -164,7 +165,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -172,7 +173,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -180,7 +181,7 @@ char max4  ;
 _Bool mode4  ;
 _Bool newmax4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -194,7 +195,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -271,7 +272,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -348,7 +349,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -425,7 +426,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -502,7 +503,7 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2835,7 +2836,7 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -2843,7 +2844,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -2851,7 +2852,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -2859,7 +2860,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
@@ -2867,7 +2868,7 @@ int main(void)
   mode4 = __VERIFIER_nondet_bool();
   newmax4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -195,7 +195,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -272,7 +275,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -349,7 +355,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -426,7 +435,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -503,7 +515,10 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.3.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,7 +149,7 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -156,7 +157,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -164,7 +165,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -172,7 +173,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -180,7 +181,7 @@ char max4  ;
 _Bool mode4  ;
 _Bool newmax4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -194,7 +195,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -271,7 +272,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -348,7 +349,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -425,7 +426,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -502,7 +503,7 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2835,7 +2836,7 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -2843,7 +2844,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -2851,7 +2852,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -2859,7 +2860,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
@@ -2867,7 +2868,7 @@ int main(void)
   mode4 = __VERIFIER_nondet_bool();
   newmax4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -195,7 +195,10 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (unsigned char )((int )r1 + 1);
+    if (r1 == 255) {
+      r1 = 4;
+    }
+    r1 = r1 + 1;
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -272,7 +275,10 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (unsigned char )((int )r2 + 1);
+    if (r2 == 255) {
+      r2 = 4;
+    }
+    r2 = r2 + 1;
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -349,7 +355,10 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (unsigned char )((int )r3 + 1);
+    if (r3 == 255) {
+      r3 = 4;
+    }
+    r3 = r3 + 1;
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -426,7 +435,10 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (unsigned char )((int )r4 + 1);
+    if (r4 == 255) {
+      r4 = 4;
+    }
+    r4 = r4 + 1;
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -503,7 +515,10 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (unsigned char )((int )r5 + 1);
+    if (r5 == 255) {
+      r5 = 4;
+    }
+    r5 = r5 + 1;
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_false-unreach-call.4.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,7 +149,7 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -156,7 +157,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -164,7 +165,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -172,7 +173,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -180,7 +181,7 @@ char max4  ;
 _Bool mode4  ;
 _Bool newmax4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -194,7 +195,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -271,7 +272,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -348,7 +349,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -425,7 +426,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -502,7 +503,7 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2835,7 +2836,7 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -2843,7 +2844,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -2851,7 +2852,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -2859,7 +2860,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
@@ -2867,7 +2868,7 @@ int main(void)
   mode4 = __VERIFIER_nondet_bool();
   newmax4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();

--- a/c/seq-mthreaded/pals_opt-floodmax.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_overflow_false-unreach-call.ufo.UNBOUNDED.pals.c
@@ -195,10 +195,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    if (r1 == 255) {
-      r1 = 4;
-    }
-    r1 = r1 + 1;
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -275,10 +272,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    if (r2 == 255) {
-      r2 = 4;
-    }
-    r2 = r2 + 1;
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -355,10 +349,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    if (r3 == 255) {
-      r3 = 4;
-    }
-    r3 = r3 + 1;
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -435,10 +426,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    if (r4 == 255) {
-      r4 = 4;
-    }
-    r4 = r4 + 1;
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -515,10 +503,7 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    if (r5 == 255) {
-      r5 = 4;
-    }
-    r5 = r5 + 1;
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;

--- a/c/seq-mthreaded/pals_opt-floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
+++ b/c/seq-mthreaded/pals_opt-floodmax.5_true-unreach-call.ufo.UNBOUNDED.pals.c
@@ -59,6 +59,7 @@ DM-0000575
 /* print_CIL_Input is true */
 
 char __VERIFIER_nondet_char(void) ;
+unsigned char __VERIFIER_nondet_uchar(void) ;
 _Bool __VERIFIER_nondet_bool(void) ;
 void assert(_Bool arg ) ;
 void __VERIFIER_assume(int arg ) ;
@@ -148,7 +149,7 @@ char p54_old ;
 char p54_new ;
 _Bool ep54  ;
 char id1  ;
-char r1  ;
+unsigned char r1  ;
 char st1  ;
 char nl1  ;
 char m1  ;
@@ -156,7 +157,7 @@ char max1  ;
 _Bool mode1  ;
 _Bool newmax1  ;
 char id2  ;
-char r2  ;
+unsigned char r2  ;
 char st2  ;
 char nl2  ;
 char m2  ;
@@ -164,7 +165,7 @@ char max2  ;
 _Bool mode2  ;
 _Bool newmax2  ;
 char id3  ;
-char r3  ;
+unsigned char r3  ;
 char st3  ;
 char nl3  ;
 char m3  ;
@@ -172,7 +173,7 @@ char max3  ;
 _Bool mode3  ;
 _Bool newmax3  ;
 char id4  ;
-char r4  ;
+unsigned char r4  ;
 char st4  ;
 char nl4  ;
 char m4  ;
@@ -180,7 +181,7 @@ char max4  ;
 _Bool mode4  ;
 _Bool newmax4  ;
 char id5  ;
-char r5  ;
+unsigned char r5  ;
 char st5  ;
 char nl5  ;
 char m5  ;
@@ -194,7 +195,7 @@ void node1(void)
   {
   newmax = (_Bool)0;
   if (mode1) {
-    r1 = (char )((int )r1 + 1);
+    r1 = (unsigned char )((int )r1 + 1);
     if (ep21) {
       m1 = p21_old;
       p21_old = nomsg;
@@ -271,7 +272,7 @@ void node2(void)
   {
   newmax = (_Bool)0;
   if (mode2) {
-    r2 = (char )((int )r2 + 1);
+    r2 = (unsigned char )((int )r2 + 1);
     if (ep12) {
       m2 = p12_old;
       p12_old = nomsg;
@@ -348,7 +349,7 @@ void node3(void)
   {
   newmax = (_Bool)0;
   if (mode3) {
-    r3 = (char )((int )r3 + 1);
+    r3 = (unsigned char )((int )r3 + 1);
     if (ep13) {
       m3 = p13_old;
       p13_old = nomsg;
@@ -425,7 +426,7 @@ void node4(void)
   {
   newmax = (_Bool)0;
   if (mode4) {
-    r4 = (char )((int )r4 + 1);
+    r4 = (unsigned char )((int )r4 + 1);
     if (ep14) {
       m4 = p14_old;
       p14_old = nomsg;
@@ -502,7 +503,7 @@ void node5(void)
   {
   newmax = (_Bool)0;
   if (mode5) {
-    r5 = (char )((int )r5 + 1);
+    r5 = (unsigned char )((int )r5 + 1);
     if (ep15) {
       m5 = p15_old;
       p15_old = nomsg;
@@ -2835,7 +2836,7 @@ int main(void)
   ep53 = __VERIFIER_nondet_bool();
   ep54 = __VERIFIER_nondet_bool();
   id1 = __VERIFIER_nondet_char();
-  r1 = __VERIFIER_nondet_char();
+  r1 = __VERIFIER_nondet_uchar();
   st1 = __VERIFIER_nondet_char();
   nl1 = __VERIFIER_nondet_char();
   m1 = __VERIFIER_nondet_char();
@@ -2843,7 +2844,7 @@ int main(void)
   mode1 = __VERIFIER_nondet_bool();
   newmax1 = __VERIFIER_nondet_bool();
   id2 = __VERIFIER_nondet_char();
-  r2 = __VERIFIER_nondet_char();
+  r2 = __VERIFIER_nondet_uchar();
   st2 = __VERIFIER_nondet_char();
   nl2 = __VERIFIER_nondet_char();
   m2 = __VERIFIER_nondet_char();
@@ -2851,7 +2852,7 @@ int main(void)
   mode2 = __VERIFIER_nondet_bool();
   newmax2 = __VERIFIER_nondet_bool();
   id3 = __VERIFIER_nondet_char();
-  r3 = __VERIFIER_nondet_char();
+  r3 = __VERIFIER_nondet_uchar();
   st3 = __VERIFIER_nondet_char();
   nl3 = __VERIFIER_nondet_char();
   m3 = __VERIFIER_nondet_char();
@@ -2859,7 +2860,7 @@ int main(void)
   mode3 = __VERIFIER_nondet_bool();
   newmax3 = __VERIFIER_nondet_bool();
   id4 = __VERIFIER_nondet_char();
-  r4 = __VERIFIER_nondet_char();
+  r4 = __VERIFIER_nondet_uchar();
   st4 = __VERIFIER_nondet_char();
   nl4 = __VERIFIER_nondet_char();
   m4 = __VERIFIER_nondet_char();
@@ -2867,7 +2868,7 @@ int main(void)
   mode4 = __VERIFIER_nondet_bool();
   newmax4 = __VERIFIER_nondet_bool();
   id5 = __VERIFIER_nondet_char();
-  r5 = __VERIFIER_nondet_char();
+  r5 = __VERIFIER_nondet_uchar();
   st5 = __VERIFIER_nondet_char();
   nl5 = __VERIFIER_nondet_char();
   m5 = __VERIFIER_nondet_char();


### PR DESCRIPTION
Fix an issue with overflows in several tasks in seq-mthreaded.
This should cover #231 and #166.

What I did:
1) Fixed undefined behavior caused by (potential) signed-integer overflow
2) Preserved the bug caused by the (now defined, unsigned-integer) overflow in tasks with changed labels
3) Fixed the *unintended* overflow in *all* original ``true-unreach-call`` _and_ ``false-unreach-call``, so that the original ``true-unreach-call`` are now (hopefully) really bug free and the original ``false-unreach-call`` now (hopefully) contain unambiguously the intended bug.