### PR TITLE
Limit command-line arguments to 9999

### DIFF
--- a/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -360,7 +360,7 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1381,7 +1381,7 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1915,7 +1915,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3678,7 +3678,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1212,7 +1212,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3112,7 +3112,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -287,7 +287,7 @@ static void xfunc_die(void)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2231,7 +2231,7 @@ static void xfunc_die(void)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1611,7 +1611,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3623,7 +3623,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1413,7 +1413,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3449,7 +3449,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -391,7 +391,7 @@ static void xfunc_die(void)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2339,7 +2339,7 @@ static void xfunc_die(void)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2174,7 +2174,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -4212,7 +4212,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1636,7 +1636,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3302,7 +3302,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1835,7 +1835,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3720,7 +3720,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.c
@@ -148,7 +148,7 @@ static char * single_argv(char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.i
@@ -921,7 +921,7 @@ static char * single_argv(char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1411,7 +1411,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3364,7 +3364,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1489,7 +1489,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3510,7 +3510,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -593,7 +593,7 @@ static void * xmalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2475,7 +2475,7 @@ static void * xmalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1909,7 +1909,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3542,7 +3542,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1560,7 +1560,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3292,7 +3292,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1454,7 +1454,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3164,7 +3164,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1059,7 +1059,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2831,7 +2831,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -70,7 +70,7 @@ signed int __main(signed int argc, char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1463,7 +1463,7 @@ signed int __main(signed int argc, char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1416,7 +1416,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3207,7 +3207,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1311,7 +1311,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3286,7 +3286,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -275,7 +275,7 @@ static void xfunc_die(void)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2223,7 +2223,7 @@ static void xfunc_die(void)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -4076,7 +4076,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -5596,7 +5596,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1353,7 +1353,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3336,7 +3336,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -280,7 +280,7 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1899,7 +1899,7 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2278,7 +2278,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -4296,7 +4296,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -3677,7 +3677,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -5100,7 +5100,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1586,7 +1586,7 @@ static void * xmalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3335,7 +3335,7 @@ static void * xmalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1159,7 +1159,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3170,7 +3170,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1094,7 +1094,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2886,7 +2886,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -362,7 +362,7 @@ static char * xmalloc_realpath(const char *path)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2288,7 +2288,7 @@ static char * xmalloc_realpath(const char *path)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1429,7 +1429,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3476,7 +3476,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1055,7 +1055,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2860,7 +2860,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1133,7 +1133,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2915,7 +2915,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -524,7 +524,7 @@ inval:
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2545,7 +2545,7 @@ inval:
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -3189,7 +3189,7 @@ inval:
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -4650,7 +4650,7 @@ inval:
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -224,7 +224,7 @@ signed int __main(signed int argc, char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1737,7 +1737,7 @@ signed int __main(signed int argc, char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1232,7 +1232,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2988,7 +2988,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1939,7 +1939,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3879,7 +3879,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1284,7 +1284,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3029,7 +3029,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1755,7 +1755,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3549,7 +3549,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1535,7 +1535,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3593,7 +3593,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1065,7 +1065,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2862,7 +2862,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1066,7 +1066,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2874,7 +2874,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1333,7 +1333,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3183,7 +3183,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -393,7 +393,7 @@ inval:
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2311,7 +2311,7 @@ inval:
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2050,7 +2050,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3749,7 +3749,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1198,7 +1198,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3278,7 +3278,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1321,7 +1321,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3067,7 +3067,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1091,7 +1091,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3204,7 +3204,7 @@ static void * xzalloc(unsigned long int size)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -287,7 +287,7 @@ static char * xuid2uname(unsigned int uid)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2264,7 +2264,7 @@ static char * xuid2uname(unsigned int uid)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)

--- a/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -300,7 +300,7 @@ signed int __main(signed int argc, char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
 
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;

--- a/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2242,7 +2242,7 @@ signed int __main(signed int argc, char **argv)
 int main()
 {
   int argc = __VERIFIER_nondet_int();
-  __VERIFIER_assume(argc>=1);
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
   char **argv=malloc((argc+1)*sizeof(char*));
   argv[argc]=0;
   for(int i=0; i<argc; ++i)


### PR DESCRIPTION
This pull request puts a bound of ``10 000`` on argc in the BusyBux benchmark set.
This means that in addition to the executable name, ``9 999 `` command-line arguments are allowed.
This may mitigate issue #331.
@Guoanshisb  please review.