### PR TITLE
Busybox leaks

### DIFF
--- a/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -375,5 +375,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1391,5 +1391,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1930,5 +1930,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cal_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3688,5 +3688,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1227,5 +1227,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cat_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3122,5 +3122,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -302,5 +302,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2241,5 +2241,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1626,5 +1626,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chmod_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3633,5 +3633,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1428,5 +1428,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chown-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3459,5 +3459,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -406,5 +406,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chroot-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2349,5 +2349,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2189,5 +2189,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cp-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -4222,5 +4222,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1651,5 +1651,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3312,5 +3312,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1850,5 +1850,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3730,5 +3730,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.c
@@ -163,5 +163,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.i
@@ -931,5 +931,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1426,5 +1426,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/dos2unix_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3374,5 +3374,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1504,5 +1504,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/du_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3520,5 +3520,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -608,5 +608,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/echo_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2485,5 +2485,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1924,5 +1924,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3552,5 +3552,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1575,5 +1575,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/expr_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3302,5 +3302,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1469,5 +1469,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/fold_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3174,5 +3174,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1074,5 +1074,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/head_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2841,5 +2841,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -85,5 +85,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/hostid_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1473,5 +1473,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1431,5 +1431,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/id-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3217,5 +3217,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1326,5 +1326,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ln_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3296,5 +3296,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -290,5 +290,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/logname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2233,5 +2233,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -4091,5 +4091,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -5606,5 +5606,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1368,5 +1368,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3346,5 +3346,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -295,5 +295,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1909,5 +1909,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2293,5 +2293,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mv-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -4306,5 +4306,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -3692,5 +3692,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -5110,5 +5110,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1601,5 +1601,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3345,5 +3345,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1174,5 +1174,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/pwd_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3180,5 +3180,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1109,5 +1109,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/readlink_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2896,5 +2896,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -377,5 +377,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/realpath_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2298,5 +2298,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1444,5 +1444,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/rm_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3486,5 +3486,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1070,5 +1070,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/rmdir_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2870,5 +2870,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1148,5 +1148,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/seq_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2925,5 +2925,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -539,5 +539,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sleep_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2555,5 +2555,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -3204,5 +3204,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -4660,5 +4660,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -239,5 +239,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sync_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1747,5 +1747,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1247,5 +1247,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tac_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2998,5 +2998,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1954,5 +1954,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tail_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3889,5 +3889,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1299,5 +1299,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tee_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3039,5 +3039,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1770,5 +1770,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3559,5 +3559,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1550,5 +1550,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3603,5 +3603,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1080,5 +1080,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tty_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2872,5 +2872,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1081,5 +1081,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uname_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2884,5 +2884,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1348,5 +1348,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uniq_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3193,5 +3193,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -408,5 +408,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/usleep_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2321,5 +2321,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2065,5 +2065,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uudecode_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3759,5 +3759,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1213,5 +1213,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uuencode_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3288,5 +3288,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1336,5 +1336,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3077,5 +3077,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1106,5 +1106,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/who_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3214,5 +3214,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -302,5 +302,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/whoami-incomplete_true-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2274,5 +2274,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }

--- a/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -315,5 +315,12 @@ int main()
       argv[i][j]=__VERIFIER_nondet_char();
   }
 
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+
+  // Free argv
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+
+  return res;
 }

--- a/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/yes_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2252,5 +2252,9 @@ int main()
     for(int j=0; j<10; ++j)
       argv[i][j]=__VERIFIER_nondet_char();
   }
-  return __main(argc, argv);
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(argv[i]);
+  free(argv);
+  return res;
 }


### PR DESCRIPTION
New PR to fix leaks on the busybox benchmarks.

Unfortunately, I had to change the preprocessed benchmarks by hand (I'll probably finish the competition with a CTS), as my version of gcc was changing a bunch of header's definition, including some structs. I don't think it's a good idea to change them a day before the deadline.
