### PR TITLE
Termination crafted memsafety

### DIFF
--- a/c/termination-crafted/LexIndexValue-Pointer_true-termination_true-valid-memsafety.c
+++ b/c/termination-crafted/LexIndexValue-Pointer_true-termination_true-valid-memsafety.c
@@ -8,6 +8,7 @@
  typedef long unsigned int size_t;
 
 void * __attribute__((__cdecl__)) malloc (size_t __size) ;
+extern void free(void *);
 
 extern int __VERIFIER_nondet_int(void);
 
@@ -25,5 +26,6 @@ int main() {
 			(*q)--;
 		}
 	}
+	free(p);
 	return 0;
 }

--- a/c/termination-crafted/NonTermination3_false-termination_false-valid-deref.c
+++ b/c/termination-crafted/NonTermination3_false-termination_false-valid-deref.c
@@ -10,8 +10,9 @@ int main() {
 	int i = __VERIFIER_nondet_int();
 	int a[10];
 	while (0 <= i && i < 10 && a[i] >= 0) {
-		a[i] = 0;
 		i = __VERIFIER_nondet_int();
+		/* possible invalid dereference */
+		a[i] = 0;
 	}
 	return 0;
 }

--- a/c/termination-crafted/SyntaxSupportPointer01_true-termination_true-valid-memsafety.c
+++ b/c/termination-crafted/SyntaxSupportPointer01_true-termination_true-valid-memsafety.c
@@ -6,6 +6,7 @@
 typedef long unsigned int size_t;
 
 void * __attribute__((__cdecl__)) malloc (size_t __size) ;
+extern void free(void *);
 
 extern int __VERIFIER_nondet_int(void);
 
@@ -15,5 +16,6 @@ int main() {
 	while (*p >= 0) {
 		(*p)--;
 	}
+	free(p);
 	return 0;
 }


### PR DESCRIPTION
Fix two memory leaks and one out-of-bound access in termination-crafted benchmarks