### PR TITLE
Threads should return a value of type void*

### DIFF
--- a/c/pthread-lit/fk2012_true-unreach-call.c
+++ b/c/pthread-lit/fk2012_true-unreach-call.c
@@ -45,7 +45,7 @@ void* producer(void *arg) {
 	counter++;
 	release1();
 	release2();
-	return 1;
+	return NULL;
     } else {
 	release1();
 	counter = 0;
@@ -55,7 +55,7 @@ void* producer(void *arg) {
 	}
 	batch = counter;
 	release2();
-	return batch;
+	return NULL;
     }
 }
 
@@ -68,6 +68,7 @@ void* consumer(void *arg) {
     counter--;
     __VERIFIER_assert(counter >= 0);
     release1();
+    return NULL;
 }
 
 int main () {

--- a/c/pthread-lit/fk2012_true-unreach-call.i
+++ b/c/pthread-lit/fk2012_true-unreach-call.i
@@ -1056,7 +1056,7 @@ void* producer(void *arg) {
  counter++;
  release1();
  release2();
- return 1;
+ return ((void *)0);
     } else {
  release1();
  counter = 0;
@@ -1066,7 +1066,7 @@ void* producer(void *arg) {
  }
  batch = counter;
  release2();
- return batch;
+ return ((void *)0);
     }
 }
 void* consumer(void *arg) {
@@ -1078,6 +1078,7 @@ void* consumer(void *arg) {
     counter--;
     __VERIFIER_assert(counter >= 0);
     release1();
+    return ((void *)0);
 }
 int main () {
     pthread_t t;


### PR DESCRIPTION
The values are never used thus using NULL seems good enough. Fixes #77.