### PR TITLE
Add nondet calls to remove undef behaviour in floats-cbmc-regression …

### DIFF
--- a/c/floats-cbmc-regression/float19_true-unreach-call.c
+++ b/c/floats-cbmc-regression/float19_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 #include <math.h>
 
 #ifdef __GNUC__
@@ -15,7 +16,7 @@ void f00 (float f)
 int main (void)
 {
   #ifdef __GNUC__
-  float f;
+  float f=__VERIFIER_nondet_float();
 
   f00(f);
   #endif

--- a/c/floats-cbmc-regression/float19_true-unreach-call.i
+++ b/c/floats-cbmc-regression/float19_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 
 
 
@@ -962,7 +963,7 @@ void f00 (float f)
 int main (void)
 {
 
-  float f;
+  float f=__VERIFIER_nondet_float();
 
   f00(f);
 

--- a/c/floats-cbmc-regression/float20_true-unreach-call.c
+++ b/c/floats-cbmc-regression/float20_true-unreach-call.c
@@ -1,5 +1,7 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
+extern double __VERIFIER_nondet_double(void);
 /*
 ** float-rounder-bug.c
 **
@@ -44,13 +46,13 @@ void bugCasting (double d) {
 }
 
 int main (void) {
-  float f;
+  float f=__VERIFIER_nondet_float();
   bug(f);
 
-  float g;
+  float g=__VERIFIER_nondet_float();
   bugBrokenOut(g);
 
-  double d;
+  double d=__VERIFIER_nondet_double();
   bugCasting(d);
 
   return 1;

--- a/c/floats-cbmc-regression/float20_true-unreach-call.i
+++ b/c/floats-cbmc-regression/float20_true-unreach-call.i
@@ -1,5 +1,7 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
+extern double __VERIFIER_nondet_double(void);
 void bug (float min) {
   __VERIFIER_assume(min == 0x1.fffffep-105f);
   float modifier = (0x1.0p-23 * (1<<1));
@@ -32,13 +34,13 @@ void bugCasting (double d) {
 }
 
 int main (void) {
-  float f;
+  float f=__VERIFIER_nondet_float();
   bug(f);
 
-  float g;
+  float g=__VERIFIER_nondet_float();
   bugBrokenOut(g);
 
-  double d;
+  double d=__VERIFIER_nondet_double();
   bugCasting(d);
 
   return 1;

--- a/c/floats-cbmc-regression/float5_true-unreach-call.c
+++ b/c/floats-cbmc-regression/float5_true-unreach-call.c
@@ -1,9 +1,10 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float a, b;
-  
+  float a=__VERIFIER_nondet_float(), b=__VERIFIER_nondet_float();
+
   __VERIFIER_assume(a==1 || a==0.5 || a==2 || a==3 || a==0.1);
   b=a;
   a/=2;

--- a/c/floats-cbmc-regression/float5_true-unreach-call.i
+++ b/c/floats-cbmc-regression/float5_true-unreach-call.i
@@ -1,8 +1,9 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
-  float a, b;
+  float a=__VERIFIER_nondet_float(), b=__VERIFIER_nondet_float();
 
   __VERIFIER_assume(a==1 || a==0.5 || a==2 || a==3 || a==0.1);
   b=a;

--- a/c/floats-cbmc-regression/float6_true-unreach-call.c
+++ b/c/floats-cbmc-regression/float6_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
   // constants
@@ -23,7 +24,7 @@ int main()
   if(!(!(-2.0>=-1.0))) __VERIFIER_error();  
   
   // variables
-  float a, b, _a=a, _b=b;
+  float a=__VERIFIER_nondet_float(), b=__VERIFIER_nondet_float();
   __VERIFIER_assume(a==1 && b==2);
 
   if(!(a!=b)) __VERIFIER_error();

--- a/c/floats-cbmc-regression/float6_true-unreach-call.i
+++ b/c/floats-cbmc-regression/float6_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_assume(int);
 extern void __VERIFIER_error(void);
+extern float __VERIFIER_nondet_float(void);
 int main()
 {
 
@@ -23,7 +24,7 @@ int main()
   if(!(!(-2.0>=-1.0))) __VERIFIER_error();
 
 
-  float a, b, _a=a, _b=b;
+  float a=__VERIFIER_nondet_float(), b=__VERIFIER_nondet_float();
   __VERIFIER_assume(a==1 && b==2);
 
   if(!(a!=b)) __VERIFIER_error();


### PR DESCRIPTION
These benchmarks have undefined behaviour due to uninitialised variables. The changes add `_VERIFIER_nondet_*` calls to remove this undefined behaviour.
