### PR TITLE
heap-manipulation: resolve function pointer with unspecified arguments (#462)

### DIFF
--- a/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.c
+++ b/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.c
@@ -58,7 +58,7 @@ void dll_insert_slave(struct slave_item **dll)
     *dll = item;
 }
 
-void* dll_create_generic(void (*insert_fnc)())
+void* dll_create_generic(void (*insert_fnc)(void **dll))
 {
     void *dll = NULL;
     insert_fnc(&dll);

--- a/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.c
+++ b/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.c
@@ -47,7 +47,8 @@ struct master_item* alloc_or_die_master(void)
     return ptr;
 }
 
-void dll_insert_slave(struct slave_item **dll)
+// the argument should be of type 'struct slave_item**'
+void dll_insert_slave(void **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
     struct slave_item *next = *dll;
@@ -58,7 +59,7 @@ void dll_insert_slave(struct slave_item **dll)
     *dll = item;
 }
 
-void* dll_create_generic(void (*insert_fnc)(void **dll))
+void* dll_create_generic(void (*insert_fnc)(void**))
 {
     void *dll = NULL;
     insert_fnc(&dll);
@@ -109,7 +110,8 @@ void dll_destroy_master(struct master_item *dll)
     }
 }
 
-void dll_insert_master(struct master_item **dll)
+// the argument should be of type 'struct master_item**'
+void dll_insert_master(void **dll)
 {
     struct master_item *item = alloc_or_die_master();
     struct master_item *next = *dll;

--- a/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
+++ b/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
@@ -1241,7 +1241,8 @@ struct master_item* alloc_or_die_master(void)
     return ptr;
 }
 
-void dll_insert_slave(struct slave_item **dll)
+
+void dll_insert_slave(void **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
     struct slave_item *next = *dll;
@@ -1252,12 +1253,12 @@ void dll_insert_slave(struct slave_item **dll)
     *dll = item;
 }
 
-void* dll_create_generic(void (*insert_fnc)(void **dll))
+void* dll_create_generic(void (*insert_fnc)(void**))
 {
     void *dll = 
-# 63 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+# 64 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
                ((void *)0)
-# 63 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+# 64 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
                    ;
     insert_fnc(&dll);
     insert_fnc(&dll);
@@ -1294,9 +1295,9 @@ void dll_reinit_nested_lists(struct master_item *dll)
 {
     while (dll) {
         dll->slave = 
-# 98 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+# 99 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
                     ((void *)0)
-# 98 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+# 99 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
                         ;
         dll = dll->next;
     }
@@ -1311,7 +1312,8 @@ void dll_destroy_master(struct master_item *dll)
     }
 }
 
-void dll_insert_master(struct master_item **dll)
+
+void dll_insert_master(void **dll)
 {
     struct master_item *item = alloc_or_die_master();
     struct master_item *next = *dll;

--- a/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
+++ b/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
@@ -1,83 +1,24 @@
-# 1 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
-# 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
-# 1 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-# 1 "/usr/include/stdlib.h" 1 3 4
-# 24 "/usr/include/stdlib.h" 3 4
-# 1 "/usr/include/features.h" 1 3 4
-# 364 "/usr/include/features.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 1 3 4
-# 415 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 416 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 2 3 4
-# 365 "/usr/include/features.h" 2 3 4
-# 388 "/usr/include/features.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 1 3 4
-# 10 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs-64.h" 1 3 4
-# 11 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 2 3 4
-# 389 "/usr/include/features.h" 2 3 4
-# 25 "/usr/include/stdlib.h" 2 3 4
-
-
-
-
-
-
-
-# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
-# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
-
-# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
 typedef long unsigned int size_t;
-# 328 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
 typedef int wchar_t;
-# 33 "/usr/include/stdlib.h" 2 3 4
 
-
-
-
-
-
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 1 3 4
-# 50 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 3 4
 typedef enum
 {
   P_ALL,
   P_PID,
   P_PGID
 } idtype_t;
-# 42 "/usr/include/stdlib.h" 2 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/waitstatus.h" 1 3 4
-# 43 "/usr/include/stdlib.h" 2 3 4
-# 56 "/usr/include/stdlib.h" 3 4
-
 
 typedef struct
   {
     int quot;
     int rem;
   } div_t;
-
-
-
 typedef struct
   {
     long int quot;
     long int rem;
   } ldiv_t;
-
-
-
-
-
 
 
 __extension__ typedef struct
@@ -86,31 +27,18 @@ __extension__ typedef struct
     long long int rem;
   } lldiv_t;
 
-
-# 100 "/usr/include/stdlib.h" 3 4
 extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
-
-
-
 
 extern double atof (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
 extern int atoi (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
 extern long int atol (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
 
 
-
-
-
 __extension__ extern long long int atoll (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
-
-
 
 
 extern double strtod (const char *__restrict __nptr,
@@ -118,104 +46,56 @@ extern double strtod (const char *__restrict __nptr,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
-
-
-
 extern float strtof (const char *__restrict __nptr,
        char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 extern long double strtold (const char *__restrict __nptr,
        char **__restrict __endptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
-
-
-
 extern long int strtol (const char *__restrict __nptr,
    char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 extern unsigned long int strtoul (const char *__restrict __nptr,
       char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
 
 __extension__
 extern long long int strtoq (const char *__restrict __nptr,
         char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 __extension__
 extern unsigned long long int strtouq (const char *__restrict __nptr,
            char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-
-
-
-
 __extension__
 extern long long int strtoll (const char *__restrict __nptr,
          char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 __extension__
 extern unsigned long long int strtoull (const char *__restrict __nptr,
      char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-# 266 "/usr/include/stdlib.h" 3 4
 extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
-
-
 extern long int a64l (const char *__s)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
-
-
-
-# 1 "/usr/include/x86_64-linux-gnu/sys/types.h" 1 3 4
-# 27 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/types.h" 1 3 4
-# 27 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 28 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
-
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
 typedef unsigned long int __u_long;
-
-
 typedef signed char __int8_t;
 typedef unsigned char __uint8_t;
 typedef signed short int __int16_t;
 typedef unsigned short int __uint16_t;
 typedef signed int __int32_t;
 typedef unsigned int __uint32_t;
-
 typedef signed long int __int64_t;
 typedef unsigned long int __uint64_t;
-
-
-
-
-
-
-
 typedef long int __quad_t;
 typedef unsigned long int __u_quad_t;
-# 121 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/typesizes.h" 1 3 4
-# 122 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
-
-
 typedef unsigned long int __dev_t;
 typedef unsigned int __uid_t;
 typedef unsigned int __gid_t;
@@ -234,58 +114,26 @@ typedef unsigned int __id_t;
 typedef long int __time_t;
 typedef unsigned int __useconds_t;
 typedef long int __suseconds_t;
-
 typedef int __daddr_t;
 typedef int __key_t;
-
-
 typedef int __clockid_t;
-
-
 typedef void * __timer_t;
-
-
 typedef long int __blksize_t;
-
-
-
-
 typedef long int __blkcnt_t;
 typedef long int __blkcnt64_t;
-
-
 typedef unsigned long int __fsblkcnt_t;
 typedef unsigned long int __fsblkcnt64_t;
-
-
 typedef unsigned long int __fsfilcnt_t;
 typedef unsigned long int __fsfilcnt64_t;
-
-
 typedef long int __fsword_t;
-
 typedef long int __ssize_t;
-
-
 typedef long int __syscall_slong_t;
-
 typedef unsigned long int __syscall_ulong_t;
-
-
-
 typedef __off64_t __loff_t;
 typedef __quad_t *__qaddr_t;
 typedef char *__caddr_t;
-
-
 typedef long int __intptr_t;
-
-
 typedef unsigned int __socklen_t;
-# 30 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
 typedef __u_char u_char;
 typedef __u_short u_short;
 typedef __u_int u_int;
@@ -293,244 +141,85 @@ typedef __u_long u_long;
 typedef __quad_t quad_t;
 typedef __u_quad_t u_quad_t;
 typedef __fsid_t fsid_t;
-
-
-
-
 typedef __loff_t loff_t;
-
-
-
 typedef __ino_t ino_t;
-# 60 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __dev_t dev_t;
-
-
-
-
 typedef __gid_t gid_t;
-
-
-
-
 typedef __mode_t mode_t;
-
-
-
-
 typedef __nlink_t nlink_t;
-
-
-
-
 typedef __uid_t uid_t;
-
-
-
-
-
 typedef __off_t off_t;
-# 98 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __pid_t pid_t;
-
-
-
-
-
 typedef __id_t id_t;
-
-
-
-
 typedef __ssize_t ssize_t;
-
-
-
-
-
 typedef __daddr_t daddr_t;
 typedef __caddr_t caddr_t;
-
-
-
-
-
 typedef __key_t key_t;
-# 132 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/include/time.h" 1 3 4
-# 57 "/usr/include/time.h" 3 4
-
 
 typedef __clock_t clock_t;
 
 
 
-# 73 "/usr/include/time.h" 3 4
-
-
 typedef __time_t time_t;
 
 
-
-# 91 "/usr/include/time.h" 3 4
 typedef __clockid_t clockid_t;
-# 103 "/usr/include/time.h" 3 4
 typedef __timer_t timer_t;
-# 133 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-# 146 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
-# 147 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
 typedef unsigned long int ulong;
 typedef unsigned short int ushort;
 typedef unsigned int uint;
-# 194 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef int int8_t __attribute__ ((__mode__ (__QI__)));
 typedef int int16_t __attribute__ ((__mode__ (__HI__)));
 typedef int int32_t __attribute__ ((__mode__ (__SI__)));
 typedef int int64_t __attribute__ ((__mode__ (__DI__)));
-
-
 typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
 typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
 typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
 typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
-
 typedef int register_t __attribute__ ((__mode__ (__word__)));
-# 216 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/include/endian.h" 1 3 4
-# 36 "/usr/include/endian.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/endian.h" 1 3 4
-# 37 "/usr/include/endian.h" 2 3 4
-# 60 "/usr/include/endian.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 1 3 4
-# 28 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 29 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
-
-
-
-
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap-16.h" 1 3 4
-# 36 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
-# 44 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
 static __inline unsigned int
 __bswap_32 (unsigned int __bsx)
 {
   return __builtin_bswap32 (__bsx);
 }
-# 108 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
 static __inline __uint64_t
 __bswap_64 (__uint64_t __bsx)
 {
   return __builtin_bswap64 (__bsx);
 }
-# 61 "/usr/include/endian.h" 2 3 4
-# 217 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/sys/select.h" 1 3 4
-# 30 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/select.h" 1 3 4
-# 22 "/usr/include/x86_64-linux-gnu/bits/select.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 23 "/usr/include/x86_64-linux-gnu/bits/select.h" 2 3 4
-# 31 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 1 3 4
-# 22 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 3 4
 typedef int __sig_atomic_t;
-
-
-
-
 typedef struct
   {
     unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
   } __sigset_t;
-# 34 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-
-
 typedef __sigset_t sigset_t;
-
-
-
-
-
-
-
-# 1 "/usr/include/time.h" 1 3 4
-# 120 "/usr/include/time.h" 3 4
 struct timespec
   {
     __time_t tv_sec;
     __syscall_slong_t tv_nsec;
   };
-# 46 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/time.h" 1 3 4
-# 30 "/usr/include/x86_64-linux-gnu/bits/time.h" 3 4
 struct timeval
   {
     __time_t tv_sec;
     __suseconds_t tv_usec;
   };
-# 48 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-
 typedef __suseconds_t suseconds_t;
-
-
-
-
-
 typedef long int __fd_mask;
-# 66 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 typedef struct
   {
-
-
-
-
-
-
     __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
-
-
   } fd_set;
-
-
-
-
-
-
 typedef __fd_mask fd_mask;
-# 98 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 
-# 108 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int select (int __nfds, fd_set *__restrict __readfds,
      fd_set *__restrict __writefds,
      fd_set *__restrict __exceptfds,
      struct timeval *__restrict __timeout);
-# 120 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int pselect (int __nfds, fd_set *__restrict __readfds,
       fd_set *__restrict __writefds,
       fd_set *__restrict __exceptfds,
       const struct timespec *__restrict __timeout,
       const __sigset_t *__restrict __sigmask);
-# 133 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
-
-# 220 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 1 3 4
-# 24 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
 
 
 __extension__
@@ -543,57 +232,23 @@ __extension__
 extern unsigned long long int gnu_dev_makedev (unsigned int __major,
             unsigned int __minor)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
-# 58 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
-
-# 223 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
-
 
 typedef __blksize_t blksize_t;
-
-
-
-
-
-
 typedef __blkcnt_t blkcnt_t;
-
-
-
 typedef __fsblkcnt_t fsblkcnt_t;
-
-
-
 typedef __fsfilcnt_t fsfilcnt_t;
-# 270 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 1 3 4
-# 21 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 22 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 2 3 4
-# 60 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef unsigned long int pthread_t;
-
-
 union pthread_attr_t
 {
   char __size[56];
   long int __align;
 };
-
 typedef union pthread_attr_t pthread_attr_t;
-
-
-
-
-
 typedef struct __pthread_internal_list
 {
   struct __pthread_internal_list *__prev;
   struct __pthread_internal_list *__next;
 } __pthread_list_t;
-# 90 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef union
 {
   struct __pthread_mutex_s
@@ -601,31 +256,20 @@ typedef union
     int __lock;
     unsigned int __count;
     int __owner;
-
     unsigned int __nusers;
-
-
-
     int __kind;
-
     short __spins;
     short __elision;
     __pthread_list_t __list;
-# 125 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
   } __data;
   char __size[40];
   long int __align;
 } pthread_mutex_t;
-
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_mutexattr_t;
-
-
-
-
 typedef union
 {
   struct
@@ -642,28 +286,15 @@ typedef union
   char __size[48];
   __extension__ long long int __align;
 } pthread_cond_t;
-
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_condattr_t;
-
-
-
 typedef unsigned int pthread_key_t;
-
-
-
 typedef int pthread_once_t;
-
-
-
-
-
 typedef union
 {
-
   struct
   {
     int __lock;
@@ -675,83 +306,35 @@ typedef union
     int __writer;
     int __shared;
     signed char __rwelision;
-
-
-
-
     unsigned char __pad1[7];
-
-
     unsigned long int __pad2;
-
-
     unsigned int __flags;
-
   } __data;
-# 220 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
   char __size[56];
   long int __align;
 } pthread_rwlock_t;
-
 typedef union
 {
   char __size[8];
   long int __align;
 } pthread_rwlockattr_t;
-
-
-
-
-
 typedef volatile int pthread_spinlock_t;
-
-
-
-
 typedef union
 {
   char __size[32];
   long int __align;
 } pthread_barrier_t;
-
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_barrierattr_t;
-# 271 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
-# 276 "/usr/include/stdlib.h" 2 3 4
-
-
-
-
-
 
 extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
-
-
 extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
-
-
 extern char *initstate (unsigned int __seed, char *__statebuf,
    size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
-
-
 extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
-
 struct random_data
   {
     int32_t *fptr;
@@ -762,65 +345,34 @@ struct random_data
     int rand_sep;
     int32_t *end_ptr;
   };
-
 extern int random_r (struct random_data *__restrict __buf,
        int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
 extern int srandom_r (unsigned int __seed, struct random_data *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
 extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
    size_t __statelen,
    struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
-
 extern int setstate_r (char *__restrict __statebuf,
          struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
-
-
-
-
-
 extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
-
 extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-
 extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
-
-
-
-
 extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
 extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int nrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
 extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int jrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
 extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
 extern unsigned short int *seed48 (unsigned short int __seed16v[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
 struct drand48_data
   {
     unsigned short int __x[3];
@@ -828,17 +380,12 @@ struct drand48_data
     unsigned short int __c;
     unsigned short int __init;
     __extension__ unsigned long long int __a;
-
   };
-
-
 extern int drand48_r (struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern int erand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
-
 extern int lrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -846,8 +393,6 @@ extern int nrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
-
 extern int mrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -855,219 +400,75 @@ extern int jrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
-
 extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
 extern int seed48_r (unsigned short int __seed16v[3],
        struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
 extern int lcong48_r (unsigned short int __param[7],
         struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
-
-
-
-
-
-
-
-
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
-
 extern void *calloc (size_t __nmemb, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 
 
-
-
-
-
-
-
-
-
 extern void *realloc (void *__ptr, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
-
 extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
 
 extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-# 1 "/usr/include/alloca.h" 1 3 4
-# 24 "/usr/include/alloca.h" 3 4
-# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
-# 25 "/usr/include/alloca.h" 2 3 4
-
-
-
-
-
-
-
 extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-
-
-
-# 454 "/usr/include/stdlib.h" 2 3 4
-
-
-
-
-
 extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
-
-
-
-
 extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
-
-
-
-
 extern void *aligned_alloc (size_t __alignment, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
 
-
-
-
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-
-
 extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
-
 extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
 
 extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-
-
-
-
-
 extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-
-
-
-
 extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-
-
-
-
 
 
 extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
-
-
-
-
 extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
 
-# 539 "/usr/include/stdlib.h" 3 4
 extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
 extern int setenv (const char *__name, const char *__value, int __replace)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
-
 extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
 extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
-# 567 "/usr/include/stdlib.h" 3 4
 extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-# 580 "/usr/include/stdlib.h" 3 4
 extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
-# 602 "/usr/include/stdlib.h" 3 4
 extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
-# 623 "/usr/include/stdlib.h" 3 4
 extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
-# 672 "/usr/include/stdlib.h" 3 4
-
-
-
-
 
 extern int system (const char *__command) ;
 
-# 694 "/usr/include/stdlib.h" 3 4
 extern char *realpath (const char *__restrict __name,
          char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
-
-
-
-
-
-
 typedef int (*__compar_fn_t) (const void *, const void *);
-# 712 "/usr/include/stdlib.h" 3 4
-
-
 
 extern void *bsearch (const void *__key, const void *__base,
         size_t __nmemb, size_t __size, __compar_fn_t __compar)
      __attribute__ ((__nonnull__ (1, 2, 5))) ;
-
-
-
-
-
-
-
 extern void qsort (void *__base, size_t __nmemb, size_t __size,
      __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
-# 735 "/usr/include/stdlib.h" 3 4
 extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
-
-
 __extension__ extern long long int llabs (long long int __x)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
-
-
-
-
-
-
 
 extern div_t div (int __numer, int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
@@ -1075,31 +476,16 @@ extern ldiv_t ldiv (long int __numer, long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
 
-
-
 __extension__ extern lldiv_t lldiv (long long int __numer,
         long long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
-# 772 "/usr/include/stdlib.h" 3 4
 extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
-
-
-
-
 extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
-
-
-
-
 extern char *gcvt (double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
-
-
-
-
 extern char *qecvt (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
@@ -1108,17 +494,12 @@ extern char *qfcvt (long double __value, int __ndigit,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
 extern char *qgcvt (long double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
-
-
-
-
 extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
-
 extern int qecvt_r (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign,
       char *__restrict __buf, size_t __len)
@@ -1128,120 +509,56 @@ extern int qfcvt_r (long double __value, int __ndigit,
       char *__restrict __buf, size_t __len)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 
-
-
-
-
-
 extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
-
-
 extern int mbtowc (wchar_t *__restrict __pwc,
      const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
-
-
 extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
 extern size_t mbstowcs (wchar_t *__restrict __pwcs,
    const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
-
 extern size_t wcstombs (char *__restrict __s,
    const wchar_t *__restrict __pwcs, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-
-
-
-
-
 extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
-# 859 "/usr/include/stdlib.h" 3 4
 extern int getsubopt (char **__restrict __optionp,
         char *const *__restrict __tokens,
         char **__restrict __valuep)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
-# 911 "/usr/include/stdlib.h" 3 4
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-# 921 "/usr/include/stdlib.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/stdlib-float.h" 1 3 4
-# 922 "/usr/include/stdlib.h" 2 3 4
-# 934 "/usr/include/stdlib.h" 3 4
 
-# 4 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 2
-
-
-# 5 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
 extern int __VERIFIER_nondet_int(void);
-
 static void fail(void) {
 ERROR: __VERIFIER_error();
 }
-
-
-
-
-
-
 struct slave_item {
     struct slave_item *next;
     struct slave_item *prev;
 };
-
 struct slave_item* alloc_or_die_slave(void)
 {
     struct slave_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-
-    ptr->next = 
-# 27 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-               ((void *)0)
-# 27 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                   ;
-    ptr->next = 
-# 28 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-               ((void *)0)
-# 28 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                   ;
+    ptr->next = ((void *)0);
+    ptr->next = ((void *)0);
     return ptr;
 }
-
 struct master_item {
     struct master_item *next;
     struct master_item *prev;
     struct slave_item *slave;
 };
-
 struct master_item* alloc_or_die_master(void)
 {
     struct master_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-
-    ptr->next = 
-# 44 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-               ((void *)0)
-# 44 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                   ;
-    ptr->prev = 
-# 45 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-               ((void *)0)
-# 45 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                   ;
-    ptr->slave = 
-# 46 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-                ((void *)0)
-# 46 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                    ;
+    ptr->next = ((void *)0);
+    ptr->prev = ((void *)0);
+    ptr->slave = ((void *)0);
     return ptr;
 }
-
-
 void dll_insert_slave(void **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
@@ -1249,31 +566,21 @@ void dll_insert_slave(void **dll)
     item->next = next;
     if (next)
         next->prev = item;
-
     *dll = item;
 }
-
 void* dll_create_generic(void (*insert_fnc)(void**))
 {
-    void *dll = 
-# 64 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-               ((void *)0)
-# 64 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                   ;
+    void *dll = ((void *)0);
     insert_fnc(&dll);
     insert_fnc(&dll);
-
     while (__VERIFIER_nondet_int())
         insert_fnc(&dll);
-
     return dll;
 }
-
 struct slave_item* dll_create_slave(void)
 {
     return dll_create_generic(dll_insert_slave);
 }
-
 void dll_destroy_slave(struct slave_item *dll)
 {
     while (dll) {
@@ -1282,7 +589,6 @@ void dll_destroy_slave(struct slave_item *dll)
         dll = next;
     }
 }
-
 void dll_destroy_nested_lists(struct master_item *dll)
 {
     while (dll) {
@@ -1290,19 +596,13 @@ void dll_destroy_nested_lists(struct master_item *dll)
         dll = dll->next;
     }
 }
-
 void dll_reinit_nested_lists(struct master_item *dll)
 {
     while (dll) {
-        dll->slave = 
-# 99 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
-                    ((void *)0)
-# 99 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
-                        ;
+        dll->slave = ((void *)0);
         dll = dll->next;
     }
 }
-
 void dll_destroy_master(struct master_item *dll)
 {
     while (dll) {
@@ -1311,8 +611,6 @@ void dll_destroy_master(struct master_item *dll)
         dll = next;
     }
 }
-
-
 void dll_insert_master(void **dll)
 {
     struct master_item *item = alloc_or_die_master();
@@ -1320,39 +618,32 @@ void dll_insert_master(void **dll)
     item->next = next;
     if (next)
         next->prev = item;
-
     item->slave = dll_create_slave();
     *dll = item;
 }
-
 struct master_item* dll_create_master(void)
 {
     return dll_create_generic(dll_insert_master);
 }
-
 void inspect_base(struct master_item *dll)
 {
     do { if (!(dll)) fail(); } while (0);
     do { if (!(dll->next)) fail(); } while (0);
     do { if (!(!dll->prev)) fail(); } while (0);
-
     for (dll = dll->next; dll; dll = dll->next) {
         do { if (!(dll->prev)) fail(); } while (0);
         do { if (!(dll->prev->next)) fail(); } while (0);
         do { if (!(dll->prev->next == dll)) fail(); } while (0);
     }
 }
-
 void inspect_full(struct master_item *dll)
 {
     inspect_base(dll);
-
     for (; dll; dll = dll->next) {
         struct slave_item *pos = dll->slave;
         do { if (!(pos)) fail(); } while (0);
         do { if (!(pos->next)) fail(); } while (0);
         do { if (!(!pos->prev)) fail(); } while (0);
-
         for (pos = pos->next; pos; pos = pos->next) {
             do { if (!(pos->prev)) fail(); } while (0);
             do { if (!(pos->prev->next)) fail(); } while (0);
@@ -1360,35 +651,26 @@ void inspect_full(struct master_item *dll)
         }
     }
 }
-
 void inspect_dangling(struct master_item *dll)
 {
     inspect_base(dll);
-
     for (; dll; dll = dll->next)
         do { if (!(dll->slave)) fail(); } while (0);
 }
-
 void inspect_init(struct master_item *dll)
 {
     inspect_base(dll);
-
     for (; dll; dll = dll->next)
         do { if (!(!dll->slave)) fail(); } while (0);
 }
-
 int main()
 {
     struct master_item *dll = dll_create_master();
     inspect_full(dll);
-
     dll_destroy_nested_lists(dll);
     inspect_dangling(dll);
-
     dll_reinit_nested_lists(dll);
     inspect_init(dll);
-
-
     dll_destroy_master(dll);
     return 0;
 }

--- a/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
+++ b/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-typedef long unsigned int size_t;
-typedef int wchar_t;
+typedef unsigned int size_t;
+typedef long int wchar_t;
 
 typedef enum
 {
@@ -92,48 +92,48 @@ typedef signed short int __int16_t;
 typedef unsigned short int __uint16_t;
 typedef signed int __int32_t;
 typedef unsigned int __uint32_t;
-typedef signed long int __int64_t;
-typedef unsigned long int __uint64_t;
-typedef long int __quad_t;
-typedef unsigned long int __u_quad_t;
-typedef unsigned long int __dev_t;
-typedef unsigned int __uid_t;
-typedef unsigned int __gid_t;
-typedef unsigned long int __ino_t;
-typedef unsigned long int __ino64_t;
-typedef unsigned int __mode_t;
-typedef unsigned long int __nlink_t;
-typedef long int __off_t;
-typedef long int __off64_t;
-typedef int __pid_t;
-typedef struct { int __val[2]; } __fsid_t;
-typedef long int __clock_t;
-typedef unsigned long int __rlim_t;
-typedef unsigned long int __rlim64_t;
-typedef unsigned int __id_t;
-typedef long int __time_t;
-typedef unsigned int __useconds_t;
-typedef long int __suseconds_t;
-typedef int __daddr_t;
-typedef int __key_t;
-typedef int __clockid_t;
-typedef void * __timer_t;
-typedef long int __blksize_t;
-typedef long int __blkcnt_t;
-typedef long int __blkcnt64_t;
-typedef unsigned long int __fsblkcnt_t;
-typedef unsigned long int __fsblkcnt64_t;
-typedef unsigned long int __fsfilcnt_t;
-typedef unsigned long int __fsfilcnt64_t;
-typedef long int __fsword_t;
-typedef long int __ssize_t;
-typedef long int __syscall_slong_t;
-typedef unsigned long int __syscall_ulong_t;
+__extension__ typedef signed long long int __int64_t;
+__extension__ typedef unsigned long long int __uint64_t;
+__extension__ typedef long long int __quad_t;
+__extension__ typedef unsigned long long int __u_quad_t;
+__extension__ typedef __u_quad_t __dev_t;
+__extension__ typedef unsigned int __uid_t;
+__extension__ typedef unsigned int __gid_t;
+__extension__ typedef unsigned long int __ino_t;
+__extension__ typedef __u_quad_t __ino64_t;
+__extension__ typedef unsigned int __mode_t;
+__extension__ typedef unsigned int __nlink_t;
+__extension__ typedef long int __off_t;
+__extension__ typedef __quad_t __off64_t;
+__extension__ typedef int __pid_t;
+__extension__ typedef struct { int __val[2]; } __fsid_t;
+__extension__ typedef long int __clock_t;
+__extension__ typedef unsigned long int __rlim_t;
+__extension__ typedef __u_quad_t __rlim64_t;
+__extension__ typedef unsigned int __id_t;
+__extension__ typedef long int __time_t;
+__extension__ typedef unsigned int __useconds_t;
+__extension__ typedef long int __suseconds_t;
+__extension__ typedef int __daddr_t;
+__extension__ typedef int __key_t;
+__extension__ typedef int __clockid_t;
+__extension__ typedef void * __timer_t;
+__extension__ typedef long int __blksize_t;
+__extension__ typedef long int __blkcnt_t;
+__extension__ typedef __quad_t __blkcnt64_t;
+__extension__ typedef unsigned long int __fsblkcnt_t;
+__extension__ typedef __u_quad_t __fsblkcnt64_t;
+__extension__ typedef unsigned long int __fsfilcnt_t;
+__extension__ typedef __u_quad_t __fsfilcnt64_t;
+__extension__ typedef int __fsword_t;
+__extension__ typedef int __ssize_t;
+__extension__ typedef long int __syscall_slong_t;
+__extension__ typedef unsigned long int __syscall_ulong_t;
 typedef __off64_t __loff_t;
 typedef __quad_t *__qaddr_t;
 typedef char *__caddr_t;
-typedef long int __intptr_t;
-typedef unsigned int __socklen_t;
+__extension__ typedef int __intptr_t;
+__extension__ typedef unsigned int __socklen_t;
 typedef __u_char u_char;
 typedef __u_short u_short;
 typedef __u_int u_int;
@@ -240,15 +240,14 @@ typedef __fsfilcnt_t fsfilcnt_t;
 typedef unsigned long int pthread_t;
 union pthread_attr_t
 {
-  char __size[56];
+  char __size[36];
   long int __align;
 };
 typedef union pthread_attr_t pthread_attr_t;
-typedef struct __pthread_internal_list
+typedef struct __pthread_internal_slist
 {
-  struct __pthread_internal_list *__prev;
-  struct __pthread_internal_list *__next;
-} __pthread_list_t;
+  struct __pthread_internal_slist *__next;
+} __pthread_slist_t;
 typedef union
 {
   struct __pthread_mutex_s
@@ -256,13 +255,19 @@ typedef union
     int __lock;
     unsigned int __count;
     int __owner;
-    unsigned int __nusers;
     int __kind;
-    short __spins;
-    short __elision;
-    __pthread_list_t __list;
+    unsigned int __nusers;
+    __extension__ union
+    {
+      struct
+      {
+ short __espins;
+ short __elision;
+      } __elision_data;
+      __pthread_slist_t __list;
+    };
   } __data;
-  char __size[40];
+  char __size[24];
   long int __align;
 } pthread_mutex_t;
 typedef union
@@ -303,14 +308,13 @@ typedef union
     unsigned int __writer_wakeup;
     unsigned int __nr_readers_queued;
     unsigned int __nr_writers_queued;
-    int __writer;
-    int __shared;
+    unsigned char __flags;
+    unsigned char __shared;
     signed char __rwelision;
-    unsigned char __pad1[7];
-    unsigned long int __pad2;
-    unsigned int __flags;
+    unsigned char __pad2;
+    int __writer;
   } __data;
-  char __size[56];
+  char __size[32];
   long int __align;
 } pthread_rwlock_t;
 typedef union
@@ -321,7 +325,7 @@ typedef union
 typedef volatile int pthread_spinlock_t;
 typedef union
 {
-  char __size[32];
+  char __size[20];
   long int __align;
 } pthread_barrier_t;
 typedef union

--- a/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
+++ b/c/heap-manipulation/dll_of_dll_false-unreach-call_false-valid-memcleanup.i
@@ -1,108 +1,83 @@
+# 1 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 31 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 32 "<command-line>" 2
+# 1 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-typedef unsigned int size_t;
-typedef long int wchar_t;
 
+# 1 "/usr/include/stdlib.h" 1 3 4
+# 24 "/usr/include/stdlib.h" 3 4
+# 1 "/usr/include/features.h" 1 3 4
+# 364 "/usr/include/features.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 1 3 4
+# 415 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 416 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 2 3 4
+# 365 "/usr/include/features.h" 2 3 4
+# 388 "/usr/include/features.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 1 3 4
+# 10 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs-64.h" 1 3 4
+# 11 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 2 3 4
+# 389 "/usr/include/features.h" 2 3 4
+# 25 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
+
+
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
+# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
+
+# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
+typedef long unsigned int size_t;
+# 328 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
+typedef int wchar_t;
+# 33 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 1 3 4
+# 50 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 3 4
 typedef enum
 {
   P_ALL,
   P_PID,
   P_PGID
 } idtype_t;
-typedef unsigned char __u_char;
-typedef unsigned short int __u_short;
-typedef unsigned int __u_int;
-typedef unsigned long int __u_long;
-typedef signed char __int8_t;
-typedef unsigned char __uint8_t;
-typedef signed short int __int16_t;
-typedef unsigned short int __uint16_t;
-typedef signed int __int32_t;
-typedef unsigned int __uint32_t;
-__extension__ typedef signed long long int __int64_t;
-__extension__ typedef unsigned long long int __uint64_t;
-__extension__ typedef long long int __quad_t;
-__extension__ typedef unsigned long long int __u_quad_t;
-__extension__ typedef __u_quad_t __dev_t;
-__extension__ typedef unsigned int __uid_t;
-__extension__ typedef unsigned int __gid_t;
-__extension__ typedef unsigned long int __ino_t;
-__extension__ typedef __u_quad_t __ino64_t;
-__extension__ typedef unsigned int __mode_t;
-__extension__ typedef unsigned int __nlink_t;
-__extension__ typedef long int __off_t;
-__extension__ typedef __quad_t __off64_t;
-__extension__ typedef int __pid_t;
-__extension__ typedef struct { int __val[2]; } __fsid_t;
-__extension__ typedef long int __clock_t;
-__extension__ typedef unsigned long int __rlim_t;
-__extension__ typedef __u_quad_t __rlim64_t;
-__extension__ typedef unsigned int __id_t;
-__extension__ typedef long int __time_t;
-__extension__ typedef unsigned int __useconds_t;
-__extension__ typedef long int __suseconds_t;
-__extension__ typedef int __daddr_t;
-__extension__ typedef int __key_t;
-__extension__ typedef int __clockid_t;
-__extension__ typedef void * __timer_t;
-__extension__ typedef long int __blksize_t;
-__extension__ typedef long int __blkcnt_t;
-__extension__ typedef __quad_t __blkcnt64_t;
-__extension__ typedef unsigned long int __fsblkcnt_t;
-__extension__ typedef __u_quad_t __fsblkcnt64_t;
-__extension__ typedef unsigned long int __fsfilcnt_t;
-__extension__ typedef __u_quad_t __fsfilcnt64_t;
-__extension__ typedef int __fsword_t;
-__extension__ typedef int __ssize_t;
-__extension__ typedef long int __syscall_slong_t;
-__extension__ typedef unsigned long int __syscall_ulong_t;
-typedef __off64_t __loff_t;
-typedef __quad_t *__qaddr_t;
-typedef char *__caddr_t;
-__extension__ typedef int __intptr_t;
-__extension__ typedef unsigned int __socklen_t;
-static __inline unsigned int
-__bswap_32 (unsigned int __bsx)
-{
-  return __builtin_bswap32 (__bsx);
-}
-static __inline __uint64_t
-__bswap_64 (__uint64_t __bsx)
-{
-  return __builtin_bswap64 (__bsx);
-}
-union wait
-  {
-    int w_status;
-    struct
-      {
- unsigned int __w_termsig:7;
- unsigned int __w_coredump:1;
- unsigned int __w_retcode:8;
- unsigned int:16;
-      } __wait_terminated;
-    struct
-      {
- unsigned int __w_stopval:8;
- unsigned int __w_stopsig:8;
- unsigned int:16;
-      } __wait_stopped;
-  };
-typedef union
-  {
-    union wait *__uptr;
-    int *__iptr;
-  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+# 42 "/usr/include/stdlib.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/waitstatus.h" 1 3 4
+# 43 "/usr/include/stdlib.h" 2 3 4
+# 56 "/usr/include/stdlib.h" 3 4
+
 
 typedef struct
   {
     int quot;
     int rem;
   } div_t;
+
+
+
 typedef struct
   {
     long int quot;
     long int rem;
   } ldiv_t;
+
+
+
+
+
 
 
 __extension__ typedef struct
@@ -111,18 +86,31 @@ __extension__ typedef struct
     long long int rem;
   } lldiv_t;
 
+
+# 100 "/usr/include/stdlib.h" 3 4
 extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+
+
 
 extern double atof (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
 extern int atoi (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
 extern long int atol (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
 
 
+
+
+
 __extension__ extern long long int atoll (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+
 
 
 extern double strtod (const char *__restrict __nptr,
@@ -130,41 +118,173 @@ extern double strtod (const char *__restrict __nptr,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
+
+
+
 extern float strtof (const char *__restrict __nptr,
        char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 extern long double strtold (const char *__restrict __nptr,
        char **__restrict __endptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
+
+
+
 extern long int strtol (const char *__restrict __nptr,
    char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 extern unsigned long int strtoul (const char *__restrict __nptr,
       char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
 
 __extension__
 extern long long int strtoq (const char *__restrict __nptr,
         char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 __extension__
 extern unsigned long long int strtouq (const char *__restrict __nptr,
            char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+
+
+
+
 __extension__
 extern long long int strtoll (const char *__restrict __nptr,
          char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 __extension__
 extern unsigned long long int strtoull (const char *__restrict __nptr,
      char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+# 266 "/usr/include/stdlib.h" 3 4
 extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+
 extern long int a64l (const char *__s)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/sys/types.h" 1 3 4
+# 27 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/types.h" 1 3 4
+# 27 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 28 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+
+
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+
+
+
+
+
+
+
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+# 121 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/typesizes.h" 1 3 4
+# 122 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+
+
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+
+typedef int __daddr_t;
+typedef int __key_t;
+
+
+typedef int __clockid_t;
+
+
+typedef void * __timer_t;
+
+
+typedef long int __blksize_t;
+
+
+
+
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+
+
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+
+
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+
+
+typedef long int __fsword_t;
+
+typedef long int __ssize_t;
+
+
+typedef long int __syscall_slong_t;
+
+typedef unsigned long int __syscall_ulong_t;
+
+
+
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+
+
+typedef long int __intptr_t;
+
+
+typedef unsigned int __socklen_t;
+# 30 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
 
 typedef __u_char u_char;
 typedef __u_short u_short;
@@ -173,75 +293,244 @@ typedef __u_long u_long;
 typedef __quad_t quad_t;
 typedef __u_quad_t u_quad_t;
 typedef __fsid_t fsid_t;
+
+
+
+
 typedef __loff_t loff_t;
+
+
+
 typedef __ino_t ino_t;
+# 60 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __dev_t dev_t;
+
+
+
+
 typedef __gid_t gid_t;
+
+
+
+
 typedef __mode_t mode_t;
+
+
+
+
 typedef __nlink_t nlink_t;
+
+
+
+
 typedef __uid_t uid_t;
+
+
+
+
+
 typedef __off_t off_t;
+# 98 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __pid_t pid_t;
+
+
+
+
+
 typedef __id_t id_t;
+
+
+
+
 typedef __ssize_t ssize_t;
+
+
+
+
+
 typedef __daddr_t daddr_t;
 typedef __caddr_t caddr_t;
+
+
+
+
+
 typedef __key_t key_t;
+# 132 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/include/time.h" 1 3 4
+# 57 "/usr/include/time.h" 3 4
+
 
 typedef __clock_t clock_t;
 
 
 
+# 73 "/usr/include/time.h" 3 4
+
+
 typedef __time_t time_t;
 
 
+
+# 91 "/usr/include/time.h" 3 4
 typedef __clockid_t clockid_t;
+# 103 "/usr/include/time.h" 3 4
 typedef __timer_t timer_t;
+# 133 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+# 146 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
+# 147 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+
 typedef unsigned long int ulong;
 typedef unsigned short int ushort;
 typedef unsigned int uint;
+# 194 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef int int8_t __attribute__ ((__mode__ (__QI__)));
 typedef int int16_t __attribute__ ((__mode__ (__HI__)));
 typedef int int32_t __attribute__ ((__mode__ (__SI__)));
 typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+
+
 typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
 typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
 typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
 typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+
 typedef int register_t __attribute__ ((__mode__ (__word__)));
+# 216 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/include/endian.h" 1 3 4
+# 36 "/usr/include/endian.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/endian.h" 1 3 4
+# 37 "/usr/include/endian.h" 2 3 4
+# 60 "/usr/include/endian.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 1 3 4
+# 28 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 29 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
+
+
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap-16.h" 1 3 4
+# 36 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
+# 44 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+# 108 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+# 61 "/usr/include/endian.h" 2 3 4
+# 217 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/sys/select.h" 1 3 4
+# 30 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/select.h" 1 3 4
+# 22 "/usr/include/x86_64-linux-gnu/bits/select.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 23 "/usr/include/x86_64-linux-gnu/bits/select.h" 2 3 4
+# 31 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 1 3 4
+# 22 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 3 4
 typedef int __sig_atomic_t;
+
+
+
+
 typedef struct
   {
     unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
   } __sigset_t;
+# 34 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+
+
 typedef __sigset_t sigset_t;
+
+
+
+
+
+
+
+# 1 "/usr/include/time.h" 1 3 4
+# 120 "/usr/include/time.h" 3 4
 struct timespec
   {
     __time_t tv_sec;
     __syscall_slong_t tv_nsec;
   };
+# 46 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/time.h" 1 3 4
+# 30 "/usr/include/x86_64-linux-gnu/bits/time.h" 3 4
 struct timeval
   {
     __time_t tv_sec;
     __suseconds_t tv_usec;
   };
+# 48 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+
 typedef __suseconds_t suseconds_t;
+
+
+
+
+
 typedef long int __fd_mask;
+# 66 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 typedef struct
   {
-    __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
-  } fd_set;
-typedef __fd_mask fd_mask;
 
+
+
+
+
+
+    __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+
+
+  } fd_set;
+
+
+
+
+
+
+typedef __fd_mask fd_mask;
+# 98 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
+
+# 108 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int select (int __nfds, fd_set *__restrict __readfds,
      fd_set *__restrict __writefds,
      fd_set *__restrict __exceptfds,
      struct timeval *__restrict __timeout);
+# 120 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int pselect (int __nfds, fd_set *__restrict __readfds,
       fd_set *__restrict __writefds,
       fd_set *__restrict __exceptfds,
       const struct timespec *__restrict __timeout,
       const __sigset_t *__restrict __sigmask);
+# 133 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
+
+# 220 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 1 3 4
+# 24 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
 
 
 __extension__
@@ -254,22 +543,57 @@ __extension__
 extern unsigned long long int gnu_dev_makedev (unsigned int __major,
             unsigned int __minor)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+# 58 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
+
+# 223 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+
+
 
 typedef __blksize_t blksize_t;
+
+
+
+
+
+
 typedef __blkcnt_t blkcnt_t;
+
+
+
 typedef __fsblkcnt_t fsblkcnt_t;
+
+
+
 typedef __fsfilcnt_t fsfilcnt_t;
+# 270 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 1 3 4
+# 21 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 22 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 2 3 4
+# 60 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef unsigned long int pthread_t;
+
+
 union pthread_attr_t
 {
-  char __size[36];
+  char __size[56];
   long int __align;
 };
+
 typedef union pthread_attr_t pthread_attr_t;
-typedef struct __pthread_internal_slist
+
+
+
+
+
+typedef struct __pthread_internal_list
 {
-  struct __pthread_internal_slist *__next;
-} __pthread_slist_t;
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+# 90 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef union
 {
   struct __pthread_mutex_s
@@ -277,26 +601,31 @@ typedef union
     int __lock;
     unsigned int __count;
     int __owner;
-    int __kind;
+
     unsigned int __nusers;
-    __extension__ union
-    {
-      struct
-      {
- short __espins;
- short __elision;
-      } d;
-      __pthread_slist_t __list;
-    };
+
+
+
+    int __kind;
+
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+# 125 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
   } __data;
-  char __size[24];
+  char __size[40];
   long int __align;
 } pthread_mutex_t;
+
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_mutexattr_t;
+
+
+
+
 typedef union
 {
   struct
@@ -313,15 +642,28 @@ typedef union
   char __size[48];
   __extension__ long long int __align;
 } pthread_cond_t;
+
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_condattr_t;
+
+
+
 typedef unsigned int pthread_key_t;
+
+
+
 typedef int pthread_once_t;
+
+
+
+
+
 typedef union
 {
+
   struct
   {
     int __lock;
@@ -330,37 +672,86 @@ typedef union
     unsigned int __writer_wakeup;
     unsigned int __nr_readers_queued;
     unsigned int __nr_writers_queued;
-    unsigned char __flags;
-    unsigned char __shared;
-    unsigned char __pad1;
-    unsigned char __pad2;
     int __writer;
+    int __shared;
+    signed char __rwelision;
+
+
+
+
+    unsigned char __pad1[7];
+
+
+    unsigned long int __pad2;
+
+
+    unsigned int __flags;
+
   } __data;
-  char __size[32];
+# 220 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
+  char __size[56];
   long int __align;
 } pthread_rwlock_t;
+
 typedef union
 {
   char __size[8];
   long int __align;
 } pthread_rwlockattr_t;
+
+
+
+
+
 typedef volatile int pthread_spinlock_t;
+
+
+
+
 typedef union
 {
-  char __size[20];
+  char __size[32];
   long int __align;
 } pthread_barrier_t;
+
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_barrierattr_t;
+# 271 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+
+# 276 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
 
 extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
 extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
+
+
 extern char *initstate (unsigned int __seed, char *__statebuf,
    size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+
+
 extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
+
 struct random_data
   {
     int32_t *fptr;
@@ -371,34 +762,65 @@ struct random_data
     int rand_sep;
     int32_t *end_ptr;
   };
+
 extern int random_r (struct random_data *__restrict __buf,
        int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
 extern int srandom_r (unsigned int __seed, struct random_data *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
 extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
    size_t __statelen,
    struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+
 extern int setstate_r (char *__restrict __statebuf,
          struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
+
+
+
+
+
 extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+
 extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+
 extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
+
+
+
+
 extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
 extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int nrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
 extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int jrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
 extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
 extern unsigned short int *seed48 (unsigned short int __seed16v[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
 struct drand48_data
   {
     unsigned short int __x[3];
@@ -406,12 +828,17 @@ struct drand48_data
     unsigned short int __c;
     unsigned short int __init;
     __extension__ unsigned long long int __a;
+
   };
+
+
 extern int drand48_r (struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern int erand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
 extern int lrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -419,6 +846,8 @@ extern int nrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
 extern int mrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -426,71 +855,219 @@ extern int jrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
 extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
 extern int seed48_r (unsigned short int __seed16v[3],
        struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
 extern int lcong48_r (unsigned short int __param[7],
         struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
+
+
+
+
+
+
+
+
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
 extern void *calloc (size_t __nmemb, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 
 
+
+
+
+
+
+
+
+
 extern void *realloc (void *__ptr, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+
 extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
 
 extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+# 1 "/usr/include/alloca.h" 1 3 4
+# 24 "/usr/include/alloca.h" 3 4
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
+# 25 "/usr/include/alloca.h" 2 3 4
+
+
+
+
+
+
+
 extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+
+
+
+# 454 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
 extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+
+
 extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
 
+
+
+
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+
+
+
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+
 extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
+
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
 
 extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+
+
+
+
+
 extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+
+
+
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+
+
+
 
 
 extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
+
+
+
+
 extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
 
+# 539 "/usr/include/stdlib.h" 3 4
 extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
 extern int setenv (const char *__name, const char *__value, int __replace)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+
 extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
 extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+# 567 "/usr/include/stdlib.h" 3 4
 extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+# 580 "/usr/include/stdlib.h" 3 4
 extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+# 602 "/usr/include/stdlib.h" 3 4
 extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+# 623 "/usr/include/stdlib.h" 3 4
 extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+# 672 "/usr/include/stdlib.h" 3 4
+
+
+
+
 
 extern int system (const char *__command) ;
 
+# 694 "/usr/include/stdlib.h" 3 4
 extern char *realpath (const char *__restrict __name,
          char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+
+
+
+
+
 typedef int (*__compar_fn_t) (const void *, const void *);
+# 712 "/usr/include/stdlib.h" 3 4
+
+
 
 extern void *bsearch (const void *__key, const void *__base,
         size_t __nmemb, size_t __size, __compar_fn_t __compar)
      __attribute__ ((__nonnull__ (1, 2, 5))) ;
+
+
+
+
+
+
+
 extern void qsort (void *__base, size_t __nmemb, size_t __size,
      __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+# 735 "/usr/include/stdlib.h" 3 4
 extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
+
+
 __extension__ extern long long int llabs (long long int __x)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+
+
+
+
 
 extern div_t div (int __numer, int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
@@ -498,16 +1075,31 @@ extern ldiv_t ldiv (long int __numer, long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
 
+
+
 __extension__ extern lldiv_t lldiv (long long int __numer,
         long long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
+# 772 "/usr/include/stdlib.h" 3 4
 extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+
+
+
+
 extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+
+
+
+
 extern char *gcvt (double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+
+
+
+
 extern char *qecvt (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
@@ -516,12 +1108,17 @@ extern char *qfcvt (long double __value, int __ndigit,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
 extern char *qgcvt (long double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+
+
+
+
 extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
 extern int qecvt_r (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign,
       char *__restrict __buf, size_t __len)
@@ -531,56 +1128,119 @@ extern int qfcvt_r (long double __value, int __ndigit,
       char *__restrict __buf, size_t __len)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 
+
+
+
+
+
 extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+
 extern int mbtowc (wchar_t *__restrict __pwc,
      const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+
 extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
 extern size_t mbstowcs (wchar_t *__restrict __pwcs,
    const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
 extern size_t wcstombs (char *__restrict __s,
    const wchar_t *__restrict __pwcs, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+
+
+
+
+
 extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+# 859 "/usr/include/stdlib.h" 3 4
 extern int getsubopt (char **__restrict __optionp,
         char *const *__restrict __tokens,
         char **__restrict __valuep)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+# 911 "/usr/include/stdlib.h" 3 4
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+# 921 "/usr/include/stdlib.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/stdlib-float.h" 1 3 4
+# 922 "/usr/include/stdlib.h" 2 3 4
+# 934 "/usr/include/stdlib.h" 3 4
 
+# 4 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 2
+
+
+# 5 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
 extern int __VERIFIER_nondet_int(void);
+
 static void fail(void) {
 ERROR: __VERIFIER_error();
 }
+
+
+
+
+
+
 struct slave_item {
     struct slave_item *next;
     struct slave_item *prev;
 };
+
 struct slave_item* alloc_or_die_slave(void)
 {
     struct slave_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-    ptr->next = ((void *)0);
-    ptr->next = ((void *)0);
+
+    ptr->next = 
+# 27 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+               ((void *)0)
+# 27 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                   ;
+    ptr->next = 
+# 28 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+               ((void *)0)
+# 28 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                   ;
     return ptr;
 }
+
 struct master_item {
     struct master_item *next;
     struct master_item *prev;
     struct slave_item *slave;
 };
+
 struct master_item* alloc_or_die_master(void)
 {
     struct master_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-    ptr->next = ((void *)0);
-    ptr->prev = ((void *)0);
-    ptr->slave = ((void *)0);
+
+    ptr->next = 
+# 44 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+               ((void *)0)
+# 44 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                   ;
+    ptr->prev = 
+# 45 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+               ((void *)0)
+# 45 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                   ;
+    ptr->slave = 
+# 46 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+                ((void *)0)
+# 46 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                    ;
     return ptr;
 }
+
 void dll_insert_slave(struct slave_item **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
@@ -588,21 +1248,31 @@ void dll_insert_slave(struct slave_item **dll)
     item->next = next;
     if (next)
         next->prev = item;
+
     *dll = item;
 }
-void* dll_create_generic(void (*insert_fnc)())
+
+void* dll_create_generic(void (*insert_fnc)(void **dll))
 {
-    void *dll = ((void *)0);
+    void *dll = 
+# 63 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+               ((void *)0)
+# 63 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                   ;
     insert_fnc(&dll);
     insert_fnc(&dll);
+
     while (__VERIFIER_nondet_int())
         insert_fnc(&dll);
+
     return dll;
 }
+
 struct slave_item* dll_create_slave(void)
 {
     return dll_create_generic(dll_insert_slave);
 }
+
 void dll_destroy_slave(struct slave_item *dll)
 {
     while (dll) {
@@ -611,6 +1281,7 @@ void dll_destroy_slave(struct slave_item *dll)
         dll = next;
     }
 }
+
 void dll_destroy_nested_lists(struct master_item *dll)
 {
     while (dll) {
@@ -618,13 +1289,19 @@ void dll_destroy_nested_lists(struct master_item *dll)
         dll = dll->next;
     }
 }
+
 void dll_reinit_nested_lists(struct master_item *dll)
 {
     while (dll) {
-        dll->slave = ((void *)0);
+        dll->slave = 
+# 98 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c" 3 4
+                    ((void *)0)
+# 98 "dll_of_dll_false-unreach-call_false-valid-memcleanup.c"
+                        ;
         dll = dll->next;
     }
 }
+
 void dll_destroy_master(struct master_item *dll)
 {
     while (dll) {
@@ -633,6 +1310,7 @@ void dll_destroy_master(struct master_item *dll)
         dll = next;
     }
 }
+
 void dll_insert_master(struct master_item **dll)
 {
     struct master_item *item = alloc_or_die_master();
@@ -640,32 +1318,39 @@ void dll_insert_master(struct master_item **dll)
     item->next = next;
     if (next)
         next->prev = item;
+
     item->slave = dll_create_slave();
     *dll = item;
 }
+
 struct master_item* dll_create_master(void)
 {
     return dll_create_generic(dll_insert_master);
 }
+
 void inspect_base(struct master_item *dll)
 {
     do { if (!(dll)) fail(); } while (0);
     do { if (!(dll->next)) fail(); } while (0);
     do { if (!(!dll->prev)) fail(); } while (0);
+
     for (dll = dll->next; dll; dll = dll->next) {
         do { if (!(dll->prev)) fail(); } while (0);
         do { if (!(dll->prev->next)) fail(); } while (0);
         do { if (!(dll->prev->next == dll)) fail(); } while (0);
     }
 }
+
 void inspect_full(struct master_item *dll)
 {
     inspect_base(dll);
+
     for (; dll; dll = dll->next) {
         struct slave_item *pos = dll->slave;
         do { if (!(pos)) fail(); } while (0);
         do { if (!(pos->next)) fail(); } while (0);
         do { if (!(!pos->prev)) fail(); } while (0);
+
         for (pos = pos->next; pos; pos = pos->next) {
             do { if (!(pos->prev)) fail(); } while (0);
             do { if (!(pos->prev->next)) fail(); } while (0);
@@ -673,26 +1358,35 @@ void inspect_full(struct master_item *dll)
         }
     }
 }
+
 void inspect_dangling(struct master_item *dll)
 {
     inspect_base(dll);
+
     for (; dll; dll = dll->next)
         do { if (!(dll->slave)) fail(); } while (0);
 }
+
 void inspect_init(struct master_item *dll)
 {
     inspect_base(dll);
+
     for (; dll; dll = dll->next)
         do { if (!(!dll->slave)) fail(); } while (0);
 }
+
 int main()
 {
     struct master_item *dll = dll_create_master();
     inspect_full(dll);
+
     dll_destroy_nested_lists(dll);
     inspect_dangling(dll);
+
     dll_reinit_nested_lists(dll);
     inspect_init(dll);
+
+
     dll_destroy_master(dll);
     return 0;
 }

--- a/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.c
+++ b/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.c
@@ -58,7 +58,7 @@ void dll_insert_slave(struct slave_item **dll)
     *dll = item;
 }
 
-void* dll_create_generic(void (*insert_fnc)())
+void* dll_create_generic(void (*insert_fnc)(void **dll))
 {
     void *dll = NULL;
     insert_fnc(&dll);

--- a/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.c
+++ b/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.c
@@ -47,7 +47,8 @@ struct master_item* alloc_or_die_master(void)
     return ptr;
 }
 
-void dll_insert_slave(struct slave_item **dll)
+// the argument should be of type 'struct slave_item**'
+void dll_insert_slave(void **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
     struct slave_item *next = *dll;
@@ -58,7 +59,7 @@ void dll_insert_slave(struct slave_item **dll)
     *dll = item;
 }
 
-void* dll_create_generic(void (*insert_fnc)(void **dll))
+void* dll_create_generic(void (*insert_fnc)(void**))
 {
     void *dll = NULL;
     insert_fnc(&dll);
@@ -109,7 +110,8 @@ void dll_destroy_master(struct master_item *dll)
     }
 }
 
-void dll_insert_master(struct master_item **dll)
+// the argument should be of type 'struct master_item**'
+void dll_insert_master(void **dll)
 {
     struct master_item *item = alloc_or_die_master();
     struct master_item *next = *dll;

--- a/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
+++ b/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
@@ -1,83 +1,24 @@
-# 1 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
-# 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
-# 1 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-# 1 "/usr/include/stdlib.h" 1 3 4
-# 24 "/usr/include/stdlib.h" 3 4
-# 1 "/usr/include/features.h" 1 3 4
-# 364 "/usr/include/features.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 1 3 4
-# 415 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 416 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 2 3 4
-# 365 "/usr/include/features.h" 2 3 4
-# 388 "/usr/include/features.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 1 3 4
-# 10 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs-64.h" 1 3 4
-# 11 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 2 3 4
-# 389 "/usr/include/features.h" 2 3 4
-# 25 "/usr/include/stdlib.h" 2 3 4
-
-
-
-
-
-
-
-# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
-# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
-
-# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
 typedef long unsigned int size_t;
-# 328 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
 typedef int wchar_t;
-# 33 "/usr/include/stdlib.h" 2 3 4
 
-
-
-
-
-
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 1 3 4
-# 50 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 3 4
 typedef enum
 {
   P_ALL,
   P_PID,
   P_PGID
 } idtype_t;
-# 42 "/usr/include/stdlib.h" 2 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/waitstatus.h" 1 3 4
-# 43 "/usr/include/stdlib.h" 2 3 4
-# 56 "/usr/include/stdlib.h" 3 4
-
 
 typedef struct
   {
     int quot;
     int rem;
   } div_t;
-
-
-
 typedef struct
   {
     long int quot;
     long int rem;
   } ldiv_t;
-
-
-
-
-
 
 
 __extension__ typedef struct
@@ -86,31 +27,18 @@ __extension__ typedef struct
     long long int rem;
   } lldiv_t;
 
-
-# 100 "/usr/include/stdlib.h" 3 4
 extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
-
-
-
 
 extern double atof (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
 extern int atoi (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
 extern long int atol (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
 
 
-
-
-
 __extension__ extern long long int atoll (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
-
-
 
 
 extern double strtod (const char *__restrict __nptr,
@@ -118,104 +46,56 @@ extern double strtod (const char *__restrict __nptr,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
-
-
-
 extern float strtof (const char *__restrict __nptr,
        char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 extern long double strtold (const char *__restrict __nptr,
        char **__restrict __endptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
-
-
-
 extern long int strtol (const char *__restrict __nptr,
    char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 extern unsigned long int strtoul (const char *__restrict __nptr,
       char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
 
 __extension__
 extern long long int strtoq (const char *__restrict __nptr,
         char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 __extension__
 extern unsigned long long int strtouq (const char *__restrict __nptr,
            char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-
-
-
-
 __extension__
 extern long long int strtoll (const char *__restrict __nptr,
          char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
 __extension__
 extern unsigned long long int strtoull (const char *__restrict __nptr,
      char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-# 266 "/usr/include/stdlib.h" 3 4
 extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
-
-
 extern long int a64l (const char *__s)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
-
-
-
-
-# 1 "/usr/include/x86_64-linux-gnu/sys/types.h" 1 3 4
-# 27 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/types.h" 1 3 4
-# 27 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 28 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
-
 
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
 typedef unsigned long int __u_long;
-
-
 typedef signed char __int8_t;
 typedef unsigned char __uint8_t;
 typedef signed short int __int16_t;
 typedef unsigned short int __uint16_t;
 typedef signed int __int32_t;
 typedef unsigned int __uint32_t;
-
 typedef signed long int __int64_t;
 typedef unsigned long int __uint64_t;
-
-
-
-
-
-
-
 typedef long int __quad_t;
 typedef unsigned long int __u_quad_t;
-# 121 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/typesizes.h" 1 3 4
-# 122 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
-
-
 typedef unsigned long int __dev_t;
 typedef unsigned int __uid_t;
 typedef unsigned int __gid_t;
@@ -234,58 +114,26 @@ typedef unsigned int __id_t;
 typedef long int __time_t;
 typedef unsigned int __useconds_t;
 typedef long int __suseconds_t;
-
 typedef int __daddr_t;
 typedef int __key_t;
-
-
 typedef int __clockid_t;
-
-
 typedef void * __timer_t;
-
-
 typedef long int __blksize_t;
-
-
-
-
 typedef long int __blkcnt_t;
 typedef long int __blkcnt64_t;
-
-
 typedef unsigned long int __fsblkcnt_t;
 typedef unsigned long int __fsblkcnt64_t;
-
-
 typedef unsigned long int __fsfilcnt_t;
 typedef unsigned long int __fsfilcnt64_t;
-
-
 typedef long int __fsword_t;
-
 typedef long int __ssize_t;
-
-
 typedef long int __syscall_slong_t;
-
 typedef unsigned long int __syscall_ulong_t;
-
-
-
 typedef __off64_t __loff_t;
 typedef __quad_t *__qaddr_t;
 typedef char *__caddr_t;
-
-
 typedef long int __intptr_t;
-
-
 typedef unsigned int __socklen_t;
-# 30 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
 typedef __u_char u_char;
 typedef __u_short u_short;
 typedef __u_int u_int;
@@ -293,244 +141,85 @@ typedef __u_long u_long;
 typedef __quad_t quad_t;
 typedef __u_quad_t u_quad_t;
 typedef __fsid_t fsid_t;
-
-
-
-
 typedef __loff_t loff_t;
-
-
-
 typedef __ino_t ino_t;
-# 60 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __dev_t dev_t;
-
-
-
-
 typedef __gid_t gid_t;
-
-
-
-
 typedef __mode_t mode_t;
-
-
-
-
 typedef __nlink_t nlink_t;
-
-
-
-
 typedef __uid_t uid_t;
-
-
-
-
-
 typedef __off_t off_t;
-# 98 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __pid_t pid_t;
-
-
-
-
-
 typedef __id_t id_t;
-
-
-
-
 typedef __ssize_t ssize_t;
-
-
-
-
-
 typedef __daddr_t daddr_t;
 typedef __caddr_t caddr_t;
-
-
-
-
-
 typedef __key_t key_t;
-# 132 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/include/time.h" 1 3 4
-# 57 "/usr/include/time.h" 3 4
-
 
 typedef __clock_t clock_t;
 
 
 
-# 73 "/usr/include/time.h" 3 4
-
-
 typedef __time_t time_t;
 
 
-
-# 91 "/usr/include/time.h" 3 4
 typedef __clockid_t clockid_t;
-# 103 "/usr/include/time.h" 3 4
 typedef __timer_t timer_t;
-# 133 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-# 146 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
-# 147 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
 typedef unsigned long int ulong;
 typedef unsigned short int ushort;
 typedef unsigned int uint;
-# 194 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef int int8_t __attribute__ ((__mode__ (__QI__)));
 typedef int int16_t __attribute__ ((__mode__ (__HI__)));
 typedef int int32_t __attribute__ ((__mode__ (__SI__)));
 typedef int int64_t __attribute__ ((__mode__ (__DI__)));
-
-
 typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
 typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
 typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
 typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
-
 typedef int register_t __attribute__ ((__mode__ (__word__)));
-# 216 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/include/endian.h" 1 3 4
-# 36 "/usr/include/endian.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/endian.h" 1 3 4
-# 37 "/usr/include/endian.h" 2 3 4
-# 60 "/usr/include/endian.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 1 3 4
-# 28 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 29 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
-
-
-
-
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap-16.h" 1 3 4
-# 36 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
-# 44 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
 static __inline unsigned int
 __bswap_32 (unsigned int __bsx)
 {
   return __builtin_bswap32 (__bsx);
 }
-# 108 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
 static __inline __uint64_t
 __bswap_64 (__uint64_t __bsx)
 {
   return __builtin_bswap64 (__bsx);
 }
-# 61 "/usr/include/endian.h" 2 3 4
-# 217 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/sys/select.h" 1 3 4
-# 30 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/select.h" 1 3 4
-# 22 "/usr/include/x86_64-linux-gnu/bits/select.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 23 "/usr/include/x86_64-linux-gnu/bits/select.h" 2 3 4
-# 31 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 1 3 4
-# 22 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 3 4
 typedef int __sig_atomic_t;
-
-
-
-
 typedef struct
   {
     unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
   } __sigset_t;
-# 34 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-
-
 typedef __sigset_t sigset_t;
-
-
-
-
-
-
-
-# 1 "/usr/include/time.h" 1 3 4
-# 120 "/usr/include/time.h" 3 4
 struct timespec
   {
     __time_t tv_sec;
     __syscall_slong_t tv_nsec;
   };
-# 46 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-# 1 "/usr/include/x86_64-linux-gnu/bits/time.h" 1 3 4
-# 30 "/usr/include/x86_64-linux-gnu/bits/time.h" 3 4
 struct timeval
   {
     __time_t tv_sec;
     __suseconds_t tv_usec;
   };
-# 48 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
-
-
 typedef __suseconds_t suseconds_t;
-
-
-
-
-
 typedef long int __fd_mask;
-# 66 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 typedef struct
   {
-
-
-
-
-
-
     __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
-
-
   } fd_set;
-
-
-
-
-
-
 typedef __fd_mask fd_mask;
-# 98 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 
-# 108 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int select (int __nfds, fd_set *__restrict __readfds,
      fd_set *__restrict __writefds,
      fd_set *__restrict __exceptfds,
      struct timeval *__restrict __timeout);
-# 120 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int pselect (int __nfds, fd_set *__restrict __readfds,
       fd_set *__restrict __writefds,
       fd_set *__restrict __exceptfds,
       const struct timespec *__restrict __timeout,
       const __sigset_t *__restrict __sigmask);
-# 133 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
-
-# 220 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-# 1 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 1 3 4
-# 24 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
 
 
 __extension__
@@ -543,57 +232,23 @@ __extension__
 extern unsigned long long int gnu_dev_makedev (unsigned int __major,
             unsigned int __minor)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
-# 58 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
-
-# 223 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
-
 
 typedef __blksize_t blksize_t;
-
-
-
-
-
-
 typedef __blkcnt_t blkcnt_t;
-
-
-
 typedef __fsblkcnt_t fsblkcnt_t;
-
-
-
 typedef __fsfilcnt_t fsfilcnt_t;
-# 270 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 1 3 4
-# 21 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
-# 22 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 2 3 4
-# 60 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef unsigned long int pthread_t;
-
-
 union pthread_attr_t
 {
   char __size[56];
   long int __align;
 };
-
 typedef union pthread_attr_t pthread_attr_t;
-
-
-
-
-
 typedef struct __pthread_internal_list
 {
   struct __pthread_internal_list *__prev;
   struct __pthread_internal_list *__next;
 } __pthread_list_t;
-# 90 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef union
 {
   struct __pthread_mutex_s
@@ -601,31 +256,20 @@ typedef union
     int __lock;
     unsigned int __count;
     int __owner;
-
     unsigned int __nusers;
-
-
-
     int __kind;
-
     short __spins;
     short __elision;
     __pthread_list_t __list;
-# 125 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
   } __data;
   char __size[40];
   long int __align;
 } pthread_mutex_t;
-
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_mutexattr_t;
-
-
-
-
 typedef union
 {
   struct
@@ -642,28 +286,15 @@ typedef union
   char __size[48];
   __extension__ long long int __align;
 } pthread_cond_t;
-
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_condattr_t;
-
-
-
 typedef unsigned int pthread_key_t;
-
-
-
 typedef int pthread_once_t;
-
-
-
-
-
 typedef union
 {
-
   struct
   {
     int __lock;
@@ -675,83 +306,35 @@ typedef union
     int __writer;
     int __shared;
     signed char __rwelision;
-
-
-
-
     unsigned char __pad1[7];
-
-
     unsigned long int __pad2;
-
-
     unsigned int __flags;
-
   } __data;
-# 220 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
   char __size[56];
   long int __align;
 } pthread_rwlock_t;
-
 typedef union
 {
   char __size[8];
   long int __align;
 } pthread_rwlockattr_t;
-
-
-
-
-
 typedef volatile int pthread_spinlock_t;
-
-
-
-
 typedef union
 {
   char __size[32];
   long int __align;
 } pthread_barrier_t;
-
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_barrierattr_t;
-# 271 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
-
-
-
-# 276 "/usr/include/stdlib.h" 2 3 4
-
-
-
-
-
 
 extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
-
-
 extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
-
-
 extern char *initstate (unsigned int __seed, char *__statebuf,
    size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
-
-
 extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
-
 struct random_data
   {
     int32_t *fptr;
@@ -762,65 +345,34 @@ struct random_data
     int rand_sep;
     int32_t *end_ptr;
   };
-
 extern int random_r (struct random_data *__restrict __buf,
        int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
 extern int srandom_r (unsigned int __seed, struct random_data *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
 extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
    size_t __statelen,
    struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
-
 extern int setstate_r (char *__restrict __statebuf,
          struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
-
-
-
-
-
 extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
-
 extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-
 extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
-
-
-
-
 extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
 extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int nrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
 extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int jrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
 extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
 extern unsigned short int *seed48 (unsigned short int __seed16v[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
 struct drand48_data
   {
     unsigned short int __x[3];
@@ -828,17 +380,12 @@ struct drand48_data
     unsigned short int __c;
     unsigned short int __init;
     __extension__ unsigned long long int __a;
-
   };
-
-
 extern int drand48_r (struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern int erand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
-
 extern int lrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -846,8 +393,6 @@ extern int nrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
-
 extern int mrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -855,219 +400,75 @@ extern int jrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
-
 extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
 extern int seed48_r (unsigned short int __seed16v[3],
        struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
-
 extern int lcong48_r (unsigned short int __param[7],
         struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
-
-
-
-
-
-
-
-
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
-
 extern void *calloc (size_t __nmemb, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 
 
-
-
-
-
-
-
-
-
 extern void *realloc (void *__ptr, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
-
 extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
 
 extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-# 1 "/usr/include/alloca.h" 1 3 4
-# 24 "/usr/include/alloca.h" 3 4
-# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
-# 25 "/usr/include/alloca.h" 2 3 4
-
-
-
-
-
-
-
 extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-
-
-
-# 454 "/usr/include/stdlib.h" 2 3 4
-
-
-
-
-
 extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
-
-
-
-
 extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
-
-
-
-
 extern void *aligned_alloc (size_t __alignment, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
 
-
-
-
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-
-
 extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
-
 extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
 
 extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-
-
-
-
-
 extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-
-
-
-
 extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
-
-
-
-
-
 
 
 extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
-
-
-
-
 extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
 
-# 539 "/usr/include/stdlib.h" 3 4
 extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
 extern int setenv (const char *__name, const char *__value, int __replace)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
-
-
 extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-
-
-
-
-
-
 extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
-# 567 "/usr/include/stdlib.h" 3 4
 extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-# 580 "/usr/include/stdlib.h" 3 4
 extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
-# 602 "/usr/include/stdlib.h" 3 4
 extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
-# 623 "/usr/include/stdlib.h" 3 4
 extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
-# 672 "/usr/include/stdlib.h" 3 4
-
-
-
-
 
 extern int system (const char *__command) ;
 
-# 694 "/usr/include/stdlib.h" 3 4
 extern char *realpath (const char *__restrict __name,
          char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
-
-
-
-
-
-
 typedef int (*__compar_fn_t) (const void *, const void *);
-# 712 "/usr/include/stdlib.h" 3 4
-
-
 
 extern void *bsearch (const void *__key, const void *__base,
         size_t __nmemb, size_t __size, __compar_fn_t __compar)
      __attribute__ ((__nonnull__ (1, 2, 5))) ;
-
-
-
-
-
-
-
 extern void qsort (void *__base, size_t __nmemb, size_t __size,
      __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
-# 735 "/usr/include/stdlib.h" 3 4
 extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
-
-
 __extension__ extern long long int llabs (long long int __x)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
-
-
-
-
-
-
 
 extern div_t div (int __numer, int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
@@ -1075,31 +476,16 @@ extern ldiv_t ldiv (long int __numer, long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
 
-
-
 __extension__ extern lldiv_t lldiv (long long int __numer,
         long long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
-# 772 "/usr/include/stdlib.h" 3 4
 extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
-
-
-
-
 extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
-
-
-
-
 extern char *gcvt (double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
-
-
-
-
 extern char *qecvt (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
@@ -1108,17 +494,12 @@ extern char *qfcvt (long double __value, int __ndigit,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
 extern char *qgcvt (long double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
-
-
-
-
 extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
-
 extern int qecvt_r (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign,
       char *__restrict __buf, size_t __len)
@@ -1128,120 +509,56 @@ extern int qfcvt_r (long double __value, int __ndigit,
       char *__restrict __buf, size_t __len)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 
-
-
-
-
-
 extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
-
-
 extern int mbtowc (wchar_t *__restrict __pwc,
      const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
-
-
 extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
-
-
-
 extern size_t mbstowcs (wchar_t *__restrict __pwcs,
    const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
-
 extern size_t wcstombs (char *__restrict __s,
    const wchar_t *__restrict __pwcs, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__));
 
-
-
-
-
-
-
-
 extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
-# 859 "/usr/include/stdlib.h" 3 4
 extern int getsubopt (char **__restrict __optionp,
         char *const *__restrict __tokens,
         char **__restrict __valuep)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
-# 911 "/usr/include/stdlib.h" 3 4
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
-# 921 "/usr/include/stdlib.h" 3 4
-# 1 "/usr/include/x86_64-linux-gnu/bits/stdlib-float.h" 1 3 4
-# 922 "/usr/include/stdlib.h" 2 3 4
-# 934 "/usr/include/stdlib.h" 3 4
 
-# 4 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 2
-
-
-# 5 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
 extern int __VERIFIER_nondet_int(void);
-
 static void fail(void) {
 ERROR: __VERIFIER_error();
 }
-
-
-
-
-
-
 struct slave_item {
     struct slave_item *next;
     struct slave_item *prev;
 };
-
 struct slave_item* alloc_or_die_slave(void)
 {
     struct slave_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-
-    ptr->next = 
-# 27 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-               ((void *)0)
-# 27 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                   ;
-    ptr->prev = 
-# 28 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-               ((void *)0)
-# 28 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                   ;
+    ptr->next = ((void *)0);
+    ptr->prev = ((void *)0);
     return ptr;
 }
-
 struct master_item {
     struct master_item *next;
     struct master_item *prev;
     struct slave_item *slave;
 };
-
 struct master_item* alloc_or_die_master(void)
 {
     struct master_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-
-    ptr->next = 
-# 44 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-               ((void *)0)
-# 44 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                   ;
-    ptr->prev = 
-# 45 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-               ((void *)0)
-# 45 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                   ;
-    ptr->slave = 
-# 46 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-                ((void *)0)
-# 46 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                    ;
+    ptr->next = ((void *)0);
+    ptr->prev = ((void *)0);
+    ptr->slave = ((void *)0);
     return ptr;
 }
-
-
 void dll_insert_slave(void **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
@@ -1249,31 +566,21 @@ void dll_insert_slave(void **dll)
     item->next = next;
     if (next)
         next->prev = item;
-
     *dll = item;
 }
-
 void* dll_create_generic(void (*insert_fnc)(void**))
 {
-    void *dll = 
-# 64 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-               ((void *)0)
-# 64 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                   ;
+    void *dll = ((void *)0);
     insert_fnc(&dll);
     insert_fnc(&dll);
-
     while (__VERIFIER_nondet_int())
         insert_fnc(&dll);
-
     return dll;
 }
-
 struct slave_item* dll_create_slave(void)
 {
     return dll_create_generic(dll_insert_slave);
 }
-
 void dll_destroy_slave(struct slave_item *dll)
 {
     while (dll) {
@@ -1282,7 +589,6 @@ void dll_destroy_slave(struct slave_item *dll)
         dll = next;
     }
 }
-
 void dll_destroy_nested_lists(struct master_item *dll)
 {
     while (dll) {
@@ -1290,19 +596,13 @@ void dll_destroy_nested_lists(struct master_item *dll)
         dll = dll->next;
     }
 }
-
 void dll_reinit_nested_lists(struct master_item *dll)
 {
     while (dll) {
-        dll->slave = 
-# 99 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
-                    ((void *)0)
-# 99 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
-                        ;
+        dll->slave = ((void *)0);
         dll = dll->next;
     }
 }
-
 void dll_destroy_master(struct master_item *dll)
 {
     while (dll) {
@@ -1311,8 +611,6 @@ void dll_destroy_master(struct master_item *dll)
         dll = next;
     }
 }
-
-
 void dll_insert_master(void **dll)
 {
     struct master_item *item = alloc_or_die_master();
@@ -1320,39 +618,32 @@ void dll_insert_master(void **dll)
     item->next = next;
     if (next)
         next->prev = item;
-
     item->slave = dll_create_slave();
     *dll = item;
 }
-
 struct master_item* dll_create_master(void)
 {
     return dll_create_generic(dll_insert_master);
 }
-
 void inspect_base(struct master_item *dll)
 {
     do { if (!(dll)) fail(); } while (0);
     do { if (!(dll->next)) fail(); } while (0);
     do { if (!(!dll->prev)) fail(); } while (0);
-
     for (dll = dll->next; dll; dll = dll->next) {
         do { if (!(dll->prev)) fail(); } while (0);
         do { if (!(dll->prev->next)) fail(); } while (0);
         do { if (!(dll->prev->next == dll)) fail(); } while (0);
     }
 }
-
 void inspect_full(struct master_item *dll)
 {
     inspect_base(dll);
-
     for (; dll; dll = dll->next) {
         struct slave_item *pos = dll->slave;
         do { if (!(pos)) fail(); } while (0);
         do { if (!(pos->next)) fail(); } while (0);
         do { if (!(!pos->prev)) fail(); } while (0);
-
         for (pos = pos->next; pos; pos = pos->next) {
             do { if (!(pos->prev)) fail(); } while (0);
             do { if (!(pos->prev->next)) fail(); } while (0);
@@ -1360,35 +651,26 @@ void inspect_full(struct master_item *dll)
         }
     }
 }
-
 void inspect_dangling(struct master_item *dll)
 {
     inspect_base(dll);
-
     for (; dll; dll = dll->next)
         do { if (!(dll->slave)) fail(); } while (0);
 }
-
 void inspect_init(struct master_item *dll)
 {
     inspect_base(dll);
-
     for (; dll; dll = dll->next)
         do { if (!(!dll->slave)) fail(); } while (0);
 }
-
 int main()
 {
     struct master_item *dll = dll_create_master();
     inspect_full(dll);
-
     dll_destroy_nested_lists(dll);
     inspect_dangling(dll);
-
     dll_reinit_nested_lists(dll);
     inspect_init(dll);
-
-
     dll_destroy_master(dll);
     return 0;
 }

--- a/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
+++ b/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
@@ -1,108 +1,83 @@
+# 1 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 31 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 32 "<command-line>" 2
+# 1 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-typedef unsigned int size_t;
-typedef long int wchar_t;
 
+# 1 "/usr/include/stdlib.h" 1 3 4
+# 24 "/usr/include/stdlib.h" 3 4
+# 1 "/usr/include/features.h" 1 3 4
+# 364 "/usr/include/features.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 1 3 4
+# 415 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 416 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 2 3 4
+# 365 "/usr/include/features.h" 2 3 4
+# 388 "/usr/include/features.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 1 3 4
+# 10 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs-64.h" 1 3 4
+# 11 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 2 3 4
+# 389 "/usr/include/features.h" 2 3 4
+# 25 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
+
+
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
+# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
+
+# 216 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
+typedef long unsigned int size_t;
+# 328 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 3 4
+typedef int wchar_t;
+# 33 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 1 3 4
+# 50 "/usr/include/x86_64-linux-gnu/bits/waitflags.h" 3 4
 typedef enum
 {
   P_ALL,
   P_PID,
   P_PGID
 } idtype_t;
-typedef unsigned char __u_char;
-typedef unsigned short int __u_short;
-typedef unsigned int __u_int;
-typedef unsigned long int __u_long;
-typedef signed char __int8_t;
-typedef unsigned char __uint8_t;
-typedef signed short int __int16_t;
-typedef unsigned short int __uint16_t;
-typedef signed int __int32_t;
-typedef unsigned int __uint32_t;
-__extension__ typedef signed long long int __int64_t;
-__extension__ typedef unsigned long long int __uint64_t;
-__extension__ typedef long long int __quad_t;
-__extension__ typedef unsigned long long int __u_quad_t;
-__extension__ typedef __u_quad_t __dev_t;
-__extension__ typedef unsigned int __uid_t;
-__extension__ typedef unsigned int __gid_t;
-__extension__ typedef unsigned long int __ino_t;
-__extension__ typedef __u_quad_t __ino64_t;
-__extension__ typedef unsigned int __mode_t;
-__extension__ typedef unsigned int __nlink_t;
-__extension__ typedef long int __off_t;
-__extension__ typedef __quad_t __off64_t;
-__extension__ typedef int __pid_t;
-__extension__ typedef struct { int __val[2]; } __fsid_t;
-__extension__ typedef long int __clock_t;
-__extension__ typedef unsigned long int __rlim_t;
-__extension__ typedef __u_quad_t __rlim64_t;
-__extension__ typedef unsigned int __id_t;
-__extension__ typedef long int __time_t;
-__extension__ typedef unsigned int __useconds_t;
-__extension__ typedef long int __suseconds_t;
-__extension__ typedef int __daddr_t;
-__extension__ typedef int __key_t;
-__extension__ typedef int __clockid_t;
-__extension__ typedef void * __timer_t;
-__extension__ typedef long int __blksize_t;
-__extension__ typedef long int __blkcnt_t;
-__extension__ typedef __quad_t __blkcnt64_t;
-__extension__ typedef unsigned long int __fsblkcnt_t;
-__extension__ typedef __u_quad_t __fsblkcnt64_t;
-__extension__ typedef unsigned long int __fsfilcnt_t;
-__extension__ typedef __u_quad_t __fsfilcnt64_t;
-__extension__ typedef int __fsword_t;
-__extension__ typedef int __ssize_t;
-__extension__ typedef long int __syscall_slong_t;
-__extension__ typedef unsigned long int __syscall_ulong_t;
-typedef __off64_t __loff_t;
-typedef __quad_t *__qaddr_t;
-typedef char *__caddr_t;
-__extension__ typedef int __intptr_t;
-__extension__ typedef unsigned int __socklen_t;
-static __inline unsigned int
-__bswap_32 (unsigned int __bsx)
-{
-  return __builtin_bswap32 (__bsx);
-}
-static __inline __uint64_t
-__bswap_64 (__uint64_t __bsx)
-{
-  return __builtin_bswap64 (__bsx);
-}
-union wait
-  {
-    int w_status;
-    struct
-      {
- unsigned int __w_termsig:7;
- unsigned int __w_coredump:1;
- unsigned int __w_retcode:8;
- unsigned int:16;
-      } __wait_terminated;
-    struct
-      {
- unsigned int __w_stopval:8;
- unsigned int __w_stopsig:8;
- unsigned int:16;
-      } __wait_stopped;
-  };
-typedef union
-  {
-    union wait *__uptr;
-    int *__iptr;
-  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+# 42 "/usr/include/stdlib.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/waitstatus.h" 1 3 4
+# 43 "/usr/include/stdlib.h" 2 3 4
+# 56 "/usr/include/stdlib.h" 3 4
+
 
 typedef struct
   {
     int quot;
     int rem;
   } div_t;
+
+
+
 typedef struct
   {
     long int quot;
     long int rem;
   } ldiv_t;
+
+
+
+
+
 
 
 __extension__ typedef struct
@@ -111,18 +86,31 @@ __extension__ typedef struct
     long long int rem;
   } lldiv_t;
 
+
+# 100 "/usr/include/stdlib.h" 3 4
 extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+
+
 
 extern double atof (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
 extern int atoi (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
 extern long int atol (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
 
 
+
+
+
 __extension__ extern long long int atoll (const char *__nptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+
 
 
 extern double strtod (const char *__restrict __nptr,
@@ -130,41 +118,173 @@ extern double strtod (const char *__restrict __nptr,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
+
+
+
 extern float strtof (const char *__restrict __nptr,
        char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 extern long double strtold (const char *__restrict __nptr,
        char **__restrict __endptr)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 
+
+
+
 extern long int strtol (const char *__restrict __nptr,
    char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 extern unsigned long int strtoul (const char *__restrict __nptr,
       char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
 
 __extension__
 extern long long int strtoq (const char *__restrict __nptr,
         char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 __extension__
 extern unsigned long long int strtouq (const char *__restrict __nptr,
            char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+
+
+
+
 __extension__
 extern long long int strtoll (const char *__restrict __nptr,
          char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
 __extension__
 extern unsigned long long int strtoull (const char *__restrict __nptr,
      char **__restrict __endptr, int __base)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+# 266 "/usr/include/stdlib.h" 3 4
 extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+
 extern long int a64l (const char *__s)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/sys/types.h" 1 3 4
+# 27 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/types.h" 1 3 4
+# 27 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 28 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+
+
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+
+
+
+
+
+
+
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+# 121 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/typesizes.h" 1 3 4
+# 122 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+
+
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+
+typedef int __daddr_t;
+typedef int __key_t;
+
+
+typedef int __clockid_t;
+
+
+typedef void * __timer_t;
+
+
+typedef long int __blksize_t;
+
+
+
+
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+
+
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+
+
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+
+
+typedef long int __fsword_t;
+
+typedef long int __ssize_t;
+
+
+typedef long int __syscall_slong_t;
+
+typedef unsigned long int __syscall_ulong_t;
+
+
+
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+
+
+typedef long int __intptr_t;
+
+
+typedef unsigned int __socklen_t;
+# 30 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
 
 typedef __u_char u_char;
 typedef __u_short u_short;
@@ -173,75 +293,244 @@ typedef __u_long u_long;
 typedef __quad_t quad_t;
 typedef __u_quad_t u_quad_t;
 typedef __fsid_t fsid_t;
+
+
+
+
 typedef __loff_t loff_t;
+
+
+
 typedef __ino_t ino_t;
+# 60 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __dev_t dev_t;
+
+
+
+
 typedef __gid_t gid_t;
+
+
+
+
 typedef __mode_t mode_t;
+
+
+
+
 typedef __nlink_t nlink_t;
+
+
+
+
 typedef __uid_t uid_t;
+
+
+
+
+
 typedef __off_t off_t;
+# 98 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef __pid_t pid_t;
+
+
+
+
+
 typedef __id_t id_t;
+
+
+
+
 typedef __ssize_t ssize_t;
+
+
+
+
+
 typedef __daddr_t daddr_t;
 typedef __caddr_t caddr_t;
+
+
+
+
+
 typedef __key_t key_t;
+# 132 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/include/time.h" 1 3 4
+# 57 "/usr/include/time.h" 3 4
+
 
 typedef __clock_t clock_t;
 
 
 
+# 73 "/usr/include/time.h" 3 4
+
+
 typedef __time_t time_t;
 
 
+
+# 91 "/usr/include/time.h" 3 4
 typedef __clockid_t clockid_t;
+# 103 "/usr/include/time.h" 3 4
 typedef __timer_t timer_t;
+# 133 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+# 146 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
+# 147 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+
 typedef unsigned long int ulong;
 typedef unsigned short int ushort;
 typedef unsigned int uint;
+# 194 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
 typedef int int8_t __attribute__ ((__mode__ (__QI__)));
 typedef int int16_t __attribute__ ((__mode__ (__HI__)));
 typedef int int32_t __attribute__ ((__mode__ (__SI__)));
 typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+
+
 typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
 typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
 typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
 typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+
 typedef int register_t __attribute__ ((__mode__ (__word__)));
+# 216 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/include/endian.h" 1 3 4
+# 36 "/usr/include/endian.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/endian.h" 1 3 4
+# 37 "/usr/include/endian.h" 2 3 4
+# 60 "/usr/include/endian.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 1 3 4
+# 28 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 29 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
+
+
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/byteswap-16.h" 1 3 4
+# 36 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 2 3 4
+# 44 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+# 108 "/usr/include/x86_64-linux-gnu/bits/byteswap.h" 3 4
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+# 61 "/usr/include/endian.h" 2 3 4
+# 217 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/sys/select.h" 1 3 4
+# 30 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/select.h" 1 3 4
+# 22 "/usr/include/x86_64-linux-gnu/bits/select.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 23 "/usr/include/x86_64-linux-gnu/bits/select.h" 2 3 4
+# 31 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 1 3 4
+# 22 "/usr/include/x86_64-linux-gnu/bits/sigset.h" 3 4
 typedef int __sig_atomic_t;
+
+
+
+
 typedef struct
   {
     unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
   } __sigset_t;
+# 34 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+
+
 typedef __sigset_t sigset_t;
+
+
+
+
+
+
+
+# 1 "/usr/include/time.h" 1 3 4
+# 120 "/usr/include/time.h" 3 4
 struct timespec
   {
     __time_t tv_sec;
     __syscall_slong_t tv_nsec;
   };
+# 46 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/time.h" 1 3 4
+# 30 "/usr/include/x86_64-linux-gnu/bits/time.h" 3 4
 struct timeval
   {
     __time_t tv_sec;
     __suseconds_t tv_usec;
   };
+# 48 "/usr/include/x86_64-linux-gnu/sys/select.h" 2 3 4
+
+
 typedef __suseconds_t suseconds_t;
+
+
+
+
+
 typedef long int __fd_mask;
+# 66 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 typedef struct
   {
-    __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
-  } fd_set;
-typedef __fd_mask fd_mask;
 
+
+
+
+
+
+    __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+
+
+  } fd_set;
+
+
+
+
+
+
+typedef __fd_mask fd_mask;
+# 98 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
+
+# 108 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int select (int __nfds, fd_set *__restrict __readfds,
      fd_set *__restrict __writefds,
      fd_set *__restrict __exceptfds,
      struct timeval *__restrict __timeout);
+# 120 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
 extern int pselect (int __nfds, fd_set *__restrict __readfds,
       fd_set *__restrict __writefds,
       fd_set *__restrict __exceptfds,
       const struct timespec *__restrict __timeout,
       const __sigset_t *__restrict __sigmask);
+# 133 "/usr/include/x86_64-linux-gnu/sys/select.h" 3 4
+
+# 220 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 1 3 4
+# 24 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
 
 
 __extension__
@@ -254,22 +543,57 @@ __extension__
 extern unsigned long long int gnu_dev_makedev (unsigned int __major,
             unsigned int __minor)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+# 58 "/usr/include/x86_64-linux-gnu/sys/sysmacros.h" 3 4
+
+# 223 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+
+
 
 typedef __blksize_t blksize_t;
+
+
+
+
+
+
 typedef __blkcnt_t blkcnt_t;
+
+
+
 typedef __fsblkcnt_t fsblkcnt_t;
+
+
+
 typedef __fsfilcnt_t fsfilcnt_t;
+# 270 "/usr/include/x86_64-linux-gnu/sys/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 1 3 4
+# 21 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 22 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 2 3 4
+# 60 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef unsigned long int pthread_t;
+
+
 union pthread_attr_t
 {
-  char __size[36];
+  char __size[56];
   long int __align;
 };
+
 typedef union pthread_attr_t pthread_attr_t;
-typedef struct __pthread_internal_slist
+
+
+
+
+
+typedef struct __pthread_internal_list
 {
-  struct __pthread_internal_slist *__next;
-} __pthread_slist_t;
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+# 90 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
 typedef union
 {
   struct __pthread_mutex_s
@@ -277,26 +601,31 @@ typedef union
     int __lock;
     unsigned int __count;
     int __owner;
-    int __kind;
+
     unsigned int __nusers;
-    __extension__ union
-    {
-      struct
-      {
- short __espins;
- short __elision;
-      } d;
-      __pthread_slist_t __list;
-    };
+
+
+
+    int __kind;
+
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+# 125 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
   } __data;
-  char __size[24];
+  char __size[40];
   long int __align;
 } pthread_mutex_t;
+
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_mutexattr_t;
+
+
+
+
 typedef union
 {
   struct
@@ -313,15 +642,28 @@ typedef union
   char __size[48];
   __extension__ long long int __align;
 } pthread_cond_t;
+
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_condattr_t;
+
+
+
 typedef unsigned int pthread_key_t;
+
+
+
 typedef int pthread_once_t;
+
+
+
+
+
 typedef union
 {
+
   struct
   {
     int __lock;
@@ -330,37 +672,86 @@ typedef union
     unsigned int __writer_wakeup;
     unsigned int __nr_readers_queued;
     unsigned int __nr_writers_queued;
-    unsigned char __flags;
-    unsigned char __shared;
-    unsigned char __pad1;
-    unsigned char __pad2;
     int __writer;
+    int __shared;
+    signed char __rwelision;
+
+
+
+
+    unsigned char __pad1[7];
+
+
+    unsigned long int __pad2;
+
+
+    unsigned int __flags;
+
   } __data;
-  char __size[32];
+# 220 "/usr/include/x86_64-linux-gnu/bits/pthreadtypes.h" 3 4
+  char __size[56];
   long int __align;
 } pthread_rwlock_t;
+
 typedef union
 {
   char __size[8];
   long int __align;
 } pthread_rwlockattr_t;
+
+
+
+
+
 typedef volatile int pthread_spinlock_t;
+
+
+
+
 typedef union
 {
-  char __size[20];
+  char __size[32];
   long int __align;
 } pthread_barrier_t;
+
 typedef union
 {
   char __size[4];
   int __align;
 } pthread_barrierattr_t;
+# 271 "/usr/include/x86_64-linux-gnu/sys/types.h" 2 3 4
+
+
+
+# 276 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
 
 extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
 extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
+
+
 extern char *initstate (unsigned int __seed, char *__statebuf,
    size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+
+
 extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
+
 struct random_data
   {
     int32_t *fptr;
@@ -371,34 +762,65 @@ struct random_data
     int rand_sep;
     int32_t *end_ptr;
   };
+
 extern int random_r (struct random_data *__restrict __buf,
        int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
 extern int srandom_r (unsigned int __seed, struct random_data *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
 extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
    size_t __statelen,
    struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+
 extern int setstate_r (char *__restrict __statebuf,
          struct random_data *__restrict __buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
+
+
+
+
+
 extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+
 extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+
 extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
+
+
+
+
 extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
 extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int nrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
 extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
 extern long int jrand48 (unsigned short int __xsubi[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
 extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
 extern unsigned short int *seed48 (unsigned short int __seed16v[3])
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
 struct drand48_data
   {
     unsigned short int __x[3];
@@ -406,12 +828,17 @@ struct drand48_data
     unsigned short int __c;
     unsigned short int __init;
     __extension__ unsigned long long int __a;
+
   };
+
+
 extern int drand48_r (struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 extern int erand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
 extern int lrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -419,6 +846,8 @@ extern int nrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
 extern int mrand48_r (struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
@@ -426,71 +855,219 @@ extern int jrand48_r (unsigned short int __xsubi[3],
         struct drand48_data *__restrict __buffer,
         long int *__restrict __result)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
 extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
 extern int seed48_r (unsigned short int __seed16v[3],
        struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
 extern int lcong48_r (unsigned short int __param[7],
         struct drand48_data *__buffer)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
 
+
+
+
+
+
+
+
+
 extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
 extern void *calloc (size_t __nmemb, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
 
 
+
+
+
+
+
+
+
+
 extern void *realloc (void *__ptr, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+
 extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
 
 extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+# 1 "/usr/include/alloca.h" 1 3 4
+# 24 "/usr/include/alloca.h" 3 4
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/7/include/stddef.h" 1 3 4
+# 25 "/usr/include/alloca.h" 2 3 4
+
+
+
+
+
+
+
 extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+
+
+
+# 454 "/usr/include/stdlib.h" 2 3 4
+
+
+
+
+
 extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+
+
 extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
 
+
+
+
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+
+
+
 extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+
 extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
+
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
 
 extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
+
+
+
+
+
 extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+
+
+
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+
+
+
 
 
 extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 
+
+
+
+
 extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
 
+# 539 "/usr/include/stdlib.h" 3 4
 extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
 extern int setenv (const char *__name, const char *__value, int __replace)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+
 extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+
+
+
 extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+# 567 "/usr/include/stdlib.h" 3 4
 extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+# 580 "/usr/include/stdlib.h" 3 4
 extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+# 602 "/usr/include/stdlib.h" 3 4
 extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+# 623 "/usr/include/stdlib.h" 3 4
 extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+# 672 "/usr/include/stdlib.h" 3 4
+
+
+
+
 
 extern int system (const char *__command) ;
 
+# 694 "/usr/include/stdlib.h" 3 4
 extern char *realpath (const char *__restrict __name,
          char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+
+
+
+
+
 typedef int (*__compar_fn_t) (const void *, const void *);
+# 712 "/usr/include/stdlib.h" 3 4
+
+
 
 extern void *bsearch (const void *__key, const void *__base,
         size_t __nmemb, size_t __size, __compar_fn_t __compar)
      __attribute__ ((__nonnull__ (1, 2, 5))) ;
+
+
+
+
+
+
+
 extern void qsort (void *__base, size_t __nmemb, size_t __size,
      __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+# 735 "/usr/include/stdlib.h" 3 4
 extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
+
+
 __extension__ extern long long int llabs (long long int __x)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+
+
+
+
 
 extern div_t div (int __numer, int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
@@ -498,16 +1075,31 @@ extern ldiv_t ldiv (long int __numer, long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
 
+
+
 __extension__ extern lldiv_t lldiv (long long int __numer,
         long long int __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
 
+# 772 "/usr/include/stdlib.h" 3 4
 extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+
+
+
+
 extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+
+
+
+
 extern char *gcvt (double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+
+
+
+
 extern char *qecvt (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
@@ -516,12 +1108,17 @@ extern char *qfcvt (long double __value, int __ndigit,
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
 extern char *qgcvt (long double __value, int __ndigit, char *__buf)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+
+
+
+
 extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
      int *__restrict __sign, char *__restrict __buf,
      size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
 extern int qecvt_r (long double __value, int __ndigit,
       int *__restrict __decpt, int *__restrict __sign,
       char *__restrict __buf, size_t __len)
@@ -531,56 +1128,119 @@ extern int qfcvt_r (long double __value, int __ndigit,
       char *__restrict __buf, size_t __len)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
 
+
+
+
+
+
 extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+
 extern int mbtowc (wchar_t *__restrict __pwc,
      const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+
 extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+
+
+
 extern size_t mbstowcs (wchar_t *__restrict __pwcs,
    const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
 extern size_t wcstombs (char *__restrict __s,
    const wchar_t *__restrict __pwcs, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__));
 
+
+
+
+
+
+
+
 extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+# 859 "/usr/include/stdlib.h" 3 4
 extern int getsubopt (char **__restrict __optionp,
         char *const *__restrict __tokens,
         char **__restrict __valuep)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+# 911 "/usr/include/stdlib.h" 3 4
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+# 921 "/usr/include/stdlib.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/stdlib-float.h" 1 3 4
+# 922 "/usr/include/stdlib.h" 2 3 4
+# 934 "/usr/include/stdlib.h" 3 4
 
+# 4 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 2
+
+
+# 5 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
 extern int __VERIFIER_nondet_int(void);
+
 static void fail(void) {
 ERROR: __VERIFIER_error();
 }
+
+
+
+
+
+
 struct slave_item {
     struct slave_item *next;
     struct slave_item *prev;
 };
+
 struct slave_item* alloc_or_die_slave(void)
 {
     struct slave_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-    ptr->next = ((void *)0);
-    ptr->prev = ((void *)0);
+
+    ptr->next = 
+# 27 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+               ((void *)0)
+# 27 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                   ;
+    ptr->prev = 
+# 28 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+               ((void *)0)
+# 28 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                   ;
     return ptr;
 }
+
 struct master_item {
     struct master_item *next;
     struct master_item *prev;
     struct slave_item *slave;
 };
+
 struct master_item* alloc_or_die_master(void)
 {
     struct master_item *ptr = malloc(sizeof(*ptr));
     if (!ptr)
         abort();
-    ptr->next = ((void *)0);
-    ptr->prev = ((void *)0);
-    ptr->slave = ((void *)0);
+
+    ptr->next = 
+# 44 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+               ((void *)0)
+# 44 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                   ;
+    ptr->prev = 
+# 45 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+               ((void *)0)
+# 45 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                   ;
+    ptr->slave = 
+# 46 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+                ((void *)0)
+# 46 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                    ;
     return ptr;
 }
+
 void dll_insert_slave(struct slave_item **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
@@ -588,21 +1248,31 @@ void dll_insert_slave(struct slave_item **dll)
     item->next = next;
     if (next)
         next->prev = item;
+
     *dll = item;
 }
-void* dll_create_generic(void (*insert_fnc)())
+
+void* dll_create_generic(void (*insert_fnc)(void **dll))
 {
-    void *dll = ((void *)0);
+    void *dll = 
+# 63 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+               ((void *)0)
+# 63 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                   ;
     insert_fnc(&dll);
     insert_fnc(&dll);
+
     while (__VERIFIER_nondet_int())
         insert_fnc(&dll);
+
     return dll;
 }
+
 struct slave_item* dll_create_slave(void)
 {
     return dll_create_generic(dll_insert_slave);
 }
+
 void dll_destroy_slave(struct slave_item *dll)
 {
     while (dll) {
@@ -611,6 +1281,7 @@ void dll_destroy_slave(struct slave_item *dll)
         dll = next;
     }
 }
+
 void dll_destroy_nested_lists(struct master_item *dll)
 {
     while (dll) {
@@ -618,13 +1289,19 @@ void dll_destroy_nested_lists(struct master_item *dll)
         dll = dll->next;
     }
 }
+
 void dll_reinit_nested_lists(struct master_item *dll)
 {
     while (dll) {
-        dll->slave = ((void *)0);
+        dll->slave = 
+# 98 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+                    ((void *)0)
+# 98 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+                        ;
         dll = dll->next;
     }
 }
+
 void dll_destroy_master(struct master_item *dll)
 {
     while (dll) {
@@ -633,6 +1310,7 @@ void dll_destroy_master(struct master_item *dll)
         dll = next;
     }
 }
+
 void dll_insert_master(struct master_item **dll)
 {
     struct master_item *item = alloc_or_die_master();
@@ -640,32 +1318,39 @@ void dll_insert_master(struct master_item **dll)
     item->next = next;
     if (next)
         next->prev = item;
+
     item->slave = dll_create_slave();
     *dll = item;
 }
+
 struct master_item* dll_create_master(void)
 {
     return dll_create_generic(dll_insert_master);
 }
+
 void inspect_base(struct master_item *dll)
 {
     do { if (!(dll)) fail(); } while (0);
     do { if (!(dll->next)) fail(); } while (0);
     do { if (!(!dll->prev)) fail(); } while (0);
+
     for (dll = dll->next; dll; dll = dll->next) {
         do { if (!(dll->prev)) fail(); } while (0);
         do { if (!(dll->prev->next)) fail(); } while (0);
         do { if (!(dll->prev->next == dll)) fail(); } while (0);
     }
 }
+
 void inspect_full(struct master_item *dll)
 {
     inspect_base(dll);
+
     for (; dll; dll = dll->next) {
         struct slave_item *pos = dll->slave;
         do { if (!(pos)) fail(); } while (0);
         do { if (!(pos->next)) fail(); } while (0);
         do { if (!(!pos->prev)) fail(); } while (0);
+
         for (pos = pos->next; pos; pos = pos->next) {
             do { if (!(pos->prev)) fail(); } while (0);
             do { if (!(pos->prev->next)) fail(); } while (0);
@@ -673,26 +1358,35 @@ void inspect_full(struct master_item *dll)
         }
     }
 }
+
 void inspect_dangling(struct master_item *dll)
 {
     inspect_base(dll);
+
     for (; dll; dll = dll->next)
         do { if (!(dll->slave)) fail(); } while (0);
 }
+
 void inspect_init(struct master_item *dll)
 {
     inspect_base(dll);
+
     for (; dll; dll = dll->next)
         do { if (!(!dll->slave)) fail(); } while (0);
 }
+
 int main()
 {
     struct master_item *dll = dll_create_master();
     inspect_full(dll);
+
     dll_destroy_nested_lists(dll);
     inspect_dangling(dll);
+
     dll_reinit_nested_lists(dll);
     inspect_init(dll);
+
+
     dll_destroy_master(dll);
     return 0;
 }

--- a/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
+++ b/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-typedef long unsigned int size_t;
-typedef int wchar_t;
+typedef unsigned int size_t;
+typedef long int wchar_t;
 
 typedef enum
 {
@@ -92,48 +92,48 @@ typedef signed short int __int16_t;
 typedef unsigned short int __uint16_t;
 typedef signed int __int32_t;
 typedef unsigned int __uint32_t;
-typedef signed long int __int64_t;
-typedef unsigned long int __uint64_t;
-typedef long int __quad_t;
-typedef unsigned long int __u_quad_t;
-typedef unsigned long int __dev_t;
-typedef unsigned int __uid_t;
-typedef unsigned int __gid_t;
-typedef unsigned long int __ino_t;
-typedef unsigned long int __ino64_t;
-typedef unsigned int __mode_t;
-typedef unsigned long int __nlink_t;
-typedef long int __off_t;
-typedef long int __off64_t;
-typedef int __pid_t;
-typedef struct { int __val[2]; } __fsid_t;
-typedef long int __clock_t;
-typedef unsigned long int __rlim_t;
-typedef unsigned long int __rlim64_t;
-typedef unsigned int __id_t;
-typedef long int __time_t;
-typedef unsigned int __useconds_t;
-typedef long int __suseconds_t;
-typedef int __daddr_t;
-typedef int __key_t;
-typedef int __clockid_t;
-typedef void * __timer_t;
-typedef long int __blksize_t;
-typedef long int __blkcnt_t;
-typedef long int __blkcnt64_t;
-typedef unsigned long int __fsblkcnt_t;
-typedef unsigned long int __fsblkcnt64_t;
-typedef unsigned long int __fsfilcnt_t;
-typedef unsigned long int __fsfilcnt64_t;
-typedef long int __fsword_t;
-typedef long int __ssize_t;
-typedef long int __syscall_slong_t;
-typedef unsigned long int __syscall_ulong_t;
+__extension__ typedef signed long long int __int64_t;
+__extension__ typedef unsigned long long int __uint64_t;
+__extension__ typedef long long int __quad_t;
+__extension__ typedef unsigned long long int __u_quad_t;
+__extension__ typedef __u_quad_t __dev_t;
+__extension__ typedef unsigned int __uid_t;
+__extension__ typedef unsigned int __gid_t;
+__extension__ typedef unsigned long int __ino_t;
+__extension__ typedef __u_quad_t __ino64_t;
+__extension__ typedef unsigned int __mode_t;
+__extension__ typedef unsigned int __nlink_t;
+__extension__ typedef long int __off_t;
+__extension__ typedef __quad_t __off64_t;
+__extension__ typedef int __pid_t;
+__extension__ typedef struct { int __val[2]; } __fsid_t;
+__extension__ typedef long int __clock_t;
+__extension__ typedef unsigned long int __rlim_t;
+__extension__ typedef __u_quad_t __rlim64_t;
+__extension__ typedef unsigned int __id_t;
+__extension__ typedef long int __time_t;
+__extension__ typedef unsigned int __useconds_t;
+__extension__ typedef long int __suseconds_t;
+__extension__ typedef int __daddr_t;
+__extension__ typedef int __key_t;
+__extension__ typedef int __clockid_t;
+__extension__ typedef void * __timer_t;
+__extension__ typedef long int __blksize_t;
+__extension__ typedef long int __blkcnt_t;
+__extension__ typedef __quad_t __blkcnt64_t;
+__extension__ typedef unsigned long int __fsblkcnt_t;
+__extension__ typedef __u_quad_t __fsblkcnt64_t;
+__extension__ typedef unsigned long int __fsfilcnt_t;
+__extension__ typedef __u_quad_t __fsfilcnt64_t;
+__extension__ typedef int __fsword_t;
+__extension__ typedef int __ssize_t;
+__extension__ typedef long int __syscall_slong_t;
+__extension__ typedef unsigned long int __syscall_ulong_t;
 typedef __off64_t __loff_t;
 typedef __quad_t *__qaddr_t;
 typedef char *__caddr_t;
-typedef long int __intptr_t;
-typedef unsigned int __socklen_t;
+__extension__ typedef int __intptr_t;
+__extension__ typedef unsigned int __socklen_t;
 typedef __u_char u_char;
 typedef __u_short u_short;
 typedef __u_int u_int;
@@ -240,15 +240,14 @@ typedef __fsfilcnt_t fsfilcnt_t;
 typedef unsigned long int pthread_t;
 union pthread_attr_t
 {
-  char __size[56];
+  char __size[36];
   long int __align;
 };
 typedef union pthread_attr_t pthread_attr_t;
-typedef struct __pthread_internal_list
+typedef struct __pthread_internal_slist
 {
-  struct __pthread_internal_list *__prev;
-  struct __pthread_internal_list *__next;
-} __pthread_list_t;
+  struct __pthread_internal_slist *__next;
+} __pthread_slist_t;
 typedef union
 {
   struct __pthread_mutex_s
@@ -256,13 +255,19 @@ typedef union
     int __lock;
     unsigned int __count;
     int __owner;
-    unsigned int __nusers;
     int __kind;
-    short __spins;
-    short __elision;
-    __pthread_list_t __list;
+    unsigned int __nusers;
+    __extension__ union
+    {
+      struct
+      {
+ short __espins;
+ short __elision;
+      } __elision_data;
+      __pthread_slist_t __list;
+    };
   } __data;
-  char __size[40];
+  char __size[24];
   long int __align;
 } pthread_mutex_t;
 typedef union
@@ -303,14 +308,13 @@ typedef union
     unsigned int __writer_wakeup;
     unsigned int __nr_readers_queued;
     unsigned int __nr_writers_queued;
-    int __writer;
-    int __shared;
+    unsigned char __flags;
+    unsigned char __shared;
     signed char __rwelision;
-    unsigned char __pad1[7];
-    unsigned long int __pad2;
-    unsigned int __flags;
+    unsigned char __pad2;
+    int __writer;
   } __data;
-  char __size[56];
+  char __size[32];
   long int __align;
 } pthread_rwlock_t;
 typedef union
@@ -321,7 +325,7 @@ typedef union
 typedef volatile int pthread_spinlock_t;
 typedef union
 {
-  char __size[32];
+  char __size[20];
   long int __align;
 } pthread_barrier_t;
 typedef union

--- a/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
+++ b/c/heap-manipulation/dll_of_dll_true-unreach-call_true-valid-memsafety.i
@@ -1241,7 +1241,8 @@ struct master_item* alloc_or_die_master(void)
     return ptr;
 }
 
-void dll_insert_slave(struct slave_item **dll)
+
+void dll_insert_slave(void **dll)
 {
     struct slave_item *item = alloc_or_die_slave();
     struct slave_item *next = *dll;
@@ -1252,12 +1253,12 @@ void dll_insert_slave(struct slave_item **dll)
     *dll = item;
 }
 
-void* dll_create_generic(void (*insert_fnc)(void **dll))
+void* dll_create_generic(void (*insert_fnc)(void**))
 {
     void *dll = 
-# 63 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+# 64 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
                ((void *)0)
-# 63 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+# 64 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
                    ;
     insert_fnc(&dll);
     insert_fnc(&dll);
@@ -1294,9 +1295,9 @@ void dll_reinit_nested_lists(struct master_item *dll)
 {
     while (dll) {
         dll->slave = 
-# 98 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
+# 99 "dll_of_dll_true-unreach-call_true-valid-memsafety.c" 3 4
                     ((void *)0)
-# 98 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
+# 99 "dll_of_dll_true-unreach-call_true-valid-memsafety.c"
                         ;
         dll = dll->next;
     }
@@ -1311,7 +1312,8 @@ void dll_destroy_master(struct master_item *dll)
     }
 }
 
-void dll_insert_master(struct master_item **dll)
+
+void dll_insert_master(void **dll)
 {
     struct master_item *item = alloc_or_die_master();
     struct master_item *next = *dll;


### PR DESCRIPTION
(*insert_fnc)() declares insert_fnc as a function pointer with an
unknown number and type of parameters, not with an empty list of
parameters.  This may be an underspecification that can lead to possible
undefined behaviour.  This commit fixes that in two benchmarks of
Predator.

Should solve issue #462 reported by @PhilippWendler .