### PR TITLE
fix use of uninitialized value in cs_...false-unreach-call benchmarks

### DIFF
--- a/c/seq-pthread/cs_fib_false-unreach-call.i
+++ b/c/seq-pthread/cs_fib_false-unreach-call.i
@@ -660,10 +660,11 @@ const unsigned char __THREAD_UNUSED = 0x00;
 const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[6][2 +1];
-int __VERIFIER_nondet_int();
+extern int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar();
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 6);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 6 -1)?__CS_ret_PREEMPTED:__CS_ret;

--- a/c/seq-pthread/cs_fib_longer_false-unreach-call.i
+++ b/c/seq-pthread/cs_fib_longer_false-unreach-call.i
@@ -650,10 +650,11 @@ const unsigned char __THREAD_UNUSED = 0x00;
 const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[7][2 +1];
-int __VERIFIER_nondet_int();
+extern int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar();
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 7);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 7 -1)?__CS_ret_PREEMPTED:__CS_ret;

--- a/c/seq-pthread/cs_queue_false-unreach-call.i
+++ b/c/seq-pthread/cs_queue_false-unreach-call.i
@@ -866,10 +866,11 @@ const unsigned char __THREAD_UNUSED = 0x00;
 const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][2 +1];
-int __VERIFIER_nondet_int();
+extern int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar();
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 2);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 2 -1)?__CS_ret_PREEMPTED:__CS_ret;

--- a/c/seq-pthread/cs_read_write_lock_false-unreach-call.i
+++ b/c/seq-pthread/cs_read_write_lock_false-unreach-call.i
@@ -650,10 +650,11 @@ const unsigned char __THREAD_UNUSED = 0x00;
 const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][4 +1];
-int __VERIFIER_nondet_int();
+extern int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar();
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 2);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 2 -1)?__CS_ret_PREEMPTED:__CS_ret;

--- a/c/seq-pthread/cs_stack_false-unreach-call.i
+++ b/c/seq-pthread/cs_stack_false-unreach-call.i
@@ -877,10 +877,11 @@ const unsigned char __THREAD_UNUSED = 0x00;
 const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][2 +1];
-int __VERIFIER_nondet_int();
+extern int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar();
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 2);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 2 -1)?__CS_ret_PREEMPTED:__CS_ret;

--- a/c/seq-pthread/cs_stateful_false-unreach-call.i
+++ b/c/seq-pthread/cs_stateful_false-unreach-call.i
@@ -650,10 +650,11 @@ const unsigned char __THREAD_UNUSED = 0x00;
 const unsigned char __THREAD_RUNNING = 0x01;
 const unsigned char __THREAD_FINISHED = 0x02;
 unsigned char *__CS_thread_lockedon[2][2 +1];
-int __VERIFIER_nondet_int();
+extern int __VERIFIER_nondet_int();
+extern unsigned char __VERIFIER_nondet_uchar();
 void __CS_cs(void)
 {
- unsigned char k;
+ unsigned char k = __VERIFIER_nondet_uchar();
  __VERIFIER_assume(__CS_round+k < 2);
  __CS_round += k;
  __CS_ret = (__VERIFIER_nondet_int() && __CS_round == 2 -1)?__CS_ret_PREEMPTED:__CS_ret;


### PR DESCRIPTION
Hi,

I found few other benchmarks that used uninitialized values. Here's a fix (simply initialize that value using the __VERIFIER_nondet function).