### PR TITLE
Overflows-MainControlFlow

### DIFF
--- a/c/Overflows-BitVectors.set
+++ b/c/Overflows-BitVectors.set
@@ -1,10 +1,2 @@
 signedintegeroverflow-regression/*_false-no-overflow.c.i
 signedintegeroverflow-regression/*_true-no-overflow.c.i
-termination-crafted/*_false-no-overflow*.c
-termination-crafted/*_true-no-overflow*.c
-
-termination-crafted-lit/*_false-no-overflow*.c
-termination-crafted-lit/*_true-no-overflow*.c
-
-termination-numeric/*_false-no-overflow*.c
-termination-numeric/*_true-no-overflow*.c

--- a/c/Overflows-MainControlFlow.cfg
+++ b/c/Overflows-MainControlFlow.cfg
@@ -1,0 +1,2 @@
+Description: Contains verification tasks for checking if variables of type signed integers overflow (undefined behavior).
+Architecture: 64 bit

--- a/c/Overflows-MainControlFlow.set
+++ b/c/Overflows-MainControlFlow.set
@@ -1,0 +1,8 @@
+termination-crafted/*_false-no-overflow*.c
+termination-crafted/*_true-no-overflow*.c
+
+termination-crafted-lit/*_false-no-overflow*.c
+termination-crafted-lit/*_true-no-overflow*.c
+
+termination-numeric/*_false-no-overflow*.c
+termination-numeric/*_true-no-overflow*.c


### PR DESCRIPTION
```
termination-crafted/*_false-no-overflow*.c
termination-crafted/*_true-no-overflow*.c

termination-crafted-lit/*_false-no-overflow*.c
termination-crafted-lit/*_true-no-overflow*.c

termination-numeric/*_false-no-overflow*.c
termination-numeric/*_true-no-overflow*.c
```

These files come from Termination-MainControlFlow in fact. Spliting these files from Overflows-Bitvectors to a new set Overflows-MainControlFlow can make the benchmarks more consistent