### PR TITLE
Added assertion from corresponding false-unreach-call task

### DIFF
--- a/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.c
+++ b/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.c
@@ -170,6 +170,7 @@ static int parse_expression_list(char *str)
         }
         /* OK */
         r_strncpy(str2, str+start, j-start+1);
+        __VERIFIER_assert(j - start + 1 < EXPRESSION_LENGTH);
         str2[j-start+1] = EOS;
       } else {
         /* parsing error */

--- a/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.i
+++ b/c/loops/veris.c_OpenSER__cases1_stripFullBoth_arr_true-unreach-call_true-termination.i
@@ -63,6 +63,7 @@ static int parse_expression_list(char *str)
           return -1;
         }
         r_strncpy(str2, str+start, j-start+1);
+        __VERIFIER_assert(j - start + 1 < 2);
         str2[j-start+1] = 0;
       } else {
         return -1;


### PR DESCRIPTION
This variant includes a patch over the failing one
(verisec_OpenSER__cases1_stripFullBoth_arr_false-unreach-call_true-termination.c).
The property to check thus holds, but should still be checked.

Fixes #79.