### PR TITLE
Fix overflows in the BitVectorsReach catgegory

### DIFF
--- a/c/bitvector/jain_1_false-no-overflow.c
+++ b/c/bitvector/jain_1_false-no-overflow.c
@@ -1,0 +1,26 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int y;
+
+  y = 1;
+
+  while(1)
+    {
+      y = y +2*__VERIFIER_nondet_int();
+
+
+      __VERIFIER_assert (y!=0);
+	
+    }
+    return 0;
+}
+

--- a/c/bitvector/jain_1_false-no-overflow.i
+++ b/c/bitvector/jain_1_false-no-overflow.i
@@ -1,0 +1,25 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int y;
+
+  y = 1;
+
+  while(1)
+    {
+      y = y +2*__VERIFIER_nondet_int();
+
+
+      __VERIFIER_assert (y!=0);
+
+    }
+    return 0;
+}

--- a/c/bitvector/jain_1_true-unreach-call.c
+++ b/c/bitvector/jain_1_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,16 +9,16 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int y;
+  unsigned int y;
 
-  y = 1;
+  y = 1U;
 
   while(1)
     {
-      y = y +2*__VERIFIER_nondet_int();
+      y = y +2U*__VERIFIER_nondet_uint();
 
 
-      __VERIFIER_assert (y!=0);
+      __VERIFIER_assert (y!=0U);
 	
     }
     return 0;

--- a/c/bitvector/jain_1_true-unreach-call.i
+++ b/c/bitvector/jain_1_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,16 +9,16 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int y;
+  unsigned int y;
 
-  y = 1;
+  y = 1U;
 
   while(1)
     {
-      y = y +2*__VERIFIER_nondet_int();
+      y = y +2U*__VERIFIER_nondet_uint();
 
 
-      __VERIFIER_assert (y!=0);
+      __VERIFIER_assert (y!=0U);
 
     }
     return 0;

--- a/c/bitvector/jain_2_false-no-overflow.c
+++ b/c/bitvector/jain_2_false-no-overflow.c
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y;
+
+  x = 1;
+  y = 1;
+
+  while(1)
+    {
+      x = x +2*__VERIFIER_nondet_int();
+      y = y +2*__VERIFIER_nondet_int();
+
+
+      __VERIFIER_assert(x+y!=1);
+    }
+    return 0;
+}
+

--- a/c/bitvector/jain_2_false-no-overflow.i
+++ b/c/bitvector/jain_2_false-no-overflow.i
@@ -1,0 +1,26 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y;
+
+  x = 1;
+  y = 1;
+
+  while(1)
+    {
+      x = x +2*__VERIFIER_nondet_int();
+      y = y +2*__VERIFIER_nondet_int();
+
+
+      __VERIFIER_assert(x+y!=1);
+    }
+    return 0;
+}

--- a/c/bitvector/jain_2_true-unreach-call.c
+++ b/c/bitvector/jain_2_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,18 +9,18 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y;
+  unsigned int x,y;
 
-  x = 1;
-  y = 1;
+  x = 1U;
+  y = 1U;
 
   while(1)
     {
-      x = x +2*__VERIFIER_nondet_int();
-      y = y +2*__VERIFIER_nondet_int();
+      x = x +2U*__VERIFIER_nondet_uint();
+      y = y +2U*__VERIFIER_nondet_uint();
 
 
-      __VERIFIER_assert(x+y!=1);
+      __VERIFIER_assert(x+y!=1U);
     }
     return 0;
 }

--- a/c/bitvector/jain_2_true-unreach-call.i
+++ b/c/bitvector/jain_2_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,18 +9,18 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y;
+  unsigned int x,y;
 
-  x = 1;
-  y = 1;
+  x = 1U;
+  y = 1U;
 
   while(1)
     {
-      x = x +2*__VERIFIER_nondet_int();
-      y = y +2*__VERIFIER_nondet_int();
+      x = x +2U*__VERIFIER_nondet_uint();
+      y = y +2U*__VERIFIER_nondet_uint();
 
 
-      __VERIFIER_assert(x+y!=1);
+      __VERIFIER_assert(x+y!=1U);
     }
     return 0;
 }

--- a/c/bitvector/jain_4_false-no-overflow.c
+++ b/c/bitvector/jain_4_false-no-overflow.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y,z;
+
+  x=0;
+  y=0;
+  z=0;
+
+  while(1)
+    {
+      x = x +4*__VERIFIER_nondet_int();
+      y = y +4*__VERIFIER_nondet_int();
+      z = z +8*__VERIFIER_nondet_int();
+
+      __VERIFIER_assert(x+y+z!=1);
+    }
+    return 0;
+}
+

--- a/c/bitvector/jain_4_false-no-overflow.i
+++ b/c/bitvector/jain_4_false-no-overflow.i
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y,z;
+
+  x=0;
+  y=0;
+  z=0;
+
+  while(1)
+    {
+      x = x +4*__VERIFIER_nondet_int();
+      y = y +4*__VERIFIER_nondet_int();
+      z = z +8*__VERIFIER_nondet_int();
+
+      __VERIFIER_assert(x+y+z!=1);
+    }
+    return 0;
+}

--- a/c/bitvector/jain_4_true-unreach-call.c
+++ b/c/bitvector/jain_4_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y,z;
+  unsigned int x,y,z;
 
-  x=0;
-  y=0;
-  z=0;
+  x=0U;
+  y=0U;
+  z=0U;
 
   while(1)
     {
-      x = x +4*__VERIFIER_nondet_int();
-      y = y +4*__VERIFIER_nondet_int();
-      z = z +8*__VERIFIER_nondet_int();
+      x = x +4U*__VERIFIER_nondet_uint();
+      y = y +4U*__VERIFIER_nondet_uint();
+      z = z +8U*__VERIFIER_nondet_uint();
 
-      __VERIFIER_assert(x+y+z!=1);
+      __VERIFIER_assert(x+y+z!=1U);
     }
     return 0;
 }

--- a/c/bitvector/jain_4_true-unreach-call.i
+++ b/c/bitvector/jain_4_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y,z;
+  unsigned int x,y,z;
 
-  x=0;
-  y=0;
-  z=0;
+  x=0U;
+  y=0U;
+  z=0U;
 
   while(1)
     {
-      x = x +4*__VERIFIER_nondet_int();
-      y = y +4*__VERIFIER_nondet_int();
-      z = z +8*__VERIFIER_nondet_int();
+      x = x +4U*__VERIFIER_nondet_uint();
+      y = y +4U*__VERIFIER_nondet_uint();
+      z = z +8U*__VERIFIER_nondet_uint();
 
-      __VERIFIER_assert(x+y+z!=1);
+      __VERIFIER_assert(x+y+z!=1U);
     }
     return 0;
 }

--- a/c/bitvector/jain_5_false-no-overflow.c
+++ b/c/bitvector/jain_5_false-no-overflow.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y;
+
+  x=0;
+  y=4;
+
+
+  while(1)
+    {
+      x = x + y;
+      y = y +4;
+      
+      
+      __VERIFIER_assert(x!=30);
+    }
+    return 0;
+}
+

--- a/c/bitvector/jain_5_false-no-overflow.i
+++ b/c/bitvector/jain_5_false-no-overflow.i
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y;
+
+  x=0;
+  y=4;
+
+
+  while(1)
+    {
+      x = x + y;
+      y = y +4;
+
+
+      __VERIFIER_assert(x!=30);
+    }
+    return 0;
+}

--- a/c/bitvector/jain_5_true-unreach-call.c
+++ b/c/bitvector/jain_5_true-unreach-call.c
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y;
+  unsigned int x,y;
 
-  x=0;
-  y=4;
+  x=0U;
+  y=4U;
 
 
   while(1)
     {
       x = x + y;
-      y = y +4;
+      y = y +4U;
       
       
-      __VERIFIER_assert(x!=30);
+      __VERIFIER_assert(x!=30U);
     }
     return 0;
 }

--- a/c/bitvector/jain_5_true-unreach-call.i
+++ b/c/bitvector/jain_5_true-unreach-call.i
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y;
+  unsigned int x,y;
 
-  x=0;
-  y=4;
+  x=0U;
+  y=4U;
 
 
   while(1)
     {
       x = x + y;
-      y = y +4;
+      y = y +4U;
 
 
-      __VERIFIER_assert(x!=30);
+      __VERIFIER_assert(x!=30U);
     }
     return 0;
 }

--- a/c/bitvector/jain_6_false-no-overflow.c
+++ b/c/bitvector/jain_6_false-no-overflow.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y,z;
+
+  x=0;
+  y=0;
+  z=0;
+
+  while(1)
+    {
+      x = x +2*__VERIFIER_nondet_int();
+      y = y +4*__VERIFIER_nondet_int();
+      z = z +8*__VERIFIER_nondet_int();
+
+      __VERIFIER_assert(4*x+2*y+z!=4);
+    }
+    return 0;
+}
+

--- a/c/bitvector/jain_6_false-no-overflow.i
+++ b/c/bitvector/jain_6_false-no-overflow.i
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y,z;
+
+  x=0;
+  y=0;
+  z=0;
+
+  while(1)
+    {
+      x = x +2*__VERIFIER_nondet_int();
+      y = y +4*__VERIFIER_nondet_int();
+      z = z +8*__VERIFIER_nondet_int();
+
+      __VERIFIER_assert(4*x+2*y+z!=4);
+    }
+    return 0;
+}

--- a/c/bitvector/jain_6_true-unreach-call.c
+++ b/c/bitvector/jain_6_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y,z;
+  unsigned int x,y,z;
 
-  x=0;
-  y=0;
-  z=0;
+  x=0U;
+  y=0U;
+  z=0U;
 
   while(1)
     {
-      x = x +2*__VERIFIER_nondet_int();
-      y = y +4*__VERIFIER_nondet_int();
-      z = z +8*__VERIFIER_nondet_int();
+      x = x +2U*__VERIFIER_nondet_uint();
+      y = y +4U*__VERIFIER_nondet_uint();
+      z = z +8U*__VERIFIER_nondet_uint();
 
-      __VERIFIER_assert(4*x+2*y+z!=4);
+      __VERIFIER_assert(4U*x+2U*y+z!=4U);
     }
     return 0;
 }

--- a/c/bitvector/jain_6_true-unreach-call.i
+++ b/c/bitvector/jain_6_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y,z;
+  unsigned int x,y,z;
 
-  x=0;
-  y=0;
-  z=0;
+  x=0U;
+  y=0U;
+  z=0U;
 
   while(1)
     {
-      x = x +2*__VERIFIER_nondet_int();
-      y = y +4*__VERIFIER_nondet_int();
-      z = z +8*__VERIFIER_nondet_int();
+      x = x +2U*__VERIFIER_nondet_uint();
+      y = y +4U*__VERIFIER_nondet_uint();
+      z = z +8U*__VERIFIER_nondet_uint();
 
-      __VERIFIER_assert(4*x+2*y+z!=4);
+      __VERIFIER_assert(4U*x+2U*y+z!=4U);
     }
     return 0;
 }

--- a/c/bitvector/jain_7_false-no-overflow.c
+++ b/c/bitvector/jain_7_false-no-overflow.c
@@ -1,0 +1,28 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y,z;
+
+  x=0;
+  y=0;
+  z=0;
+
+  while(1)
+    {
+      x = x +1048576*__VERIFIER_nondet_int();
+      y = y +2097152*__VERIFIER_nondet_int();
+      z = z +4194304*__VERIFIER_nondet_int();
+
+      __VERIFIER_assert(4*x-2*y+z!=1048576);
+    }
+    return 0;
+}
+

--- a/c/bitvector/jain_7_false-no-overflow.i
+++ b/c/bitvector/jain_7_false-no-overflow.i
@@ -1,0 +1,27 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int main()
+{
+  int x,y,z;
+
+  x=0;
+  y=0;
+  z=0;
+
+  while(1)
+    {
+      x = x +1048576*__VERIFIER_nondet_int();
+      y = y +2097152*__VERIFIER_nondet_int();
+      z = z +4194304*__VERIFIER_nondet_int();
+
+      __VERIFIER_assert(4*x-2*y+z!=1048576);
+    }
+    return 0;
+}

--- a/c/bitvector/jain_7_true-unreach-call.c
+++ b/c/bitvector/jain_7_true-unreach-call.c
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y,z;
+  unsigned int x,y,z;
 
-  x=0;
-  y=0;
-  z=0;
+  x=0U;
+  y=0U;
+  z=0U;
 
   while(1)
     {
-      x = x +1048576*__VERIFIER_nondet_int();
-      y = y +2097152*__VERIFIER_nondet_int();
-      z = z +4194304*__VERIFIER_nondet_int();
+      x = x +1048576U*__VERIFIER_nondet_uint();
+      y = y +2097152U*__VERIFIER_nondet_uint();
+      z = z +4194304U*__VERIFIER_nondet_uint();
 
-      __VERIFIER_assert(4*x-2*y+z!=1048576);
+      __VERIFIER_assert(4U*x-2U*y+z!=1048576U);
     }
     return 0;
 }

--- a/c/bitvector/jain_7_true-unreach-call.i
+++ b/c/bitvector/jain_7_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
     ERROR: __VERIFIER_error();
@@ -9,19 +9,19 @@ void __VERIFIER_assert(int cond) {
 }
 int main()
 {
-  int x,y,z;
+  unsigned int x,y,z;
 
-  x=0;
-  y=0;
-  z=0;
+  x=0U;
+  y=0U;
+  z=0U;
 
   while(1)
     {
-      x = x +1048576*__VERIFIER_nondet_int();
-      y = y +2097152*__VERIFIER_nondet_int();
-      z = z +4194304*__VERIFIER_nondet_int();
+      x = x +1048576U*__VERIFIER_nondet_uint();
+      y = y +2097152U*__VERIFIER_nondet_uint();
+      z = z +4194304U*__VERIFIER_nondet_uint();
 
-      __VERIFIER_assert(4*x-2*y+z!=1048576);
+      __VERIFIER_assert(4U*x-2U*y+z!=1048576U);
     }
     return 0;
 }

--- a/c/check.py
+++ b/c/check.py
@@ -141,6 +141,20 @@ KNOWN_DIRECTORY_PROBLEMS = [
     ("ntdrivers-simplified", "missing readme"),
     ("ssh", "missing readme"),
     ("ssh-simplified", "missing readme"),
+
+    # pull request #310
+    ("bitvector", "jain_1_false-no-overflow.c is not contained in any category"),
+    ("bitvector", "jain_1_false-no-overflow.i is not contained in any category"),
+    ("bitvector", "jain_2_false-no-overflow.c is not contained in any category"),
+    ("bitvector", "jain_2_false-no-overflow.i is not contained in any category"),
+    ("bitvector", "jain_4_false-no-overflow.c is not contained in any category"),
+    ("bitvector", "jain_4_false-no-overflow.i is not contained in any category"),
+    ("bitvector", "jain_5_false-no-overflow.c is not contained in any category"),
+    ("bitvector", "jain_5_false-no-overflow.i is not contained in any category"),
+    ("bitvector", "jain_6_false-no-overflow.c is not contained in any category"),
+    ("bitvector", "jain_6_false-no-overflow.i is not contained in any category"),
+    ("bitvector", "jain_7_false-no-overflow.c is not contained in any category"),
+    ("bitvector", "jain_7_false-no-overflow.i is not contained in any category"),
     ]
 
 KNOWN_BENCHMARK_FILE_PROBLEMS = [


### PR DESCRIPTION
As discussed in #307, this pull request is created to remove signed integer overflows that exist in the bitvector folder. Basically all signed declarations and arithmetic operations are converted to unsigned. Given the program behavior has changed, I will attach a verified Boogie program with bit vectors types for each related benchmark. We are working on supporting loop invariant and code contracts for SMACK so please understand I have to code them into Boogie manually and thus do not provide correctness witnesses.

Verified Boogie programs for each benchmark are the following.
jain_1_true-unreach-call.*:
```boogie
procedure main() returns (r:bv32)
{
  var y,tmp1 : bv32;

  y := 1bv32;

  while(1==1)
  invariant urem.bv32(y, 2bv32) == 1bv32;
    {
      havoc tmp1;
      y := add.bv32(y, mul.bv32(2bv32, tmp1));

      assert(y != 0bv32);
    }
    r := 0bv32;
}

function {:bvbuiltin "bvadd"} add.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvmul"} mul.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvurem"} urem.bv32(i1: bv32, i2: bv32) returns (bv32);
```
jain_2_true-unreach-call.*:
```boogie
procedure main() returns (r:bv32)
{
  var x, y,tmp1,tmp2 : bv32;

  x := 1bv32;
  y := 1bv32;

  while(1==1)
  invariant urem.bv32(x, 2bv32) == 1bv32;
  invariant urem.bv32(y, 2bv32) == 1bv32;
    {
      havoc tmp1;
      x := add.bv32(x, mul.bv32(2bv32, tmp1));
      y := add.bv32(y, mul.bv32(2bv32, tmp2));

      assert(add.bv32(x,y) != 1bv32);
    }
    r := 0bv32;
}

function {:bvbuiltin "bvadd"} add.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvmul"} mul.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvurem"} urem.bv32(i1: bv32, i2: bv32) returns (bv32);
```

jain_4_true-unreach-call.*:
```boogie
procedure main() returns (r:bv32)
{
  var x,y,z,tmp1,tmp2,tmp3 : bv32;

  x := 0bv32;
  y := 0bv32;
  z := 0bv32;

  while(1==1)
  invariant urem.bv32(x, 2bv32) == 0bv32;
  invariant urem.bv32(y, 2bv32) == 0bv32;
  invariant urem.bv32(z, 2bv32) == 0bv32;
    {
      havoc tmp1;
      havoc tmp2;
      havoc tmp3;
      x := add.bv32(x, mul.bv32(4bv32, tmp1));
      y := add.bv32(y, mul.bv32(4bv32, tmp2));
      z := add.bv32(z, mul.bv32(8bv32, tmp3));

      assert((add.bv32(x, add.bv32(y, z))) != 1bv32);
    }
    r := 0bv32;
}

function {:bvbuiltin "bvadd"} add.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvmul"} mul.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvurem"} urem.bv32(i1: bv32, i2: bv32) returns (bv32);
```

jain_5_true-unreach-call.*:
```boogie
procedure main() returns (r:bv32)
{
  var x, y: bv32;

  x := 0bv32;
  y := 4bv32;

  while(1==1)
  invariant urem.bv32(x, 4bv32) == 0bv32;
  invariant urem.bv32(y, 4bv32) == 0bv32;
    {
      x := add.bv32(x, y);
      y := add.bv32(y, 4bv32);

      assert(x != 30bv32);
    }
    r := 0bv32;
}

function {:bvbuiltin "bvadd"} add.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvurem"} urem.bv32(i1: bv32, i2: bv32) returns (bv32);
```

jain_6_true-unreach-call.*:
```boogie
procedure main() returns (r:bv32)
{
  var x,y,z,tmp1,tmp2,tmp3 : bv32;

  x := 0bv32;
  y := 0bv32;
  z := 0bv32;

  while(1==1)
  invariant urem.bv32(x, 2bv32) == 0bv32;
  invariant urem.bv32(y, 4bv32) == 0bv32;
  invariant urem.bv32(z, 8bv32) == 0bv32;
    {
      havoc tmp1;
      havoc tmp2;
      havoc tmp3;
      x := add.bv32(x, mul.bv32(2bv32, tmp1));
      y := add.bv32(y, mul.bv32(4bv32, tmp2));
      z := add.bv32(z, mul.bv32(8bv32, tmp3));

      assert((add.bv32(mul.bv32(x, 4bv32), add.bv32(mul.bv32(y, 2bv32), z))) != 4bv32);
    }
    r := 0bv32;
}

function {:bvbuiltin "bvadd"} add.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvmul"} mul.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvurem"} urem.bv32(i1: bv32, i2: bv32) returns (bv32);
```
jain_7_true-unreach-call.*:
```boogie
procedure main() returns (r:bv32)
{
  var x,y,z,tmp1,tmp2,tmp3 : bv32;

  x := 0bv32;
  y := 0bv32;
  z := 0bv32;

  while(1==1)
  invariant urem.bv32(x, 1048576bv32) == 0bv32;
  invariant urem.bv32(y, 2097152bv32) == 0bv32;
  invariant urem.bv32(z, 4194304bv32) == 0bv32;
    {
      havoc tmp1;
      havoc tmp2;
      havoc tmp3;
      x := add.bv32(x, mul.bv32(1048576bv32, tmp1));
      y := add.bv32(y, mul.bv32(2097152bv32, tmp2));
      z := add.bv32(z, mul.bv32(4194304bv32, tmp3));

      assert(add.bv32(sub.bv32(mul.bv32(x, 4bv32), mul.bv32(y, 2bv32)), z) != 1048576bv32);
    }
    r := 0bv32;
}

function {:bvbuiltin "bvadd"} add.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvsub"} sub.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvmul"} mul.bv32(i1: bv32, i2: bv32) returns (bv32);
function {:bvbuiltin "bvurem"} urem.bv32(i1: bv32, i2: bv32) returns (bv32);
```