### PR TITLE
Avoid using __VERIFIER_nondet prefix for functions with side effects

### DIFF
--- a/c/array-memsafety/cstrchr_unsafe_false-valid-deref.c
+++ b/c/array-memsafety/cstrchr_unsafe_false-valid-deref.c
@@ -8,7 +8,7 @@
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -33,7 +33,7 @@ char *(cstrchr)(const char *s, int c)
  }
 
 int main() {
-    return *cstrchr(__VERIFIER_nondet_String(),__VERIFIER_nondet_int());
+    return *cstrchr(build_nondet_String(),__VERIFIER_nondet_int());
 }
 
 

--- a/c/array-memsafety/cstrchr_unsafe_false-valid-deref.i
+++ b/c/array-memsafety/cstrchr_unsafe_false-valid-deref.i
@@ -537,7 +537,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 extern int __VERIFIER_nondet_int(void);
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -553,5 +553,5 @@ char *(cstrchr)(const char *s, int c)
      return ( (*s == c) ? (char *) s : 0 );
  }
 int main() {
-    return *cstrchr(__VERIFIER_nondet_String(),__VERIFIER_nondet_int());
+    return *cstrchr(build_nondet_String(),__VERIFIER_nondet_int());
 }

--- a/c/array-memsafety/cstrlen_unsafe_false-valid-deref.c
+++ b/c/array-memsafety/cstrlen_unsafe_false-valid-deref.c
@@ -7,7 +7,7 @@
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -31,7 +31,7 @@ int (cstrlen)(const char *s)
  }
 
 int main() {
-  char* p = __VERIFIER_nondet_String();
+  char* p = build_nondet_String();
   int res = cstrlen(p);
   free(p);
   return res;

--- a/c/array-memsafety/cstrlen_unsafe_false-valid-deref.i
+++ b/c/array-memsafety/cstrlen_unsafe_false-valid-deref.i
@@ -537,7 +537,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 extern int __VERIFIER_nondet_int(void);
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -554,7 +554,7 @@ int (cstrlen)(const char *s)
      return (int)(p - s);
  }
 int main() {
-  char* p = __VERIFIER_nondet_String();
+  char* p = build_nondet_String();
   int res = cstrlen(p);
   free(p);
   return res;

--- a/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.c
+++ b/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.c
@@ -8,7 +8,7 @@
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -39,7 +39,7 @@ char *(cstrpbrk)(const char *s1, const char *s2)
  }
 
 int main() {
-    return *cstrpbrk(__VERIFIER_nondet_String(),__VERIFIER_nondet_String());
+    return *cstrpbrk(build_nondet_String(),build_nondet_String());
 }
 
 

--- a/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.i
+++ b/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.i
@@ -537,7 +537,7 @@ extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
 extern int __VERIFIER_nondet_int(void);
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -562,5 +562,5 @@ char *(cstrpbrk)(const char *s1, const char *s2)
      return 0;
  }
 int main() {
-    return *cstrpbrk(__VERIFIER_nondet_String(),__VERIFIER_nondet_String());
+    return *cstrpbrk(build_nondet_String(),build_nondet_String());
 }

--- a/c/termination-crafted-lit-todo/cstrncmp_true-termination.c
+++ b/c/termination-crafted-lit-todo/cstrncmp_true-termination.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -44,7 +44,7 @@ int (cstrncmp)(const char *s1, const char *s2, int n)
  }
 
 int main() {
-    return cstrncmp(__VERIFIER_nondet_String(),__VERIFIER_nondet_String(),__VERIFIER_nondet_int());
+    return cstrncmp(build_nondet_String(),build_nondet_String(),__VERIFIER_nondet_int());
 }
 
 

--- a/c/termination-crafted-lit-todo/strchr_true-termination.c
+++ b/c/termination-crafted-lit-todo/strchr_true-termination.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -34,7 +34,7 @@ char *(cstrchr)(const char *s, int c)
  }
 
 int main() {
-    cstrchr(__VERIFIER_nondet_String(),__VERIFIER_nondet_int());
+    cstrchr(build_nondet_String(),__VERIFIER_nondet_int());
     return 0;
 }
 

--- a/c/termination-crafted-lit/cstrcmp_true-termination_true-no-overflow.c
+++ b/c/termination-crafted-lit/cstrcmp_true-termination_true-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -41,7 +41,7 @@ int (cstrcmp)(const char *s1, const char *s2)
  }
 
 int main() {
-    return cstrcmp(__VERIFIER_nondet_String(),__VERIFIER_nondet_String());
+    return cstrcmp(build_nondet_String(),build_nondet_String());
 }
 
 

--- a/c/termination-crafted-lit/cstrcspn_true-termination_true-no-overflow.c
+++ b/c/termination-crafted-lit/cstrcspn_true-termination_true-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -39,7 +39,7 @@ int (cstrcspn)(const char *s1, const char *s2)
  }
 
 int main() {
-    return cstrcspn(__VERIFIER_nondet_String(),__VERIFIER_nondet_String());
+    return cstrcspn(build_nondet_String(),build_nondet_String());
 }
 
 

--- a/c/termination-crafted-lit/cstrlen_true-termination_true-no-overflow.c
+++ b/c/termination-crafted-lit/cstrlen_true-termination_true-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -33,7 +33,7 @@ int (cstrlen)(const char *s)
  }
 
 int main() {
-    return cstrlen(__VERIFIER_nondet_String());
+    return cstrlen(build_nondet_String());
 }
 
 

--- a/c/termination-crafted-lit/cstrncmp_false-no-overflow.c
+++ b/c/termination-crafted-lit/cstrncmp_false-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -44,7 +44,7 @@ int (cstrncmp)(const char *s1, const char *s2, int n)
  }
 
 int main() {
-    return cstrncmp(__VERIFIER_nondet_String(),__VERIFIER_nondet_String(),__VERIFIER_nondet_int());
+    return cstrncmp(build_nondet_String(),build_nondet_String(),__VERIFIER_nondet_int());
 }
 
 

--- a/c/termination-crafted-lit/cstrpbrk_true-termination_true-no-overflow.c
+++ b/c/termination-crafted-lit/cstrpbrk_true-termination_true-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -40,7 +40,7 @@ char *(cstrpbrk)(const char *s1, const char *s2)
  }
 
 int main() {
-    cstrpbrk(__VERIFIER_nondet_String(),__VERIFIER_nondet_String());
+    cstrpbrk(build_nondet_String(),build_nondet_String());
     return 0;
 }
 

--- a/c/termination-crafted-lit/cstrspn_true-termination_true-no-overflow.c
+++ b/c/termination-crafted-lit/cstrspn_true-termination_true-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -40,7 +40,7 @@ int (cstrspn)(const char *s1, const char *s2)
  }
 
 int main() {
-    return cstrspn(__VERIFIER_nondet_String(),__VERIFIER_nondet_String());
+    return cstrspn(build_nondet_String(),build_nondet_String());
 }
 
 

--- a/c/termination-crafted-lit/strchr_true-no-overflow.c
+++ b/c/termination-crafted-lit/strchr_true-no-overflow.c
@@ -9,7 +9,7 @@ void * __attribute__((__cdecl__)) malloc (size_t __size) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -34,7 +34,7 @@ char *(cstrchr)(const char *s, int c)
  }
 
 int main() {
-    cstrchr(__VERIFIER_nondet_String(),__VERIFIER_nondet_int());
+    cstrchr(build_nondet_String(),__VERIFIER_nondet_int());
     return 0;
 }
 

--- a/c/termination-recursive-malloc/rec_strcopy_malloc2_true-termination.c
+++ b/c/termination-recursive-malloc/rec_strcopy_malloc2_true-termination.c
@@ -3,7 +3,7 @@
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(int length) {
+char* build_nondet_String(int length) {
     char* nondetString = (char*) malloc(length * sizeof(char));
     nondetString[length-1] = '\0';
     return nondetString;
@@ -41,7 +41,7 @@ int main() {
         length = 1;
     }
 
-	char *original = __VERIFIER_nondet_String(length);
+	char *original = build_nondet_String(length);
 	
 	
     char *res = rec_strcopy(original);

--- a/c/termination-recursive-malloc/rec_strcopy_malloc2_true-termination.c.i
+++ b/c/termination-recursive-malloc/rec_strcopy_malloc2_true-termination.c.i
@@ -6,7 +6,7 @@ void __attribute__((__cdecl__)) free (void *) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(int length) {
+char* build_nondet_String(int length) {
     char* nondetString = (char*) malloc(length * sizeof(char));
     nondetString[length-1] = '\0';
     return nondetString;
@@ -44,7 +44,7 @@ int main() {
         length = 1;
     }
 
-	char *original = __VERIFIER_nondet_String(length);
+	char *original = build_nondet_String(length);
 	
 	
     char *res = rec_strcopy(original);

--- a/c/termination-recursive-malloc/rec_strcopy_malloc_true-termination.c
+++ b/c/termination-recursive-malloc/rec_strcopy_malloc_true-termination.c
@@ -3,7 +3,7 @@
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(int length) {
+char* build_nondet_String(int length) {
     char* nondetString = (char*) malloc(length * sizeof(char));
     nondetString[length-1] = '\0';
     return nondetString;
@@ -33,7 +33,7 @@ int main() {
         length = 1;
     }
 
-	char *original = __VERIFIER_nondet_String(length);
+	char *original = build_nondet_String(length);
 	
 	
     char *res = rec_strcopy(original, length);

--- a/c/termination-recursive-malloc/rec_strcopy_malloc_true-termination.c.i
+++ b/c/termination-recursive-malloc/rec_strcopy_malloc_true-termination.c.i
@@ -6,7 +6,7 @@ void __attribute__((__cdecl__)) free (void *) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(int length) {
+char* build_nondet_String(int length) {
     char* nondetString = (char*) malloc(length * sizeof(char));
     nondetString[length-1] = '\0';
     return nondetString;
@@ -36,7 +36,7 @@ int main() {
         length = 1;
     }
 
-	char *original = __VERIFIER_nondet_String(length);
+	char *original = build_nondet_String(length);
 	
 	
     char *res = rec_strcopy(original, length);

--- a/c/termination-recursive-malloc/rec_strlen_malloc_true-termination.c
+++ b/c/termination-recursive-malloc/rec_strlen_malloc_true-termination.c
@@ -3,7 +3,7 @@
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -24,5 +24,5 @@ int (rec_cstrlen)(const char *s)
  }
 
 int main() {
-    return rec_cstrlen(__VERIFIER_nondet_String());
+    return rec_cstrlen(build_nondet_String());
 }

--- a/c/termination-recursive-malloc/rec_strlen_malloc_true-termination.c.i
+++ b/c/termination-recursive-malloc/rec_strlen_malloc_true-termination.c.i
@@ -6,7 +6,7 @@ void __attribute__((__cdecl__)) free (void *) ;
 extern int __VERIFIER_nondet_int(void);
 
 /* Returns some null-terminated string. */
-char* __VERIFIER_nondet_String(void) {
+char* build_nondet_String(void) {
     int length = __VERIFIER_nondet_int();
     if (length < 1) {
         length = 1;
@@ -27,5 +27,5 @@ int (rec_cstrlen)(const char *s)
  }
 
 int main() {
-    return rec_cstrlen(__VERIFIER_nondet_String());
+    return rec_cstrlen(build_nondet_String());
 }


### PR DESCRIPTION
While SV-COMP rules explicitly list the suffixes that are guaranteed to yield
non-deterministic values and have no side effects, lots of benchmarks do use
different suffixes as well (but stick with the "non-det return value and no side
effects"). The use of __VERIFIER_nondet_String violated these assumptions; as an
implementation was provided, there was no need to use a __VERIFIER_nondet prefix
anyway.