### PR TITLE
Removing extraneous declaration of malloc

### DIFF
--- a/c/memsafety/20051113-1.c_false-valid-memtrack.c
+++ b/c/memsafety/20051113-1.c_false-valid-memtrack.c
@@ -2,7 +2,6 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 #include <stdlib.h>
 
-extern void *malloc(__SIZE_TYPE__);
 extern void *memset(void *, int, __SIZE_TYPE__);
 typedef struct
 {

--- a/c/memsafety/20051113-1.c_false-valid-memtrack.i
+++ b/c/memsafety/20051113-1.c_false-valid-memtrack.i
@@ -616,7 +616,6 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-extern void *malloc(long unsigned int);
 extern void *memset(void *, int, long unsigned int);
 typedef struct
 {


### PR DESCRIPTION
The removed malloc declaration is redundant and also not correct for a 32 bit benchmark. Although this benchmark requires re-preprocessing because it was done in a 64 bit set up, it does not hurt to remove the declaration for now.