### PR TITLE
Fix underflows in termination-memory-alloca

### DIFF
--- a/c/termination-memory-alloca/b.05-alloca_true-termination_true-no-overflow.c
+++ b/c/termination-memory-alloca/b.05-alloca_true-termination_true-no-overflow.c
@@ -10,7 +10,8 @@ int test_fun(int x, int tmp)
     *x_ref = x;
     *tmp_ref = tmp;
     *tmp_ref = __VERIFIER_nondet_int();
-    while ((*x_ref > 0) && (*tmp_ref < 1073741824) && (x == 2*(*tmp_ref))) {
+    while ((*x_ref > 0) && (*tmp_ref >= 0) &&
+           (*tmp_ref < 1073741824) && (x == 2*(*tmp_ref))) {
         *x_ref = *x_ref - 1;
         *tmp_ref = __VERIFIER_nondet_int();
     }

--- a/c/termination-memory-alloca/b.05-alloca_true-termination_true-no-overflow.c.i
+++ b/c/termination-memory-alloca/b.05-alloca_true-termination_true-no-overflow.c.i
@@ -551,7 +551,8 @@ int test_fun(int x, int tmp)
     *x_ref = x;
     *tmp_ref = tmp;
     *tmp_ref = __VERIFIER_nondet_int();
-    while ((*x_ref > 0) && (*tmp_ref < 1073741824) && (x == 2*(*tmp_ref))) {
+    while ((*x_ref > 0) && (*tmp_ref >= 0) &&
+           (*tmp_ref < 1073741824) && (x == 2*(*tmp_ref))) {
         *x_ref = *x_ref - 1;
         *tmp_ref = __VERIFIER_nondet_int();
     }

--- a/c/termination-memory-alloca/b.09-no-inv_assume-alloca_true-termination_true-no-overflow.c
+++ b/c/termination-memory-alloca/b.09-no-inv_assume-alloca_true-termination_true-no-overflow.c
@@ -13,7 +13,7 @@ int test_fun(int x, int y)
     *c = 0;
     if (*x_ref <= 0 || *y_ref <= 0) {
         // replace assume
-        return *x_ref + *y_ref;
+        return 0;
     }
     while (!(*x_ref == 0)) {
         if (*x_ref > *y_ref) {

--- a/c/termination-memory-alloca/b.09-no-inv_assume-alloca_true-termination_true-no-overflow.c.i
+++ b/c/termination-memory-alloca/b.09-no-inv_assume-alloca_true-termination_true-no-overflow.c.i
@@ -553,7 +553,7 @@ int test_fun(int x, int y)
     *y_ref = y;
     *c = 0;
     if (*x_ref <= 0 || *y_ref <= 0) {
-        return *x_ref + *y_ref;
+        return 0;
     }
     while (!(*x_ref == 0)) {
         if (*x_ref > *y_ref) {

--- a/c/termination-memory-alloca/b.09_assume-alloca_true-termination_true-no-overflow.c
+++ b/c/termination-memory-alloca/b.09_assume-alloca_true-termination_true-no-overflow.c
@@ -13,7 +13,7 @@ int test_fun(int x, int y)
     *c = 0;
     if (*x_ref <= 0 || *y_ref <= 0) {
         // replace assume
-        return *x_ref + *y_ref;
+        return 0;
     }
     while (!(*x_ref == 0)) {
         if (*x_ref > *y_ref) {

--- a/c/termination-memory-alloca/b.09_assume-alloca_true-termination_true-no-overflow.c.i
+++ b/c/termination-memory-alloca/b.09_assume-alloca_true-termination_true-no-overflow.c.i
@@ -553,7 +553,7 @@ int test_fun(int x, int y)
     *y_ref = y;
     *c = 0;
     if (*x_ref <= 0 || *y_ref <= 0) {
-        return *x_ref + *y_ref;
+        return 0;
     }
     while (!(*x_ref == 0)) {
         if (*x_ref > *y_ref) {

--- a/c/termination-memory-alloca/b.18-alloca_true-termination_true-no-overflow.c
+++ b/c/termination-memory-alloca/b.18-alloca_true-termination_true-no-overflow.c
@@ -20,6 +20,11 @@ int test_fun(int x, int y)
             }
         }
     }
+
+    // do not underflow in INT_MIN + INT_MIN
+    if (*x_ref < 0 && *y_ref < 0)
+        return 0;
+
     return *x_ref + *y_ref;
 }
 

--- a/c/termination-memory-alloca/b.18-alloca_true-termination_true-no-overflow.c.i
+++ b/c/termination-memory-alloca/b.18-alloca_true-termination_true-no-overflow.c.i
@@ -561,6 +561,8 @@ int test_fun(int x, int y)
             }
         }
     }
+    if (*x_ref < 0 && *y_ref < 0)
+        return 0;
     return *x_ref + *y_ref;
 }
 int main() {


### PR DESCRIPTION
In these benchmarks, there can be possibly executed either 2*INT_MIN or INT_MIN + INT_MIN operations. More detailed reasoning about the fixes is in the commit messages.