### PR TITLE
Attempt to fix the first benchmark in #191

### DIFF
--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-az6007.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--media--dvb--dvb-usb--dvb-usb-az6007.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -8292,7 +8292,7 @@ static int az6007_tuner_attach(struct dvb_usb_adapter *adap )
     __cil_tmp30 = (unsigned long )adap;
     __cil_tmp31 = __cil_tmp30 + __cil_tmp29;
     __cil_tmp32 = *((struct dvb_frontend **)__cil_tmp31);
-    (*__cil_tmp27)(__cil_tmp32, 1);
+    //(*__cil_tmp27)(__cil_tmp32, 1);
     }
   } else {
 
@@ -8327,7 +8327,7 @@ static int az6007_tuner_attach(struct dvb_usb_adapter *adap )
     __cil_tmp40 = (unsigned long )__cil_tmp39;
     __cil_tmp41 = __cil_tmp40 + 3720;
     __cil_tmp42 = (struct i2c_adapter *)__cil_tmp41;
-    tmp___11 = (*__a)(__cil_tmp38, & az6007_mt2063_config, __cil_tmp42);
+    //tmp___11 = (*__a)(__cil_tmp38, & az6007_mt2063_config, __cil_tmp42);
     __r = (void *)tmp___11;
     }
     {
@@ -8377,7 +8377,7 @@ static int az6007_tuner_attach(struct dvb_usb_adapter *adap )
     __cil_tmp65 = (unsigned long )adap;
     __cil_tmp66 = __cil_tmp65 + __cil_tmp64;
     __cil_tmp67 = *((struct dvb_frontend **)__cil_tmp66);
-    (*__cil_tmp62)(__cil_tmp67, 0);
+    //(*__cil_tmp62)(__cil_tmp67, 0);
     }
   } else {
 


### PR DESCRIPTION
This benchmark contains dispatch to uninitialized function pointers, which results in assertion failure. For example, `var_group_4` is calloced, so `__cil_tmp23` at line 8285 is equal to the return value of calloc + 1600. `__cil_tmp24` at line 8286 is the deference of `__cil_tmp23` which equals to 0 (calloced memory). `__cil_tmp26` at line 8288 will be 360, which is not initialized. `__cil_tmp27` at line 8289 is the deference of `__cil_tmp26` which can be any value. In line 8295, a function pointer is called which is the deference of `__cil_tmp27`. So a function that results in the assertion failure will be called since `*__cil_tmp27` could alias with any function.

For the record, this fix is not supposed to fix all uninitialized memory accesses. We only intend to fix those that lead to assertion failure.