### PR TITLE
Fix a bug from #451

### DIFF
--- a/c/reducercommutativity/rangesum05_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum05_false-unreach-call.c
@@ -19,7 +19,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum05_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum05_false-unreach-call.i
@@ -4,7 +4,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[5]) {
   int i;
   for (i = 0; i < 5; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum10_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum10_false-unreach-call.c
@@ -19,7 +19,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum10_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum10_false-unreach-call.i
@@ -4,7 +4,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[10]) {
   int i;
   for (i = 0; i < 10; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum20_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum20_false-unreach-call.c
@@ -19,7 +19,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum20_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum20_false-unreach-call.i
@@ -4,7 +4,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[20]) {
   int i;
   for (i = 0; i < 20; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum40_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum40_false-unreach-call.c
@@ -19,7 +19,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum40_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum40_false-unreach-call.i
@@ -4,7 +4,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[40]) {
   int i;
   for (i = 0; i < 40; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum60_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum60_false-unreach-call.c
@@ -19,7 +19,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum60_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum60_false-unreach-call.i
@@ -4,7 +4,7 @@ extern int __VERIFIER_nondet_int();
 void init_nondet(int x[60]) {
   int i;
   for (i = 0; i < 60; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum_false-unreach-call.c
+++ b/c/reducercommutativity/rangesum_false-unreach-call.c
@@ -20,7 +20,7 @@ int N;
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 

--- a/c/reducercommutativity/rangesum_false-unreach-call.i
+++ b/c/reducercommutativity/rangesum_false-unreach-call.i
@@ -5,7 +5,7 @@ int N;
 void init_nondet(int x[N]) {
   int i;
   for (i = 0; i < N; i++) {
-    x[i] == __VERIFIER_nondet_int();
+    x[i] = __VERIFIER_nondet_int();
   }
 }
 


### PR DESCRIPTION
Fix a bug from #451, where the instead of assignments, expression statements were used and the array cells were not actually initialized.