### PR TITLE
Make check.py ignore -todo directories

### DIFF
--- a/c/check.py
+++ b/c/check.py
@@ -375,7 +375,7 @@ def main():
     ok = True
     for entry in entries:
         path = os.path.join(main_directory, entry)
-        if not (entry[0] == '.' or entry == "bin"):
+        if not (entry[0] == '.' or entry == "bin" or entry.endswith("-todo")):
             if os.path.isdir(path):
                 ok &= DirectoryChecks(path, all_patterns, entry).run()
             elif entry.endswith(".set"):


### PR DESCRIPTION
I suggest this instead of adding a hundreds of temporary exceptions