### PR TITLE
Fix access to uninitialized memory in benchmark c/heap-manipulation/tree_true-unreach-call.c

### DIFF
--- a/c/heap-manipulation/tree_true-unreach-call.c
+++ b/c/heap-manipulation/tree_true-unreach-call.c
@@ -54,6 +54,7 @@ struct node *create_tree()
         node->value = value;
         nodelast = node;
     }
+    node->parent = NULL;
     while (node != NULL) {
         node->left = malloc(sizeof *node);
         if (!node)

--- a/c/heap-manipulation/tree_true-unreach-call.i
+++ b/c/heap-manipulation/tree_true-unreach-call.i
@@ -587,6 +587,7 @@ struct node *create_tree()
         node->value = value;
         nodelast = node;
     }
+    node->parent = ((void *)0);
     while (node != ((void *)0)) {
         node->left = malloc(sizeof *node);
         if (!node)


### PR DESCRIPTION
Field `parent` of root node is uninitialized yet accessed in function
`inspect`.