### PR TITLE
Fix undefined behavior in volatile_alias.c

### DIFF
--- a/c/ldv-regression/volatile_alias.c_true-unreach-call.i
+++ b/c/ldv-regression/volatile_alias.c_true-unreach-call.i
@@ -5,8 +5,8 @@ extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
 int main()
 {
-        int volatile a = 4;
-        int * p = &a;
+        int a = 4;
+        volatile int * p = &a;
         p = &a;
         a = a - 4;
         if (*p != 0){


### PR DESCRIPTION
There was an assignment of the address of a volatile int to an int*
pointer, loosing the volatile modifier.
To keep the original intention of the benchmark,
there is now an assignment of the address of an int to a volatile int*.

I inferred the original intent from https://github.com/sosy-lab/sv-benchmarks/blob/12874bd05c3373f3154518e5b60bf8a6598a9254/ldv-regression-1/volatile_alias.c#L1