### PR TITLE
Remove calls to __VERIFIER_nondet_pointer() from ldv-regression/test*.c

### DIFF
--- a/c/ldv-regression/test11_true-unreach-call.c
+++ b/c/ldv-regression/test11_true-unreach-call.c
@@ -1,15 +1,20 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);
-extern void* __VERIFIER_nondet_pointer(void);
+extern _Bool __VERIFIER_nondet_bool();
 
+int a, b;
+
+int *get_dummy()
+{
+  return (__VERIFIER_nondet_bool() ? &a : &b);
+}
 
 int main() {
-        int a, b; int c = __VERIFIER_nondet_int();
+        int c = __VERIFIER_nondet_int();
         int *pa, *pb; int *pc = &c;
         a = __VERIFIER_nondet_int();
         b = __VERIFIER_nondet_int();
-        pa = (int*) __VERIFIER_nondet_pointer();
-        pb = (int*) __VERIFIER_nondet_pointer();
+        pa = pb = get_dummy();
         if (pc == 0 ||
             pa == pb && *pa != *pb) {
                 goto ERROR;

--- a/c/ldv-regression/test14_true-unreach-call.c
+++ b/c/ldv-regression/test14_true-unreach-call.c
@@ -1,12 +1,20 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-extern void* __VERIFIER_nondet_pointer(void);
+extern int __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool();
 
+int a, b;
+
+int *get_dummy()
+{
+  return (__VERIFIER_nondet_bool() ? &a : &b);
+}
 
 int main() {
         int a, b; int c = 5; // The value of c is not important and may be arbitrary for this example
-        int *pa = (int*) __VERIFIER_nondet_pointer();
-        int *pb = (int*) __VERIFIER_nondet_pointer();
-        int *pc = &c;
+        a = __VERIFIER_nondet_int();
+        b = __VERIFIER_nondet_int();
+        int *pa, *pb; int *pc = &c;
+        pa = pb = get_dummy();
         if (pc == 0 ||
             pa == pb && *pa != *pb) {
                 goto ERROR;

--- a/c/ldv-regression/test21_false-unreach-call.c
+++ b/c/ldv-regression/test21_false-unreach-call.c
@@ -1,15 +1,25 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
+extern int __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
 
 struct dummy {
   int a, b;
 };
 
+struct dummy d1, d2;
+
+void init()
+{
+  d1.a = __VERIFIER_nondet_int();
+  d1.b = __VERIFIER_nondet_int();
+
+  d2.a = __VERIFIER_nondet_int();
+  d2.b = __VERIFIER_nondet_int();
+}
+
 struct dummy *get_dummy()
 {
-  return (struct dummy *) __VERIFIER_nondet_pointer();
+  return (__VERIFIER_nondet_bool() ? &d1 : &d2);
 }
 
 int check(struct dummy *s1, struct dummy *s2)
@@ -19,6 +29,7 @@ int check(struct dummy *s1, struct dummy *s2)
 
 int main()
 {
+  init();
   struct dummy *pd1 = get_dummy(), *pd2 = get_dummy();
   if (pd1 != 0 && pd1 == pd2) {
     if (!check(pd1, pd2)) {

--- a/c/ldv-regression/test21_true-unreach-call.c
+++ b/c/ldv-regression/test21_true-unreach-call.c
@@ -1,15 +1,25 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
+extern int __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
 
 struct dummy {
   int a, b;
 };
 
+struct dummy d1, d2;
+
+void init()
+{
+  d1.a = __VERIFIER_nondet_int();
+  d1.b = __VERIFIER_nondet_int();
+
+  d2.a = __VERIFIER_nondet_int();
+  d2.b = __VERIFIER_nondet_int();
+}
+
 struct dummy *get_dummy()
 {
-  return (struct dummy *) __VERIFIER_nondet_pointer();
+  return (__VERIFIER_nondet_bool() ? &d1 : &d2);
 }
 
 int check(struct dummy *s1, struct dummy *s2)
@@ -19,6 +29,7 @@ int check(struct dummy *s1, struct dummy *s2)
 
 int main()
 {
+  init();
   struct dummy *pd1 = get_dummy(), *pd2 = get_dummy();
   if (pd1 != 0 && pd1 == pd2) {
     if (!check(pd1, pd2)) {

--- a/c/ldv-regression/test22_false-unreach-call.c
+++ b/c/ldv-regression/test22_false-unreach-call.c
@@ -1,15 +1,25 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
+extern int __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
 
 struct dummy {
   int a, b;
 };
 
+struct dummy d1, d2;
+
+void init()
+{
+  d1.a = __VERIFIER_nondet_int();
+  d1.b = __VERIFIER_nondet_int();
+
+  d2.a = __VERIFIER_nondet_int();
+  d2.b = __VERIFIER_nondet_int();
+}
+
 struct dummy *get_dummy()
 {
-  return (struct dummy *) __VERIFIER_nondet_pointer();
+  return (__VERIFIER_nondet_bool() ? &d1 : &d2);
 }
 
 int check(struct dummy *s1, int i)
@@ -19,10 +29,11 @@ int check(struct dummy *s1, int i)
 
 int main()
 {
+  init();
   struct dummy *pd1 = get_dummy(), *pd2 = get_dummy(), *pd3 = get_dummy();
-  int i, *pa;
+  int i = __VERIFIER_nondet_int();
   if (pd1 != 0 && pd1 == pd2) {
-    pa = &pd1->a;
+    int *pa = &pd1->a;
     i = pd3->a - 10;
     while (i < *pa) {
       ++i;

--- a/c/ldv-regression/test22_true-unreach-call.c
+++ b/c/ldv-regression/test22_true-unreach-call.c
@@ -1,15 +1,25 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
+extern int __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
 
 struct dummy {
   int a, b;
 };
 
+struct dummy d1, d2;
+
+void init()
+{
+  d1.a = __VERIFIER_nondet_int();
+  d1.b = __VERIFIER_nondet_int();
+
+  d2.a = __VERIFIER_nondet_int();
+  d2.b = __VERIFIER_nondet_int();
+}
+
 struct dummy *get_dummy()
 {
-  return (struct dummy *) __VERIFIER_nondet_pointer();
+  return (__VERIFIER_nondet_bool() ? &d1 : &d2);
 }
 
 int check(struct dummy *s1, int i)
@@ -19,10 +29,11 @@ int check(struct dummy *s1, int i)
 
 int main()
 {
-  struct dummy *pd1 = get_dummy(), *pd2 = get_dummy();
-  int i, *pa;
+  init();
+  struct dummy *pd1 = get_dummy(), *pd2 = get_dummy(), *pd3 = get_dummy();
+  int i = __VERIFIER_nondet_int();
   if (pd1 != 0 && pd1 == pd2 && (*pd2).a > 0) {
-    pa = &pd1->a;
+    int *pa = &pd1->a;
     i = pd2->a - 10;
     while (i < *pa) {
       ++i;

--- a/c/ldv-regression/test23_false-unreach-call.c
+++ b/c/ldv-regression/test23_false-unreach-call.c
@@ -1,16 +1,26 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
+extern int __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
 
 struct dummy {
   int a, b;
   int array[16];
 };
 
+struct dummy d1, d2;
+
+void init()
+{
+  d1.a = __VERIFIER_nondet_int();
+  d1.b = __VERIFIER_nondet_int();
+
+  d2.a = __VERIFIER_nondet_int();
+  d2.b = __VERIFIER_nondet_int();
+}
+
 struct dummy *get_dummy()
 {
-  return (struct dummy *) __VERIFIER_nondet_pointer();
+  return (__VERIFIER_nondet_bool() ? &d1 : &d2);
 }
 
 int check(struct dummy *s1, int i)
@@ -20,11 +30,12 @@ int check(struct dummy *s1, int i)
 
 int main()
 {
+  init();
   struct dummy *pd1 = get_dummy(), *pd2 = get_dummy();
-  int i, *pa;
+  int i = __VERIFIER_nondet_int();
   if (pd1 != 0 && pd1 == pd2 && i >= 0 && i < 10) {
     pd2->array[i] = i;
-    pa = &pd1->array[i];
+    int *pa = &pd1->array[i];
     i = pd2->array[i] - 10;
     while (i <= *pa) {
       ++i;

--- a/c/ldv-regression/test23_true-unreach-call.c
+++ b/c/ldv-regression/test23_true-unreach-call.c
@@ -1,17 +1,26 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
 extern int __VERIFIER_nondet_int();
+extern _Bool __VERIFIER_nondet_bool(void);
 
 struct dummy {
   int a, b;
   int array[16];
 };
 
+struct dummy d1, d2;
+
+void init()
+{
+  d1.a = __VERIFIER_nondet_int();
+  d1.b = __VERIFIER_nondet_int();
+
+  d2.a = __VERIFIER_nondet_int();
+  d2.b = __VERIFIER_nondet_int();
+}
+
 struct dummy *get_dummy()
 {
-  return (struct dummy *) __VERIFIER_nondet_pointer();
+  return (__VERIFIER_nondet_bool() ? &d1 : &d2);
 }
 
 int check(struct dummy *s1, int i)
@@ -21,12 +30,12 @@ int check(struct dummy *s1, int i)
 
 int main()
 {
+  init();
   struct dummy *pd1 = get_dummy(), *pd2 = get_dummy();
-  int i, *pa;
-  i = __VERIFIER_nondet_int();
+  int i = __VERIFIER_nondet_int();
   if (pd1 != 0 && pd1 == pd2 && i >= 0 && i < 10) {
     pd2->array[i] = i;
-    pa = &pd1->array[i];
+    int *pa = &pd1->array[i];
     i = pd2->array[i] - 10;
     while (i < *pa) {
       ++i;

--- a/c/ldv-regression/test24_false-unreach-call.c
+++ b/c/ldv-regression/test24_false-unreach-call.c
@@ -1,7 +1,4 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
 extern int __VERIFIER_nondet_int();
 
 struct dummy {

--- a/c/ldv-regression/test24_true-unreach-call.c
+++ b/c/ldv-regression/test24_true-unreach-call.c
@@ -1,6 +1,4 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
 extern int __VERIFIER_nondet_int();
 
 struct dummy {

--- a/c/ldv-regression/test25_false-unreach-call.c
+++ b/c/ldv-regression/test25_false-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 struct dummy {
   int a, b;
 };

--- a/c/ldv-regression/test26_false-unreach-call.c
+++ b/c/ldv-regression/test26_false-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 struct dummy {
   int a, b;
 } global = {0, 1};

--- a/c/ldv-regression/test26_true-unreach-call.c
+++ b/c/ldv-regression/test26_true-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 struct dummy {
   int a, b;
 } global = {0, 1};

--- a/c/ldv-regression/test27_false-unreach-call.c
+++ b/c/ldv-regression/test27_false-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 struct dummy {
   int *array;
 };

--- a/c/ldv-regression/test28_false-unreach-call.c
+++ b/c/ldv-regression/test28_false-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 struct dummy {
   int a, b;
 };

--- a/c/ldv-regression/test29_false-unreach-call.c
+++ b/c/ldv-regression/test29_false-unreach-call.c
@@ -1,7 +1,4 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-extern void *__VERIFIER_nondet_pointer();
 extern int __VERIFIER_nondet_int();
 
 union dummy {

--- a/c/ldv-regression/test30_false-unreach-call.c
+++ b/c/ldv-regression/test30_false-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 int a = 1, b;
 
 struct dummy {

--- a/c/ldv-regression/test30_true-unreach-call.c
+++ b/c/ldv-regression/test30_true-unreach-call.c
@@ -1,8 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-
-extern void *__VERIFIER_nondet_pointer();
-
 int a = 1, b;
 
 struct dummy {


### PR DESCRIPTION
I removed the nondet_pointer calls and replaced them with an static variable and nondet initialization of its content.

I decided to use the static variable instead of malloc'ing to avoid memory leak. The programs use goto statements to jump to the __VERIFIER_error() function call, so by using a static variable we avoid changing too much the program.