### PR TITLE
fixing issues in benchmarks from pthread-driver-races

### DIFF
--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_nvram_unlocked_ioctl_true-unreach-call.i
@@ -425,27 +425,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -551,60 +548,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -2739,7 +2728,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_read_nvram_true-unreach-call.i
@@ -425,27 +425,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -551,60 +548,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -2739,7 +2728,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_llseek_write_nvram_true-unreach-call.i
@@ -425,27 +425,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -551,60 +548,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -2739,7 +2728,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_nvram_unlocked_ioctl_write_nvram_true-unreach-call.i
@@ -425,27 +425,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -551,60 +548,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -2739,7 +2728,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl_true-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_nvram_unlocked_ioctl_true-unreach-call.i
@@ -425,27 +425,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -551,60 +548,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -2739,7 +2728,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram_false-unreach-call.i
+++ b/c/pthread-driver-races/char_generic_nvram_read_nvram_write_nvram_false-unreach-call.i
@@ -425,27 +425,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -551,60 +548,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -2739,7 +2728,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_configure_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current_false-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current_false-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_get_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set_false-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_set_false-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_current_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_get_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_configure_pc8736x_gpio_set_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_get_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set_false-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_current_pc8736x_gpio_set_false-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_get_pc8736x_gpio_set_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_change_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_configure_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_current_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_get_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set_true-unreach-call.i
+++ b/c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_open_pc8736x_gpio_set_true-unreach-call.i
@@ -376,60 +376,52 @@ void spin_lock_init(spinlock_t *lock)
 }
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == 0);
-  lock->lock = tid;
+  lock->lock = 1;
   __VERIFIER_atomic_end();
 }
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
 }
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->lock = 0;
   __VERIFIER_atomic_end();
@@ -852,27 +844,24 @@ void mutex_init(struct mutex *lock)
 }
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == 0);
-  lock->locked = tid;
+  lock->locked = 1;
   __VERIFIER_atomic_end();
 }
 bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == 0);
-    lock->locked = tid;
+    lock->locked = 1;
     __VERIFIER_atomic_end();
   }
   return ret;
 }
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
   __VERIFIER_atomic_begin();
   lock->locked = 0;
   __VERIFIER_atomic_end();
@@ -1582,7 +1571,7 @@ struct super_block {
 };
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 struct swap_info_struct;
-enum migrate_mode{X};
+enum migrate_mode {X};
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);
   int (*readpage)(struct file *, struct page *);

--- a/c/pthread-driver-races/model/linux/fs.h
+++ b/c/pthread-driver-races/model/linux/fs.h
@@ -382,7 +382,7 @@ struct super_block {
 extern int fasync_helper(int, struct file *, int, struct fasync_struct **);
 
 struct swap_info_struct;
-enum migrate_mode;
+enum migrate_mode {X};
 
 struct address_space_operations {
   int (*writepage)(struct page *page, struct writeback_control *wbc);

--- a/c/pthread-driver-races/model/linux/mutex.h
+++ b/c/pthread-driver-races/model/linux/mutex.h
@@ -2,7 +2,7 @@
 #define __LINUX_MUTEX_H
 
 
-#include <pthread.h>
+//#include <pthread.h>
 #include <linux/types.h>
 #include <svcomp.h>
 
@@ -18,11 +18,16 @@
 #define MUTEX_UNLOCKED 0
 #endif
 
+#ifndef MUTEX_LOCKED
+#define MUTEX_LOCKED 1
+#endif
+
 struct mutex
 {
   int init;
   int locked;
 };
+
 
 #define DEFINE_MUTEX(x) struct mutex x = { MUTEX_INITIALIZED, MUTEX_UNLOCKED }
 
@@ -34,11 +39,11 @@ void mutex_init(struct mutex *lock)
 
 void mutex_lock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid != lock->locked);
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->locked == MUTEX_UNLOCKED);
-  lock->locked = tid;
+  lock->locked = MUTEX_LOCKED;
   __VERIFIER_atomic_end();
 }
 
@@ -46,11 +51,11 @@ bool mutex_lock_interruptible(struct mutex *lock)
 {
   bool ret = __VERIFIER_nondet_bool();
   if(!ret) {
-    pthread_t tid = pthread_self();
+    //pthread_t tid = pthread_self();
     //__VERIFIER_assert(tid != lock->locked);
     __VERIFIER_atomic_begin();
     __VERIFIER_assume(lock->locked == MUTEX_UNLOCKED);
-    lock->locked = tid;
+    lock->locked = MUTEX_LOCKED;
     __VERIFIER_atomic_end();
   }
   return ret;
@@ -58,7 +63,7 @@ bool mutex_lock_interruptible(struct mutex *lock)
 
 void mutex_unlock(struct mutex *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid == lock->locked);
   __VERIFIER_atomic_begin();
   lock->locked = MUTEX_UNLOCKED;

--- a/c/pthread-driver-races/model/linux/spinlock.h
+++ b/c/pthread-driver-races/model/linux/spinlock.h
@@ -16,6 +16,10 @@
 #define SPIN_LOCK_UNLOCKED 0
 #endif
 
+#ifndef SPIN_LOCK_LOCKED
+#define SPIN_LOCK_LOCKED 1
+#endif
+
 typedef struct
 {
   int init;
@@ -32,47 +36,47 @@ void spin_lock_init(spinlock_t *lock)
 
 void spin_lock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid != lock->lock);
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == SPIN_LOCK_UNLOCKED);
-  lock->lock = tid;
+  lock->lock = SPIN_LOCK_LOCKED;
   __VERIFIER_atomic_end();
 }
 
 void spin_lock_irqsave(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid != lock->lock);
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == SPIN_LOCK_UNLOCKED);
-  lock->lock = tid;
+  lock->lock = SPIN_LOCK_LOCKED;
   __VERIFIER_atomic_end();
 }
 
 void spin_lock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid != lock->lock);
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == SPIN_LOCK_UNLOCKED);
-  lock->lock = tid;
+  lock->lock = SPIN_LOCK_LOCKED;
   __VERIFIER_atomic_end();
 }
 
 void spin_lock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid != lock->lock);
   __VERIFIER_atomic_begin();
   __VERIFIER_assume(lock->lock == SPIN_LOCK_UNLOCKED);
-  lock->lock = tid;
+  lock->lock = SPIN_LOCK_LOCKED;
   __VERIFIER_atomic_end();
 }
 
 void spin_unlock(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid == lock->lock);
   __VERIFIER_atomic_begin();
   lock->lock = SPIN_LOCK_UNLOCKED;
@@ -81,7 +85,7 @@ void spin_unlock(spinlock_t *lock)
 
 void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid == lock->lock);
   __VERIFIER_atomic_begin();
   lock->lock = SPIN_LOCK_UNLOCKED;
@@ -90,7 +94,7 @@ void spin_unlock_irqrestore(spinlock_t *lock, unsigned long value)
 
 void spin_unlock_irq(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid == lock->lock);
   __VERIFIER_atomic_begin();
   lock->lock = SPIN_LOCK_UNLOCKED;
@@ -99,7 +103,7 @@ void spin_unlock_irq(spinlock_t *lock)
 
 void spin_unlock_bh(spinlock_t *lock)
 {
-  pthread_t tid = pthread_self();
+  //pthread_t tid = pthread_self();
   //__VERIFIER_assert(tid == lock->lock);
   __VERIFIER_atomic_begin();
   lock->lock = SPIN_LOCK_UNLOCKED;


### PR DESCRIPTION
This pull request attempt to submit the fixed version of headers (`model/linux/mutex.h` and `spinlock.h`) that assume `pthread_t` is `int`, as discussed in issue 365. Also, I just realized that the enumeration type `migrate_mode` is declared in `model/linux/fs.h`, which was complained in issue 341. So I also fix it in this pull request, so that when the `*.i` are regenerated, the fix will still be reflected.