### PR TITLE
Replaced calls to reminder with reminderf

### DIFF
--- a/c/floats-esbmc-regression/remainder_true-unreach-call.c
+++ b/c/floats-esbmc-regression/remainder_true-unreach-call.c
@@ -6,10 +6,10 @@ void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } r
 int main(void)
 {
 
-  __VERIFIER_assert(remainder(5.1f, 3) == -0x1.ccccdp-1);
-  __VERIFIER_assert(remainder(5.1f, -3) == -0x1.ccccdp-1);
-  __VERIFIER_assert(remainder(-5.1f, -3) == 0x1.ccccdp-1);
-  __VERIFIER_assert(remainder(-5.1f, 3) == 0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(5.1f, 3) == -0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(5.1f, -3) == -0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(-5.1f, -3) == 0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(-5.1f, 3) == 0x1.ccccdp-1);
 
   double rem = remainder(0.0, 1);
   __VERIFIER_assert((rem == 0.0) && (!signbit(rem)));

--- a/c/floats-esbmc-regression/remainder_true-unreach-call.i
+++ b/c/floats-esbmc-regression/remainder_true-unreach-call.i
@@ -869,10 +869,10 @@ void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } r
 int main(void)
 {
 
-  __VERIFIER_assert(remainder(5.1f, 3) == -0x1.ccccdp-1);
-  __VERIFIER_assert(remainder(5.1f, -3) == -0x1.ccccdp-1);
-  __VERIFIER_assert(remainder(-5.1f, -3) == 0x1.ccccdp-1);
-  __VERIFIER_assert(remainder(-5.1f, 3) == 0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(5.1f, 3) == -0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(5.1f, -3) == -0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(-5.1f, -3) == 0x1.ccccdp-1);
+  __VERIFIER_assert(remainderf(-5.1f, 3) == 0x1.ccccdp-1);
 
   double rem = remainder(0.0, 1);
   __VERIFIER_assert((rem == 0.0) && (!(sizeof (rem) == sizeof (float) ? __signbitf (rem) : sizeof (rem) == sizeof (double) ? __signbit (rem) : __signbitl (rem))));


### PR DESCRIPTION
It seems that the authors intention was to compare floats and
not doubles. Hence, I replaced invocations of reminder function
(which takes doubles) with invocations of reminderf function
(which takes floats). Now everything checks out fine.