### PR TITLE
fixing enumeration type declaration that miss the enumerator list

### DIFF
--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl_true-unreach-call.i
@@ -2739,7 +2739,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram_true-unreach-call.i
@@ -2739,7 +2739,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram_true-unreach-call.i
@@ -2739,7 +2739,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram_true-unreach-call.i
@@ -2739,7 +2739,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl_true-unreach-call.i
@@ -2739,7 +2739,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram_false-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram_false-unreach-call.i
@@ -2739,7 +2739,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current_false-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current_false-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set_false-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set_false-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set_false-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set_false-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set_true-unreach-call.i
@@ -1582,7 +1582,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode{X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);


### PR DESCRIPTION
A number of programs from the folder pthread-driver-races declares an enumeration type (i.e., "enum migrate_mode") without the list of enumerators, which is against the constrain from the C standards:

6.7.2.3 Tags
Constraints
...
3 A type specifier of the form
enum identifier
without an enumerator list shall only appear after the type it specifies is complete.

This commit fixes these problems by adding a dummy list of enumerators (e.g., "{X}") for the enumeration type declaration. 

Also see issue #341 