### PR TITLE
fixed undefined behavior of uninitialized variable;

### DIFF
--- a/c/pthread-complex/bounded_buffer_false-unreach-call.c
+++ b/c/pthread-complex/bounded_buffer_false-unreach-call.c
@@ -82,7 +82,8 @@ int bounded_buf_init(bounded_buf_t * bbuf, size_t sz)
     // memset(bbuf->buf, 0, sizeof(void*) * sz );
     bbuf->head = 0;
     bbuf->rear = 0;
-
+    bbuf->p_wait = 0;
+    bbuf->c_wait = 0;
     return 0;
 }
 

--- a/c/pthread-complex/bounded_buffer_false-unreach-call.i
+++ b/c/pthread-complex/bounded_buffer_false-unreach-call.i
@@ -1470,6 +1470,8 @@ int bounded_buf_init(bounded_buf_t * bbuf, size_t sz)
     }
     bbuf->head = 0;
     bbuf->rear = 0;
+    bbuf->p_wait = 0;
+    bbuf->c_wait = 0;
     return 0;
 }
 int bounded_buf_destroy(bounded_buf_t * bbuf)


### PR DESCRIPTION
The fields c_wait, p_wait (both of int type)  of the variable bbuf of bounded_buf_t type are never initialized but the values are used. Therefore, initialize these fields c_wait and p_wait with 0.