### PR TITLE
Remove duplicate files from MemSafety-LinkedLists

### DIFF
--- a/c/MemSafety-LinkedLists.set
+++ b/c/MemSafety-LinkedLists.set
@@ -3,5 +3,4 @@ list-properties/*_true-valid-memsafety*.i
 list-properties/*_false-valid-memtrack*.i
 ddv-machzwd/*_true-valid-memsafety*.i
 forester-heap/*_true-valid-memsafety*.i
-list-ext-properties/*_true-valid-memsafety*.i
 


### PR DESCRIPTION
Fixes issue #327. `list-ext-properties/*_true-valid-memsafety*.i` is already present in category MemSafety-Heap.