### PR TITLE
Attempt to fix the third benchmark in #191

### DIFF
--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--pcmcia--pcmcia.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--pcmcia--pcmcia.ko-ldv_main2_sequence_infinite_withcheck_stateful.cil.out.c
@@ -7936,6 +7936,7 @@ extern void ldv_check_return_value_probe(int  ) ;
 void ldv_initialize(void) ;
 extern void ldv_handler_precall(void) ;
 extern int __VERIFIER_nondet_int(void) ;
+extern void* __VERIFIER_nondet_pointer(void);
 int LDV_IN_INTERRUPT  ;
 void ldv_main0_sequence_infinite_withcheck_stateful(void) 
 { 
@@ -8806,7 +8807,8 @@ struct resource *pcmcia_find_mem_region(u_long base , u_long num , u_long align 
                                                                                             unsigned long  ,
                                                                                             int  ,
                                                                                             struct pcmcia_socket * ))0)) {
-    tmp = (*((s->resource_ops)->find_mem))(base, num, align, low, s);
+    //tmp = (*((s->resource_ops)->find_mem))(base, num, align, low, s);
+    tmp = __VERIFIER_nondet_pointer();
     return (tmp);
   } else {
 
@@ -10693,7 +10695,8 @@ static void *set_cis_map(struct pcmcia_socket *s , unsigned int card_offset , un
   }
   mem->card_start = card_offset;
   mem->flags = (u_char )flags;
-  ret = (*((s->ops)->set_mem_map))(s, mem);
+  //ret = (*((s->ops)->set_mem_map))(s, mem);
+  ret = __VERIFIER_nondet_int();
   if (ret != 0) {
     iounmap((void volatile   *)s->cis_virt);
     s->cis_virt = 0;


### PR DESCRIPTION
Similar to the fix in #305, this fix remove function pointer dispatch
which is uninitialized and leads to assertion failure.