### PR TITLE
RFC: Add BusyBox false-valid-deref benchmarks

### DIFF
--- a/c/Systems_BusyBox_MemSafety.set
+++ b/c/Systems_BusyBox_MemSafety.set
@@ -1,4 +1,4 @@
-#busybox-1.22.0/*_false-valid-deref*.i
+busybox-1.22.0/*_false-valid-deref*.i
 #busybox-1.22.0/*_false-valid-free*.i
 #busybox-1.22.0/*_false-valid-memtrack*.i
 busybox-1.22.0/*_true-valid-memsafety*.i


### PR DESCRIPTION
The original versions of benchmarks recently fixed had been added to the
repository, but did not become part of any tasks. This commit would thus
introduce _additional_ (though not necessarily _new_) benchmarks.

The pull request is marked as request-for-comment in light of recent discussions on the mailing list. Please do not merge without consent from >1 jury member.