### PR TITLE
Array examples fixes

### DIFF
--- a/c/array-examples/sanfoundry_24_false-valid-deref.c
+++ b/c/array-examples/sanfoundry_24_false-valid-deref.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 /*
@@ -21,12 +22,12 @@ int main()
 {
     int array[SIZE];
     int i;
-    int num;
- 
+    int num = __VERIFIER_nondet_int();
+
     //printf("Even numbers in the array are - ");
-    for (i = 0; i < num; i++) // use of uninitialized num
+    for (i = 0; i < num; i++)
     {
-        if (array[i] % 2 == 0)
+        if (array[i] % 2 == 0) // out-of-bound access for i >= SIZE
         {
             printEven( array[i] );
         }
@@ -34,7 +35,7 @@ int main()
     //printf("\n Odd numbers in the array are -");
     for (i = 0; i < num; i++)
     {
-        if (array[i] % 2 != 0)
+        if (array[i] % 2 != 0) // out-of-bound access for i >= SIZE
         {
             printOdd( array[i] );
         }

--- a/c/array-examples/sanfoundry_24_false-valid-deref.i
+++ b/c/array-examples/sanfoundry_24_false-valid-deref.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 void printEven( int i ) {
   __VERIFIER_assert( ( i % 2 ) == 0 );
@@ -10,7 +11,7 @@ int main()
 {
     int array[100000];
     int i;
-    int num;
+    int num = __VERIFIER_nondet_int();
     for (i = 0; i < num; i++)
     {
         if (array[i] % 2 == 0)

--- a/c/array-examples/sanfoundry_24_true-unreach-call.c
+++ b/c/array-examples/sanfoundry_24_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 /*
@@ -23,6 +24,7 @@ int main()
     int array[SIZE];
     int i;
     int num = __VERIFIER_nondet_int();
+    __VERIFIER_assume(num <= SIZE);
 
     //printf("Even numbers in the array are - ");
     for (i = 0; i < num; i++)

--- a/c/array-examples/sanfoundry_24_true-unreach-call.i
+++ b/c/array-examples/sanfoundry_24_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 void printEven( int i ) {
   __VERIFIER_assert( ( i % 2 ) == 0 );
@@ -12,6 +13,7 @@ int main()
     int array[100000];
     int i;
     int num = __VERIFIER_nondet_int();
+    __VERIFIER_assume(num <= 100000);
     for (i = 0; i < num; i++)
     {
         if (array[i] % 2 == 0)

--- a/c/array-examples/standard_strcpy_false-valid-deref_ground.c
+++ b/c/array-examples/standard_strcpy_false-valid-deref_ground.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 100000
@@ -6,7 +7,13 @@ void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int main( ) {
   int src[N];
   int dst[N];
+  int j;
+  for (j = 0; j < N; ++j)
+	src[j] = __VERIFIER_nondet_int();
+
   int i = 0; 
+  // if src[i] != 0 for all 0 <= i < N, then
+  // i gets >= N and we'll perform an out-of-bound access to src
   while ( src[i] != 0 ) {
     dst[i] = src[i];
     i = i + 1;

--- a/c/array-examples/standard_strcpy_false-valid-deref_ground.i
+++ b/c/array-examples/standard_strcpy_false-valid-deref_ground.i
@@ -1,8 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int main( ) {
   int src[100000];
   int dst[100000];
+  int j;
+  for (j = 0; j < 100000; ++j)
+        src[j] = __VERIFIER_nondet_int();
   int i = 0;
   while ( src[i] != 0 ) {
     dst[i] = src[i];

--- a/c/array-examples/standard_strcpy_original_false-valid-deref.c
+++ b/c/array-examples/standard_strcpy_original_false-valid-deref.c
@@ -1,17 +1,23 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 
 #define N 100000
 int main( ) {
   int src[N];
   int dst[N];
+  int j;
+  for (j = 0; j < N; ++j)
+	src[j] = __VERIFIER_nondet_int();
   int i = 0; 
+  // possible out-of-bound access
   while ( src[i] != 0 ) {
     dst[i] = src[i];
     i = i + 1;
   }
   
   i = 0;
+  // possible out-of-bound access
   while ( src[i] != 0 ) {
     __VERIFIER_assert(  dst[i] == src[i]  );
     i = i + 1;

--- a/c/array-examples/standard_strcpy_original_false-valid-deref.i
+++ b/c/array-examples/standard_strcpy_original_false-valid-deref.i
@@ -1,8 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
 int main( ) {
   int src[100000];
   int dst[100000];
+  int j;
+  for (j = 0; j < 100000; ++j)
+        src[j] = __VERIFIER_nondet_int();
   int i = 0;
   while ( src[i] != 0 ) {
     dst[i] = src[i];


### PR DESCRIPTION
Fix using uninitialized values in benchmarks with invalid pointer dereference (see #280).