### PR TITLE
fixed undefined behaviors in the benchmark pthread-numerical-integration_true-unreach-call from pthread-C-DAC

### DIFF
--- a/c/pthread-C-DAC/pthread-numerical-integration_true-unreach-call.c
+++ b/c/pthread-C-DAC/pthread-numerical-integration_true-unreach-call.c
@@ -17,6 +17,7 @@
 *******************************************************************************/
 /*                                                                                                                                                                                   Modifications are made to remove non-standard library depedencies by Yihao from VSL of University of Delaware.                                                                    **/
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int expr);
 extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 #include<pthread.h>
@@ -112,11 +113,13 @@ int main(int argc, char *argv[])
     {
       exit(-1);
     }
+    __VERIFIER_assume(numberOfIntervals>0);
+    /*
     if (numberOfIntervals == 0)
     {
         printf("\nNumber of Intervals are assumed to be 8");
         numberOfIntervals = 8;
-    }
+    }*/
     threads = (pthread_t *) malloc(sizeof(pthread_t) * numberOfIntervals);
     /* Calculate Interval Width. */
     intervalWidth = 1.0 / (double) numberOfIntervals;

--- a/c/pthread-C-DAC/pthread-numerical-integration_true-unreach-call.i
+++ b/c/pthread-C-DAC/pthread-numerical-integration_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int expr);
 extern int __VERIFIER_nondet_int(void);
 void __VERIFIER_assert(int cond) { if (!(cond)) { ERROR: __VERIFIER_error(); } return; }
 typedef unsigned char __u_char;
@@ -1361,11 +1362,13 @@ int main(int argc, char *argv[])
     {
       exit(-1);
     }
-    if (numberOfIntervals == 0)
+    __VERIFIER_assume(numberOfIntervals>0);
+    /*if (numberOfIntervals == 0)
     {
         printf("\nNumber of Intervals are assumed to be 8");
         numberOfIntervals = 8;
-    }
+	num_threads = numberOfIntervals ;
+    }*/
     threads = (pthread_t *) malloc(sizeof(pthread_t) * numberOfIntervals);
     intervalWidth = 1.0 / (double) numberOfIntervals;
     for (iCount = 0; iCount < num_threads; iCount++)


### PR DESCRIPTION
In this program, there are two int-type variables `numberOfIntervals` and `num_threads`, and `numberOfIntervals` is initialized as `__VERIFIER_nondet_int()`, and then `num_threads = numberOfIntervals`. Then `numberOfIntervals` is use as the size argument for `malloc`. The problem is that `__VERIFIER_nondet_int()` could return negative value in which case the `malloc` call would become undefined. 

The second problem is that when `__VERIFIER_nondet_int()` returns 0, `numberOfIntervals` will become 8 while `num_threads` remains 0. In this case, the allocated memory represented by `threads` will never be initialized, but in the second loop it would read `threads[iCount]`, which leads to undefined behavior.

I'm proposing to fix this by replacing `if (numberOfIntervals == 0){numberOfIntervals = 8}` with an assumption `__VERIFIER_assume(numberOfIntervals>0)`.

==== EXCERPT from code: pthread-C-DAC/pthread-numerical-integration_true-unreach-call.i/c ====

  **numberOfIntervals = __VERIFIER_nondet_int();**
    ... 
    **num_threads = numberOfIntervals ;**
    ...
    **if (numberOfIntervals == 0)**
    {
        printf("\nNumber of Intervals are assumed to be 8");
        **numberOfIntervals = 8;**
    }
    threads = (pthread_t *) malloc(sizeof(pthread_t) * numberOfIntervals);
    ...
    for (iCount = 0; iCount < num_threads; iCount++)
    {
        ret_count=pthread_create(&threads[iCount], &pta, (void *(*) (void *)) myPartOfCalc, (void *) iCount);
        ...
     }
    for (iCount = 0; iCount < numberOfIntervals; iCount++)
    {
        ret_count=pthread_join(threads[iCount], NULL);
        ...
    }