### PR TITLE
Missing frees on false-valid-deref benchmarks

### DIFF
--- a/c/array-examples/relax_false-valid-deref.c
+++ b/c/array-examples/relax_false-valid-deref.c
@@ -159,6 +159,8 @@ int main()
     __VERIFIER_assert(differences>1);
   }
 
+  free(pat);
+  free(a);
   return 0;
 }
 

--- a/c/array-examples/relax_false-valid-deref.i
+++ b/c/array-examples/relax_false-valid-deref.i
@@ -612,5 +612,7 @@ int main()
       ++differences;
     __VERIFIER_assert(differences>1);
   }
+  free(pat);
+  free(a);
   return 0;
 }

--- a/c/termination-crafted/LexIndexValue-Pointer_false-valid-deref.c
+++ b/c/termination-crafted/LexIndexValue-Pointer_false-valid-deref.c
@@ -22,5 +22,6 @@ int main() {
 			(*q)--;
 		}
 	}
+	free(p);
 	return 0;
 }

--- a/c/termination-crafted/LexIndexValue-Pointer_false-valid-deref.c
+++ b/c/termination-crafted/LexIndexValue-Pointer_false-valid-deref.c
@@ -9,6 +9,7 @@
  typedef long unsigned int size_t;
 
 void * __attribute__((__cdecl__)) malloc (size_t __size) ;
+void free (void *__ptr);
 
 extern int __VERIFIER_nondet_int(void);
 

--- a/c/termination-crafted/SyntaxSupportPointer01_false-valid-deref.c
+++ b/c/termination-crafted/SyntaxSupportPointer01_false-valid-deref.c
@@ -14,5 +14,6 @@ int main() {
 	while (*p >= 0) {
 		(*p)--;
 	}
+	free(p);
 	return 0;
 }

--- a/c/termination-crafted/SyntaxSupportPointer01_false-valid-deref.c
+++ b/c/termination-crafted/SyntaxSupportPointer01_false-valid-deref.c
@@ -6,6 +6,7 @@
  typedef long unsigned int size_t;
 
 void * __attribute__((__cdecl__)) malloc (size_t __size) ;
+void free (void *__ptr);
 
 extern int __VERIFIER_nondet_int(void);
 


### PR DESCRIPTION
Otherwise the programs would also suffer from memory leak

Signed-off-by: Mikhail Ramalho <mikhail.ramalho@gmail.com>