### PR TITLE
Initialize array cells in rangesum tasks to fix undefined behavior.

### DIFF
--- a/c/reducercommutativity/rangesum05_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum05_false-unreach-call.c
@@ -14,6 +14,14 @@
 #define fun rangesum
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[N])
 {
@@ -36,6 +44,7 @@ int rangesum (int x[N])
 int main ()
 {
   int x[N];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum05_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum05_false-unreach-call.i
@@ -1,4 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[5]) {
+  int i;
+  for (i = 0; i < 5; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[5])
 {
@@ -21,6 +29,7 @@ int rangesum (int x[5])
 int main ()
 {
   int x[5];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum10_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum10_false-unreach-call.c
@@ -14,6 +14,14 @@
 #define fun rangesum
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[N])
 {
@@ -36,6 +44,7 @@ int rangesum (int x[N])
 int main ()
 {
   int x[N];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum10_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum10_false-unreach-call.i
@@ -1,4 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[10]) {
+  int i;
+  for (i = 0; i < 10; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[10])
 {
@@ -21,6 +29,7 @@ int rangesum (int x[10])
 int main ()
 {
   int x[10];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum20_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum20_false-unreach-call.c
@@ -14,6 +14,14 @@
 #define fun rangesum
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[N])
 {
@@ -36,6 +44,7 @@ int rangesum (int x[N])
 int main ()
 {
   int x[N];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum20_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum20_false-unreach-call.i
@@ -1,4 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[20]) {
+  int i;
+  for (i = 0; i < 20; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[20])
 {
@@ -21,6 +29,7 @@ int rangesum (int x[20])
 int main ()
 {
   int x[20];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum40_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum40_false-unreach-call.c
@@ -14,6 +14,14 @@
 #define fun rangesum
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[N])
 {
@@ -36,6 +44,7 @@ int rangesum (int x[N])
 int main ()
 {
   int x[N];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum40_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum40_false-unreach-call.i
@@ -1,4 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[40]) {
+  int i;
+  for (i = 0; i < 40; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[40])
 {
@@ -21,6 +29,7 @@ int rangesum (int x[40])
 int main ()
 {
   int x[40];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum60_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum60_false-unreach-call.c
@@ -14,6 +14,14 @@
 #define fun rangesum
 
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[N])
 {
@@ -36,6 +44,7 @@ int rangesum (int x[N])
 int main ()
 {
   int x[N];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum60_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum60_false-unreach-call.i
@@ -1,4 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+void init_nondet(int x[60]) {
+  int i;
+  for (i = 0; i < 60; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[60])
 {
@@ -21,6 +29,7 @@ int rangesum (int x[60])
 int main ()
 {
   int x[60];
+  init_nondet(x);
   int temp;
   int ret;
   int ret2;

--- a/c/reducercommutativity/rangesum_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum_false-unreach-call.c
@@ -17,6 +17,13 @@ extern int __VERIFIER_nondet_int(void);
 
 int N;
 
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
+
 int rangesum (int x[N])
 {
   int i;
@@ -40,6 +47,7 @@ int main ()
   N = __VERIFIER_nondet_int();
   if (N > 1) {
     int x[N];
+    init_nondet(x);
     int temp;
     int ret;
     int ret2;

--- a/c/reducercommutativity/rangesum_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum_false-unreach-call.i
@@ -2,6 +2,12 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern int __VERIFIER_nondet_int(void);
 
 int N;
+void init_nondet(int x[N]) {
+  int i;
+  for (i = 0; i < N; i++) {
+    x[i] == __VERIFIER_nondet_int();
+  }
+}
 
 int rangesum (int x[N])
 {
@@ -26,6 +32,7 @@ int main ()
   N = __VERIFIER_nondet_int();
   if (N > 1) {
     int x[N];
+    init_nondet(x);
     int temp;
     int ret;
     int ret2;


### PR DESCRIPTION
In #181, there was already an effort to fix undefined behavior in the tasks in c/reducercommutativity, but the rangesum tasks of this set were omitted.
I did not preserve the undefined behavior as an example task, because the directory already contains plenty, largely equivalent examples from #181.