### PR TITLE
Create a 32-bit category of Termination benchmarks

### DIFF
--- a/c/Termination-Concurrency.cfg
+++ b/c/Termination-Concurrency.cfg
@@ -1,0 +1,3 @@
+Description: Contains programs for which termination should be decided from the Concurrency benchmark set.
+Architecture: 32 bit
+

--- a/c/Termination-Concurrency.prp
+++ b/c/Termination-Concurrency.prp
@@ -1,0 +1,1 @@
+Termination.prp

--- a/c/Termination-Concurrency.set
+++ b/c/Termination-Concurrency.set
@@ -1,0 +1,1 @@
+pthread-atomic/*_true-termination*.i

--- a/c/Termination-ControlFlow.cfg
+++ b/c/Termination-ControlFlow.cfg
@@ -1,0 +1,3 @@
+Description: Contains programs for which termination should be decided from the ControlFlow benchmark set.
+Architecture: 32 bit
+

--- a/c/Termination-ControlFlow.prp
+++ b/c/Termination-ControlFlow.prp
@@ -1,0 +1,1 @@
+Termination.prp

--- a/c/Termination-ControlFlow.set
+++ b/c/Termination-ControlFlow.set
@@ -1,0 +1,6 @@
+ntdrivers-simplified/*_true-termination*.cil.c
+ssh-simplified/*_false-termination*.cil.c
+ssh-simplified/*_true-termination*.cil.c
+locks/*_false-termination*.c
+
+ssh-simplified/s3_clnt_3.cil_true-unreach-call_true-termination.c

--- a/c/Termination-Loops.cfg
+++ b/c/Termination-Loops.cfg
@@ -1,0 +1,3 @@
+Description: Contains programs for which termination should be decided from the Loops benchmark set.
+Architecture: 32 bit
+

--- a/c/Termination-Loops.prp
+++ b/c/Termination-Loops.prp
@@ -1,0 +1,1 @@
+Termination.prp

--- a/c/Termination-Loops.set
+++ b/c/Termination-Loops.set
@@ -1,0 +1,9 @@
+loops/*_false-termination*.i
+loops/*_true-termination*.i
+loop-acceleration/*_true-termination*.i
+loop-invgen/*_false-termination*.i
+loop-invgen/*_true-termination*.i
+loop-lit/*_true-termination*.i
+loop-lit/*_false-termination*.i
+loop-new/*_true-termination*.i
+

--- a/c/Termination-ProductLines.cfg
+++ b/c/Termination-ProductLines.cfg
@@ -1,0 +1,3 @@
+Description: Contains programs for which termination should be decided from the ProductLines benchmark set.
+Architecture: 32 bit
+

--- a/c/Termination-ProductLines.prp
+++ b/c/Termination-ProductLines.prp
@@ -1,0 +1,1 @@
+Termination.prp

--- a/c/Termination-ProductLines.set
+++ b/c/Termination-ProductLines.set
@@ -1,0 +1,2 @@
+product-lines/*_true-termination*.c
+product-lines/*_false-termination*.c

--- a/c/Termination-Recursive.cfg
+++ b/c/Termination-Recursive.cfg
@@ -1,0 +1,3 @@
+Description: Contains programs for which termination should be decided from the Recursive benchmark set.
+Architecture: 32 bit
+

--- a/c/Termination-Recursive.prp
+++ b/c/Termination-Recursive.prp
@@ -1,0 +1,1 @@
+Termination.prp

--- a/c/Termination-Recursive.set
+++ b/c/Termination-Recursive.set
@@ -1,0 +1,2 @@
+recursive/*_false-termination*.c
+recursive/*_true-termination*.c

--- a/c/Termination-Sequentialized.cfg
+++ b/c/Termination-Sequentialized.cfg
@@ -1,0 +1,3 @@
+Description: Contains programs for which termination should be decided from the Sequentialized benchmark set.
+Architecture: 32 bit
+

--- a/c/Termination-Sequentialized.prp
+++ b/c/Termination-Sequentialized.prp
@@ -1,0 +1,1 @@
+Termination.prp

--- a/c/Termination-Sequentialized.set
+++ b/c/Termination-Sequentialized.set
@@ -1,0 +1,1 @@
+systemc/*_false-termination*.cil.c

--- a/c/Termination.set
+++ b/c/Termination.set
@@ -11,5 +11,3 @@ termination-restricted-15/*_false-termination*.c
 termination-15/*_true-termination*.c.i
 termination-15/*_false-termination*.c.i
 termination-recursive-malloc/*_true-termination*.c.i
-product-lines/*_true-termination*.c
-product-lines/*_false-termination*.c

--- a/c/check.py
+++ b/c/check.py
@@ -117,7 +117,6 @@ KNOWN_DIRECTORY_PROBLEMS = [
     ("array-examples", "standard_strcpy_false-valid-deref_ground.c is not contained in any category"),
     ("array-examples", "standard_strcpy_original_false-valid-deref.c is not contained in any category"),
     ("recursive", "Addition03_false-no-overflow.c is not contained in any category"),
-    ("ssh-simplified", "s3_clnt_3.cil_true-unreach-call_true-termination.c is not contained in any category"),
     ("termination-memory-alloca", "cll_by_lseg-alloca_false-termination.c is not contained in any category"),
     ("termination-memory-alloca", "cll_by_lseg-alloca_true-termination.c is not contained in any category"),
     ("termination-memory-alloca", "cll_by_lseg_traverse-alloca_false-termination.c is not contained in any category"),


### PR DESCRIPTION
The product-line files had been processed using Cil to use
pointer-arithmetic to access struct members. This may cause different
behaviour when moving th 64-bit architectures.