### PR TITLE
Initialize the 'IN' variables in the floats-cdfpl tasks to remove undefined behavior

### DIFF
--- a/c/floats-cdfpl/newton_1_3_true-unreach-call.c
+++ b/c/floats-cdfpl/newton_1_3_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 3
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_3_true-unreach-call.i
+++ b/c/floats-cdfpl/newton_1_3_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -0.6f && IN < 0.6f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_4_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_1_4_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 4
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_4_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_1_4_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -0.8f && IN < 0.8f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_5_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_1_5_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 5
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_5_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_1_5_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.0f && IN < 1.0f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_6_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_1_6_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 6
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_6_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_1_6_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.2f && IN < 1.2f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_7_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_1_7_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 7
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_7_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_1_7_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.4f && IN < 1.4f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_8_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_1_8_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 8
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_1_8_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_1_8_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -2.0f && IN < 2.0f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_2_true-unreach-call.c
+++ b/c/floats-cdfpl/newton_2_2_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 2
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_2_true-unreach-call.i
+++ b/c/floats-cdfpl/newton_2_2_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -0.4f && IN < 0.4f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_3_true-unreach-call.c
+++ b/c/floats-cdfpl/newton_2_3_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 3
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_3_true-unreach-call.i
+++ b/c/floats-cdfpl/newton_2_3_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -0.6f && IN < 0.6f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_6_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_2_6_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 6
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_6_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_2_6_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.2f && IN < 1.2f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_7_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_2_7_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 7
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_7_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_2_7_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.4f && IN < 1.4f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_8_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_2_8_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 8
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_2_8_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_2_8_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -2.0f && IN < 2.0f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_3_true-unreach-call.c
+++ b/c/floats-cdfpl/newton_3_3_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 3
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_3_true-unreach-call.i
+++ b/c/floats-cdfpl/newton_3_3_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -0.6f && IN < 0.6f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_4_true-unreach-call.c
+++ b/c/floats-cdfpl/newton_3_4_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 4
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_4_true-unreach-call.i
+++ b/c/floats-cdfpl/newton_3_4_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -0.8f && IN < 0.8f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_6_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_3_6_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 6
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_6_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_3_6_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.2f && IN < 1.2f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_7_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_3_7_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 7
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_7_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_3_7_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.4f && IN < 1.4f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_8_false-unreach-call.c
+++ b/c/floats-cdfpl/newton_3_8_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 
 #define NR 8
 
@@ -39,7 +40,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -VAL && IN < VAL);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/newton_3_8_false-unreach-call.i
+++ b/c/floats-cdfpl/newton_3_8_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 float f(float x)
 {
   return x - (x*x*x)/6.0f + (x*x*x*x*x)/120.0f + (x*x*x*x*x*x*x)/5040.0f;
@@ -12,7 +13,7 @@ float fp(float x)
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -2.0f && IN < 2.0f);
 
   float x = IN - f(IN)/fp(IN);

--- a/c/floats-cdfpl/sine_1_false-unreach-call.c
+++ b/c/floats-cdfpl/sine_1_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 #define HALFPI 1.57079632679f
 
 #define NR 1
@@ -25,7 +26,7 @@ extern void __VERIFIER_assume(int);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -HALFPI && IN < HALFPI);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_1_false-unreach-call.i
+++ b/c/floats-cdfpl/sine_1_false-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.57079632679f && IN < 1.57079632679f);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_2_false-unreach-call.c
+++ b/c/floats-cdfpl/sine_2_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 #define HALFPI 1.57079632679f
 
 #define NR 2
@@ -25,7 +26,7 @@ extern void __VERIFIER_assume(int);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -HALFPI && IN < HALFPI);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_2_false-unreach-call.i
+++ b/c/floats-cdfpl/sine_2_false-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.57079632679f && IN < 1.57079632679f);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_3_false-unreach-call.c
+++ b/c/floats-cdfpl/sine_3_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 #define HALFPI 1.57079632679f
 
 #define NR 3
@@ -25,7 +26,7 @@ extern void __VERIFIER_assume(int);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -HALFPI && IN < HALFPI);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_3_false-unreach-call.i
+++ b/c/floats-cdfpl/sine_3_false-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.57079632679f && IN < 1.57079632679f);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_7_true-unreach-call.c
+++ b/c/floats-cdfpl/sine_7_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 #define HALFPI 1.57079632679f
 
 #define NR 7
@@ -25,7 +26,7 @@ extern void __VERIFIER_assume(int);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -HALFPI && IN < HALFPI);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_7_true-unreach-call.i
+++ b/c/floats-cdfpl/sine_7_true-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.57079632679f && IN < 1.57079632679f);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_8_true-unreach-call.c
+++ b/c/floats-cdfpl/sine_8_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 #define HALFPI 1.57079632679f
 
 #define NR 8
@@ -25,7 +26,7 @@ extern void __VERIFIER_assume(int);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -HALFPI && IN < HALFPI);
 
   float x = IN;

--- a/c/floats-cdfpl/sine_8_true-unreach-call.i
+++ b/c/floats-cdfpl/sine_8_true-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN > -1.57079632679f && IN < 1.57079632679f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_1_false-unreach-call.c
+++ b/c/floats-cdfpl/square_1_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 //APPROXIMATES sqroot(1+x)
 
 #define NR 1
@@ -25,7 +26,7 @@ extern void __VERIFIER_error(void);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_1_false-unreach-call.i
+++ b/c/floats-cdfpl/square_1_false-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_2_false-unreach-call.c
+++ b/c/floats-cdfpl/square_2_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 //APPROXIMATES sqroot(1+x)
 
 #define NR 2
@@ -25,7 +26,7 @@ extern void __VERIFIER_error(void);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_2_false-unreach-call.i
+++ b/c/floats-cdfpl/square_2_false-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_3_false-unreach-call.c
+++ b/c/floats-cdfpl/square_3_false-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 //APPROXIMATES sqroot(1+x)
 
 #define NR 3
@@ -25,7 +26,7 @@ extern void __VERIFIER_error(void);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_3_false-unreach-call.i
+++ b/c/floats-cdfpl/square_3_false-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_5_true-unreach-call.c
+++ b/c/floats-cdfpl/square_5_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 //APPROXIMATES sqroot(1+x)
 
 #define NR 5
@@ -25,7 +26,7 @@ extern void __VERIFIER_error(void);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_5_true-unreach-call.i
+++ b/c/floats-cdfpl/square_5_true-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_8_true-unreach-call.c
+++ b/c/floats-cdfpl/square_8_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 //APPROXIMATES sqroot(1+x)
 
 #define NR 8
@@ -25,7 +26,7 @@ extern void __VERIFIER_error(void);
 
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;

--- a/c/floats-cdfpl/square_8_true-unreach-call.i
+++ b/c/floats-cdfpl/square_8_true-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_error(void);
 extern void __VERIFIER_assume(int);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float IN;
+  float IN = __VERIFIER_nondet_float();
   __VERIFIER_assume(IN >= 0.0f && IN < 1.0f);
 
   float x = IN;


### PR DESCRIPTION
All tasks in floats-cdfpl contained the line `float IN;`. The variable was then always used without initialization. This causes undefined behavior.