### PR TITLE
Fix uninitialized array in termination-crafted/Arrays02-EquivalentConstantIndices_true-no-overflow.c

### DIFF
--- a/c/termination-crafted/Arrays02-EquivalentConstantIndices_true-no-overflow.c
+++ b/c/termination-crafted/Arrays02-EquivalentConstantIndices_true-no-overflow.c
@@ -8,9 +8,7 @@ extern int __VERIFIER_nondet_int(void);
 int main() {
 	int a[1048];
 
-  for (int i = 0; i < 1048; i++) {
-    a[i] = __VERIFIER_nondet_int();
-  }
+	a[2] = __VERIFIER_nondet_int();
 
 	while (a[2] >= 0) {
 		a[2] = a[2] - 1;

--- a/c/termination-crafted/Arrays02-EquivalentConstantIndices_true-no-overflow.c
+++ b/c/termination-crafted/Arrays02-EquivalentConstantIndices_true-no-overflow.c
@@ -7,6 +7,11 @@ extern int __VERIFIER_nondet_int(void);
 
 int main() {
 	int a[1048];
+
+  for (int i = 0; i < 1048; i++) {
+    a[i] = __VERIFIER_nondet_int();
+  }
+
 	while (a[2] >= 0) {
 		a[2] = a[2] - 1;
 		a[1+1] = __VERIFIER_nondet_int();


### PR DESCRIPTION
There is a local array in `main` that is not initialized. This pull request fixes it.

I was wondering if I should keep the original file and add a label that indicates that there is undefined behavior inside it.