### PR TITLE
Fixed size_t of several mem safety benchmarks to match 32-bit arch

### DIFF
--- a/c/ldv-memsafety/memset2_false-valid-deref-write.c
+++ b/c/ldv-memsafety/memset2_false-valid-deref-write.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memset2_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memset2_true-valid-memsafety.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memset3_false-valid-deref-write.c
+++ b/c/ldv-memsafety/memset3_false-valid-deref-write.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memset3_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memset3_true-valid-memsafety.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memsetNonZero2_false-valid-deref-write.c
+++ b/c/ldv-memsafety/memsetNonZero2_false-valid-deref-write.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memsetNonZero2_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memsetNonZero2_true-valid-memsafety.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memsetNonZero3_false-valid-deref-write.c
+++ b/c/ldv-memsafety/memsetNonZero3_false-valid-deref-write.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memsetNonZero3_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memsetNonZero3_true-valid-memsafety.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memsetNonZero_false-valid-deref-write.c
+++ b/c/ldv-memsafety/memsetNonZero_false-valid-deref-write.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memsetNonZero_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memsetNonZero_true-valid-memsafety.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memset_false-valid-deref-write.c
+++ b/c/ldv-memsafety/memset_false-valid-deref-write.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;

--- a/c/ldv-memsafety/memset_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memset_true-valid-memsafety.c
@@ -1,4 +1,4 @@
-typedef unsigned long __kernel_size_t;
+typedef unsigned int __kernel_size_t;
 typedef __kernel_size_t size_t;
 
 extern void *memset(void * , int , size_t ) ;


### PR DESCRIPTION
Luckily these benchmarks do not have the respective preprocessed files,
and so this was an easy fix.