### PR TITLE
Fix labels for tasks with overflows in left-shift operations

### DIFF
--- a/c/bitvector/byte_add_1_false-no-overflow.c
+++ b/c/bitvector/byte_add_1_false-no-overflow.c
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;
 }

--- a/c/bitvector/byte_add_1_false-no-overflow.c
+++ b/c/bitvector/byte_add_1_false-no-overflow.c
@@ -94,6 +94,9 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
+    // (r3 << 24U) is undefined behavior if r3 > 127, because
+    // r3 gets promoted to int and r3<<24U will exceed INT_MAX
+    // (see ISO/IEC 9899:2011 6.5.7#4)
     r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;

--- a/c/bitvector/byte_add_1_false-no-overflow.i
+++ b/c/bitvector/byte_add_1_false-no-overflow.i
@@ -7,32 +7,36 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-/* emulates multi-precision addition */
-#include <assert.h>
+
+extern void __assert_fail (__const char *__assertion, __const char *__file,
+      unsigned int __line, __const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, __const char *__file,
+      unsigned int __line,
+      __const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 unsigned int mp_add(unsigned int a, unsigned int b)
 {
     unsigned char a0, a1, a2, a3;
     unsigned char b0, b1, b2, b3;
     unsigned char r0, r1, r2, r3;
-
     unsigned short carry;
     unsigned short partial_sum;
     unsigned int r;
     unsigned char i;
     unsigned char na, nb;
-
     a0 = a;
     a1 = a >> 8;
     a2 = a >> 16U;
     a3 = a >> 24U;
-
     b0 = b;
     b1 = b >> 8U;
     b2 = b >> 16U;
     b3 = b >> 24U;
-
-    na = (unsigned char)4; /* num of components of a */
+    na = (unsigned char)4;
     if (a3 == (unsigned char)0) {
         na = na - 1;
         if (a2 == (unsigned char)0) {
@@ -42,8 +46,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-
-    nb = (unsigned char)4; /* num of components of b */
+    nb = (unsigned char)4;
     if (b3 == (unsigned char)0) {
         nb = nb - 1;
         if (b2 == (unsigned char)0) {
@@ -53,13 +56,11 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-    
     carry = (unsigned short)0;
     i = (unsigned char)0;
     while ((i < na) || (i < nb) || (carry != (unsigned short)0)) {
         partial_sum = carry;
         carry = (unsigned short)0;
-
         if (i < na) {
             if (i == (unsigned char)0) { partial_sum = partial_sum + a0; }
             if (i == (unsigned char)1) { partial_sum = partial_sum + a1; }
@@ -76,11 +77,10 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             partial_sum = partial_sum & ((unsigned char)255);
             carry = (unsigned short)1;
         }
-
         if (i == (unsigned char)0) { r0 = (unsigned char)partial_sum; }
         if (i == (unsigned char)1) { r1 = (unsigned char)partial_sum; }
         if (i == (unsigned char)2) { r2 = (unsigned char)partial_sum; }
-        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }        
+        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }
 
         i = i + (unsigned char)1;
     }
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;
 }
@@ -111,6 +111,6 @@ int main()
     r = mp_add(a, b);
 
     __VERIFIER_assert(r == a + b);
-    
+
     return 0;
 }

--- a/c/bitvector/byte_add_1_true-unreach-call_true-no-overflow.i
+++ b/c/bitvector/byte_add_1_true-unreach-call_true-no-overflow.i
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
 
     return r;
 }

--- a/c/bitvector/byte_add_2_false-no-overflow.c
+++ b/c/bitvector/byte_add_2_false-no-overflow.c
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;
 }
@@ -104,9 +104,8 @@ int main()
 {
     unsigned int a, b, r;
 
-    b = __VERIFIER_nondet_uint();
-
-    a = 234770789;
+    a = __VERIFIER_nondet_uint();
+    b = 234770789;
 
     r = mp_add(a, b);
 

--- a/c/bitvector/byte_add_2_false-no-overflow.c
+++ b/c/bitvector/byte_add_2_false-no-overflow.c
@@ -94,6 +94,9 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
+    // (r3 << 24U) is undefined behavior if r3 > 127, because
+    // r3 gets promoted to int and r3<<24U will exceed INT_MAX
+    // (see ISO/IEC 9899:2011 6.5.7#4)
     r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;

--- a/c/bitvector/byte_add_2_false-no-overflow.i
+++ b/c/bitvector/byte_add_2_false-no-overflow.i
@@ -7,32 +7,36 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-/* emulates multi-precision addition */
-#include <assert.h>
+
+extern void __assert_fail (__const char *__assertion, __const char *__file,
+      unsigned int __line, __const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, __const char *__file,
+      unsigned int __line,
+      __const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 unsigned int mp_add(unsigned int a, unsigned int b)
 {
     unsigned char a0, a1, a2, a3;
     unsigned char b0, b1, b2, b3;
     unsigned char r0, r1, r2, r3;
-
     unsigned short carry;
     unsigned short partial_sum;
     unsigned int r;
     unsigned char i;
     unsigned char na, nb;
-
     a0 = a;
     a1 = a >> 8;
     a2 = a >> 16U;
     a3 = a >> 24U;
-
     b0 = b;
     b1 = b >> 8U;
     b2 = b >> 16U;
     b3 = b >> 24U;
-
-    na = (unsigned char)4; /* num of components of a */
+    na = (unsigned char)4;
     if (a3 == (unsigned char)0) {
         na = na - 1;
         if (a2 == (unsigned char)0) {
@@ -42,8 +46,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-
-    nb = (unsigned char)4; /* num of components of b */
+    nb = (unsigned char)4;
     if (b3 == (unsigned char)0) {
         nb = nb - 1;
         if (b2 == (unsigned char)0) {
@@ -53,13 +56,11 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-    
     carry = (unsigned short)0;
     i = (unsigned char)0;
     while ((i < na) || (i < nb) || (carry != (unsigned short)0)) {
         partial_sum = carry;
         carry = (unsigned short)0;
-
         if (i < na) {
             if (i == (unsigned char)0) { partial_sum = partial_sum + a0; }
             if (i == (unsigned char)1) { partial_sum = partial_sum + a1; }
@@ -76,11 +77,10 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             partial_sum = partial_sum & ((unsigned char)255);
             carry = (unsigned short)1;
         }
-
         if (i == (unsigned char)0) { r0 = (unsigned char)partial_sum; }
         if (i == (unsigned char)1) { r1 = (unsigned char)partial_sum; }
         if (i == (unsigned char)2) { r2 = (unsigned char)partial_sum; }
-        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }        
+        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }
 
         i = i + (unsigned char)1;
     }
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;
 }
@@ -103,14 +103,13 @@ unsigned int mp_add(unsigned int a, unsigned int b)
 int main()
 {
     unsigned int a, b, r;
+    a = __VERIFIER_nondet_uint();
 
-    b = __VERIFIER_nondet_uint();
-
-    a = 234770789;
+    b = 234770789;
 
     r = mp_add(a, b);
 
     __VERIFIER_assert(r == a + b);
-    
+
     return 0;
 }

--- a/c/bitvector/byte_add_2_true-unreach-call_true-no-overflow.c
+++ b/c/bitvector/byte_add_2_true-unreach-call_true-no-overflow.c
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
 
     return r;
 }

--- a/c/bitvector/byte_add_2_true-unreach-call_true-no-overflow.i
+++ b/c/bitvector/byte_add_2_true-unreach-call_true-no-overflow.i
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
 
     return r;
 }

--- a/c/bitvector/byte_add_false-no-overflow.c
+++ b/c/bitvector/byte_add_false-no-overflow.c
@@ -94,6 +94,9 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
+    // (r3 << 24U) is undefined behavior if r3 > 127, because
+    // r3 gets promoted to int and r3<<24U will exceed INT_MAX
+    // (see ISO/IEC 9899:2011 6.5.7#4)
     r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;

--- a/c/bitvector/byte_add_false-no-overflow.c
+++ b/c/bitvector/byte_add_false-no-overflow.c
@@ -72,7 +72,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             if (i == (unsigned char)2) { partial_sum = partial_sum + b2; }
             if (i == (unsigned char)3) { partial_sum = partial_sum + b3; }
         }
-        if (partial_sum > ((unsigned char)255)) {
+        if (partial_sum > ((unsigned char)254)) {
             partial_sum = partial_sum & ((unsigned char)255);
             carry = (unsigned short)1;
         }
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;
 }
@@ -104,9 +104,8 @@ int main()
 {
     unsigned int a, b, r;
 
+    a = __VERIFIER_nondet_uint();
     b = __VERIFIER_nondet_uint();
-
-    a = 234770789;
 
     r = mp_add(a, b);
 

--- a/c/bitvector/byte_add_false-no-overflow.i
+++ b/c/bitvector/byte_add_false-no-overflow.i
@@ -7,32 +7,36 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-/* emulates multi-precision addition */
-#include <assert.h>
+
+extern void __assert_fail (__const char *__assertion, __const char *__file,
+      unsigned int __line, __const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, __const char *__file,
+      unsigned int __line,
+      __const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
 
 unsigned int mp_add(unsigned int a, unsigned int b)
 {
     unsigned char a0, a1, a2, a3;
     unsigned char b0, b1, b2, b3;
     unsigned char r0, r1, r2, r3;
-
     unsigned short carry;
     unsigned short partial_sum;
     unsigned int r;
     unsigned char i;
     unsigned char na, nb;
-
     a0 = a;
     a1 = a >> 8;
     a2 = a >> 16U;
     a3 = a >> 24U;
-
     b0 = b;
     b1 = b >> 8U;
     b2 = b >> 16U;
     b3 = b >> 24U;
-
-    na = (unsigned char)4; /* num of components of a */
+    na = (unsigned char)4;
     if (a3 == (unsigned char)0) {
         na = na - 1;
         if (a2 == (unsigned char)0) {
@@ -42,8 +46,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-
-    nb = (unsigned char)4; /* num of components of b */
+    nb = (unsigned char)4;
     if (b3 == (unsigned char)0) {
         nb = nb - 1;
         if (b2 == (unsigned char)0) {
@@ -53,13 +56,11 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-    
     carry = (unsigned short)0;
     i = (unsigned char)0;
     while ((i < na) || (i < nb) || (carry != (unsigned short)0)) {
         partial_sum = carry;
         carry = (unsigned short)0;
-
         if (i < na) {
             if (i == (unsigned char)0) { partial_sum = partial_sum + a0; }
             if (i == (unsigned char)1) { partial_sum = partial_sum + a1; }
@@ -72,15 +73,14 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             if (i == (unsigned char)2) { partial_sum = partial_sum + b2; }
             if (i == (unsigned char)3) { partial_sum = partial_sum + b3; }
         }
-        if (partial_sum > ((unsigned char)255)) {
+        if (partial_sum > ((unsigned char)254)) {
             partial_sum = partial_sum & ((unsigned char)255);
             carry = (unsigned short)1;
         }
-
         if (i == (unsigned char)0) { r0 = (unsigned char)partial_sum; }
         if (i == (unsigned char)1) { r1 = (unsigned char)partial_sum; }
         if (i == (unsigned char)2) { r2 = (unsigned char)partial_sum; }
-        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }        
+        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }
 
         i = i + (unsigned char)1;
     }
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
 
     return r;
 }
@@ -104,13 +104,12 @@ int main()
 {
     unsigned int a, b, r;
 
+    a = __VERIFIER_nondet_uint();
     b = __VERIFIER_nondet_uint();
-
-    a = 234770789;
 
     r = mp_add(a, b);
 
     __VERIFIER_assert(r == a + b);
-    
+
     return 0;
 }

--- a/c/bitvector/byte_add_false-unreach-call_true-no-overflow.c
+++ b/c/bitvector/byte_add_false-unreach-call_true-no-overflow.c
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
 
     return r;
 }

--- a/c/bitvector/byte_add_false-unreach-call_true-no-overflow.i
+++ b/c/bitvector/byte_add_false-unreach-call_true-no-overflow.i
@@ -94,7 +94,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         i = i + (unsigned char)1;
     }
 
-    r = r0 | (r1 << 8U) | (r2 << 16U) | (r3 << 24U);
+    r = r0 | (r1 << 8U) | (r2 << 16U) | ((unsigned int)r3 << 24U);
 
     return r;
 }


### PR DESCRIPTION
Three tasks of similar fashion contain overflows in left-shifts:
the expression (r3 << 24U) triggers undefined behavior if the unsigned char r3 is larger than 127, because r3 gets promoted to int and r3<<24U will exceed INT_MAX (see ISO/IEC 9899:2011 6.5.7#4).
r3 does not get promoted to unsigned int as one might think, because all its values fit into int (ISO/IEC 9899:2011 6.3.1.1#2) 

Now the question is whether this classifies as an overflow, since the term overflow is not strictly defined anywhere. If an overflow is undefined behavior caused in (arithmetic) operations with signed integer types, then this is obviously an overflow. Otherwise, this is still undefined behavior and needs to be fixed.

This pull request currently does the following:
- Fix the overflows by explicitly casting r3 to unsigned int in the critical expression:
((unsigned int)r3 << 24U)
- Add copies of the unfixed files with label false-no-overflow and every other label removed
- Add a comment to the files labeled false-no-overflow explaining the nature of the overflow


