### PR TITLE
multiple errors in memsafety in list-ext-properties

### DIFF
--- a/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.c
+++ b/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.c
@@ -69,5 +69,14 @@ int main() {
   if(p->h != 3 || (i + y) < 20)
     ERROR: __VERIFIER_error();
 
+  /* free memory */
+  p = a;
+  while (p->n != 0) {
+    t = p->n;
+    free(p);
+    p = t;
+  }
+  free(p);
+
   return 0;
 }

--- a/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.i
+++ b/c/list-ext-properties/list-ext_false-unreach-call_false-valid-deref.i
@@ -660,5 +660,12 @@ int main() {
   }
   if(p->h != 3 || (i + y) < 20)
     ERROR: __VERIFIER_error();
+  p = a;
+  while (p->n != 0) {
+    t = p->n;
+    free(p);
+    p = t;
+  }
+  free(p);
   return 0;
 }

--- a/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.c
+++ b/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.c
@@ -69,6 +69,15 @@ int main() {
   if (p->h != 3 || i > 20)
     goto ERROR;
 
+  /* free memory */
+  p = a;
+  while (p->n != 0) {
+    t = p->n;
+    free(p);
+    p = t;
+  }
+  free(p);
+
   return 0;
 
   ERROR: __VERIFIER_error();

--- a/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.i
+++ b/c/list-ext-properties/list-ext_flag_false-unreach-call_false-valid-deref.i
@@ -658,6 +658,13 @@ int main() {
   }
   if (p->h != 3 || i > 20)
     goto ERROR;
+  p = a;
+  while (p->n != 0) {
+    t = p->n;
+    free(p);
+    p = t;
+  }
+  free(p);
   return 0;
   ERROR: __VERIFIER_error();
 }


### PR DESCRIPTION
`list-ext-properties/list-{ext,ext_flag}_false-unreach-call_false-valid-deref`: fix multiple errors in memsafety (deref+memleaks), fix PR #354 