### PR TITLE
Specification of memory model is now redundant

### DIFF
--- a/c/ArraysMemSafety.cfg
+++ b/c/ArraysMemSafety.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for checking memory safety of array-based programs.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/ArraysReach.cfg
+++ b/c/ArraysReach.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for which treatment of arrays is necessary in order to determine reachability.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/BitVectorsOverflows.cfg
+++ b/c/BitVectorsOverflows.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for checking if variables of type signed integers overflow (undefined behavior).
-Memory Model: Precise
 Architecture: 64 bit
 

--- a/c/BitVectorsReach.cfg
+++ b/c/BitVectorsReach.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for which treatment of bit-operations is necessary.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/BusyBox.cfg
+++ b/c/BusyBox.cfg
@@ -1,5 +1,4 @@
 Description: Contains problems from the software system BusyBox.
-Memory Model: Precise
 Architecture: 64 bit
 
 

--- a/c/Concurrency.cfg
+++ b/c/Concurrency.cfg
@@ -1,4 +1,3 @@
 Description: Contains concurrency problems.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/ControlFlow.cfg
+++ b/c/ControlFlow.cfg
@@ -1,4 +1,3 @@
 Description: Contains programs for which the correctness depends mostly on the control-flow structure and integer variables. There is no particular focus on pointers, data structures, and concurrency.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/DeviceDriversLinux64.cfg
+++ b/c/DeviceDriversLinux64.cfg
@@ -1,5 +1,4 @@
 Description: Contains problems that require the analysis of pointer aliases and function pointers.
-Memory Model: Precise
 Architecture: 64 bit
 
 

--- a/c/ECA.cfg
+++ b/c/ECA.cfg
@@ -1,4 +1,3 @@
 Description: Contains programs that represent event-condition-action systems.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/Floats.cfg
+++ b/c/Floats.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for checking programs with floating-point arithmetics.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/HeapMemSafety.cfg
+++ b/c/HeapMemSafety.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for checking memory safety of programs.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/HeapReach.cfg
+++ b/c/HeapReach.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks that require the analysis of data structures on the heap, pointer aliases, and function pointers.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/Loops.cfg
+++ b/c/Loops.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for which loop analysis is necessary.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/ProductLines.cfg
+++ b/c/ProductLines.cfg
@@ -1,4 +1,3 @@
 Description: Contains programs that represents 'products' and 'product simulators' that are derived using different configurations of product lines.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/Recursive.cfg
+++ b/c/Recursive.cfg
@@ -1,4 +1,3 @@
 Description: Contains verification tasks for which recursive analysis is necessary.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/Sequentialized.cfg
+++ b/c/Sequentialized.cfg
@@ -1,4 +1,3 @@
 Description: Contains sequentialized concurrent programs that were derived from SystemC programs. The programs were transformed to pure C programs by incorporating the scheduler into the C code.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/Simple.cfg
+++ b/c/Simple.cfg
@@ -1,4 +1,3 @@
 Description: Contains programs for which the correctness depends mostly on control-flow structure and integer variables. There is no particular focus on pointers, data structures, and concurrency.
-Memory Model: Precise
 Architecture: 32 bit
 

--- a/c/Termination.cfg
+++ b/c/Termination.cfg
@@ -1,4 +1,3 @@
 Description: Contains programs for which termination should be decided.
-Memory Model: Precise
 Architecture: 64 bit
 

--- a/c/check.py
+++ b/c/check.py
@@ -19,7 +19,7 @@ BENCHMARK_PATTERN = re.compile('^.*\.[ci]$')
 EXPECTED_FILE_PATTERN = re.compile(
     '^(.*\.(c|h|i|verdict)|(readme|license([-.].*)?|.*\.error_trace)(\.(txt|md))?|Makefile)$',
     re.I)
-CONFIG_KEYS = set(["Architecture", "Description", "Memory Model"])
+CONFIG_KEYS = set(["Architecture", "Description"])
 
 UNUSED_DIRECTORIES = set(["ldv-challenges", "ldv-multiproperty", "regression"])
 
@@ -481,9 +481,7 @@ class SetFileChecks(Checks):
         if not cfg.get("Description", "dummy"):
             self.error("missing description")
         if cfg.get("Architecture", "32 bit") not in ["32 bit", "64 bit"]:
-            self.error("invalid memory model <%s>", cfg.get("Memory Model"))
-        if cfg.get("Memory Model", "Precise") not in ["Precise", "Simple"]:
-            self.error("invalid memory model <%s>", cfg.get("Memory Model"))
+            self.error("invalid architecture <%s>", cfg.get("Architecture"))
 
 
 def read_set_file(path):


### PR DESCRIPTION
With just a single ("Precise") memory model, there is no need to specify
this in configuration files.