### PR TITLE
Fix undefined behavior in systemc token-ring tasks

### DIFF
--- a/c/systemc/token_ring.01_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.01_false-unreach-call_false-termination.cil.c
@@ -29,7 +29,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.02_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.02_false-unreach-call_false-termination.cil.c
@@ -35,7 +35,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.03_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.03_false-unreach-call_false-termination.cil.c
@@ -41,7 +41,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.04_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.04_false-unreach-call_false-termination.cil.c
@@ -47,7 +47,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.05_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.05_false-unreach-call_false-termination.cil.c
@@ -53,7 +53,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.06_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.06_false-unreach-call_false-termination.cil.c
@@ -59,7 +59,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.07_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.07_false-unreach-call_false-termination.cil.c
@@ -65,7 +65,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.08_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.08_false-unreach-call_false-termination.cil.c
@@ -71,7 +71,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.09_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.09_false-unreach-call_false-termination.cil.c
@@ -77,7 +77,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.10_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.10_false-unreach-call_false-termination.cil.c
@@ -83,7 +83,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.11_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.11_false-unreach-call_false-termination.cil.c
@@ -89,7 +89,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.12_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.12_false-unreach-call_false-termination.cil.c
@@ -95,7 +95,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.13_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.13_false-unreach-call_false-termination.cil.c
@@ -101,7 +101,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.14_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.14_false-unreach-call_false-termination.cil.c
@@ -95,7 +95,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;

--- a/c/systemc/token_ring.15_false-unreach-call_false-termination.cil.c
+++ b/c/systemc/token_ring.15_false-unreach-call_false-termination.cil.c
@@ -101,7 +101,7 @@ int __VERIFIER_nondet_int()  ;
 int local  ;
 void master(void) 
 { 
-int tmp_var ;
+  int tmp_var = __VERIFIER_nondet_int();
   {
   if (m_pc == 0) {
     goto M_ENTRY;


### PR DESCRIPTION
The systemc token-ring tasks with verdict false-unreach-call contained uses of uninitialized variables declared as `int tmp_var ;`. This pull request fixes the undefined behavior caused by this by initializing the variables using `__VERIFIER_nondet_int()`.