### PR TITLE
Add array initialisation to remove undefined behaviour in array-examples

### DIFF
--- a/c/array-examples/sanfoundry_10_true-unreach-call_ground.c
+++ b/c/array-examples/sanfoundry_10_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 /*
  * Adapted from http://www.sanfoundry.com/c-programming-examples-arrays/
@@ -11,7 +12,7 @@ int main()
     int i;
     int n = 100000;
     int pos;
-    int element;
+    int element = __VERIFIER_nondet_int();
     int found = 0;
     int vectorx[n];
  

--- a/c/array-examples/sanfoundry_10_true-unreach-call_ground.i
+++ b/c/array-examples/sanfoundry_10_true-unreach-call_ground.i
@@ -1,11 +1,12 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
     int i;
     int n = 100000;
     int pos;
-    int element;
+    int element = __VERIFIER_nondet_int();
     int found = 0;
     int vectorx[n];
     for (i = 0; i < n && !found; i++)

--- a/c/array-examples/standard_copy1_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy1_false-unreach-call_ground.c
@@ -1,13 +1,20 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
 int main( ) {
   int a1[N];
   int a2[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+      a1[a] = __VERIFIER_nondet_int();
+      a2[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a1[i] = a1[i];
   }

--- a/c/array-examples/standard_copy1_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy1_false-unreach-call_ground.i
@@ -1,8 +1,14 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+      a1[a] = __VERIFIER_nondet_int();
+      a2[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a1[i] = a1[i];

--- a/c/array-examples/standard_copy1_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy1_true-unreach-call_ground.c
@@ -1,13 +1,19 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
 int main( ) {
   int a1[N];
   int a2[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+      a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy1_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy1_true-unreach-call_ground.i
@@ -1,8 +1,13 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+      a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy2_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy2_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -7,8 +8,14 @@ int main( ) {
   int a1[N];
   int a2[N];
   int a3[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a2[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a3[i] = a1[i];
   }

--- a/c/array-examples/standard_copy2_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy2_false-unreach-call_ground.i
@@ -1,9 +1,15 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
   int a3[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a2[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a3[i] = a1[i];

--- a/c/array-examples/standard_copy2_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy2_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -7,8 +8,13 @@ int main( ) {
   int a1[N];
   int a2[N];
   int a3[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+      a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy2_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy2_true-unreach-call_ground.i
@@ -1,9 +1,14 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
   int a3[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+      a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy3_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy3_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -8,8 +9,14 @@ int main( ) {
   int a2[N];
   int a3[N];
   int a4[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a3[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy3_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy3_false-unreach-call_ground.i
@@ -1,10 +1,16 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
   int a3[100000];
   int a4[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a3[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy3_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy3_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -8,8 +9,13 @@ int main( ) {
   int a2[N];
   int a3[N];
   int a4[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy3_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy3_true-unreach-call_ground.i
@@ -1,10 +1,15 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
   int a3[100000];
   int a4[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy4_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy4_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -9,8 +10,14 @@ int main( ) {
   int a3[N];
   int a4[N];
   int a5[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a4[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy4_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy4_false-unreach-call_ground.i
@@ -1,11 +1,17 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
   int a3[100000];
   int a4[100000];
   int a5[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a4[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy4_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy4_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -9,8 +10,13 @@ int main( ) {
   int a3[N];
   int a4[N];
   int a5[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy4_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy4_true-unreach-call_ground.i
@@ -1,11 +1,16 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
   int a3[100000];
   int a4[100000];
   int a5[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy5_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy5_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -10,8 +11,14 @@ int main( ) {
   int a4[N];
   int a5[N];
   int a6[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a5[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy5_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy5_false-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -7,6 +8,11 @@ int main( ) {
   int a4[100000];
   int a5[100000];
   int a6[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a5[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy5_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy5_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -10,8 +11,13 @@ int main( ) {
   int a4[N];
   int a5[N];
   int a6[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy5_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy5_true-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -7,6 +8,10 @@ int main( ) {
   int a4[100000];
   int a5[100000];
   int a6[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy6_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy6_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -11,8 +12,14 @@ int main( ) {
   int a5[N];
   int a6[N];
   int a7[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a6[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy6_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy6_false-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -8,6 +9,11 @@ int main( ) {
   int a5[100000];
   int a6[100000];
   int a7[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a6[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy6_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy6_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -11,8 +12,13 @@ int main( ) {
   int a5[N];
   int a6[N];
   int a7[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy6_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy6_true-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -8,6 +9,10 @@ int main( ) {
   int a5[100000];
   int a6[100000];
   int a7[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy7_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy7_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -12,8 +13,14 @@ int main( ) {
   int a6[N];
   int a7[N];
   int a8[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a7[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy7_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy7_false-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -9,6 +10,11 @@ int main( ) {
   int a6[100000];
   int a7[100000];
   int a8[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a7[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy7_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy7_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -12,8 +13,13 @@ int main( ) {
   int a6[N];
   int a7[N];
   int a8[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy7_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy7_true-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -9,6 +10,10 @@ int main( ) {
   int a6[100000];
   int a7[100000];
   int a8[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy8_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy8_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -13,8 +14,14 @@ int main( ) {
   int a7[N];
   int a8[N];
   int a9[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a8[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy8_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy8_false-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -10,6 +11,11 @@ int main( ) {
   int a7[100000];
   int a8[100000];
   int a9[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a8[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy8_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy8_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -13,8 +14,13 @@ int main( ) {
   int a7[N];
   int a8[N];
   int a9[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy8_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy8_true-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -10,6 +11,10 @@ int main( ) {
   int a7[100000];
   int a8[100000];
   int a9[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy9_false-unreach-call_ground.c
+++ b/c/array-examples/standard_copy9_false-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -14,8 +15,14 @@ int main( ) {
   int a8[N];
   int a9[N];
   int a0[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a9[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy9_false-unreach-call_ground.i
+++ b/c/array-examples/standard_copy9_false-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -11,6 +12,11 @@ int main( ) {
   int a8[100000];
   int a9[100000];
   int a0[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+    a9[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_copy9_true-unreach-call_ground.c
+++ b/c/array-examples/standard_copy9_true-unreach-call_ground.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
@@ -14,8 +15,13 @@ int main( ) {
   int a8[N];
   int a9[N];
   int a0[N];
-  
-  int i; 
+
+  int a;
+  for ( a = 0 ; a < N ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
+
+  int i;
   for ( i = 0 ; i < N ; i++ ) {
     a2[i] = a1[i];
   }

--- a/c/array-examples/standard_copy9_true-unreach-call_ground.i
+++ b/c/array-examples/standard_copy9_true-unreach-call_ground.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( ) {
   int a1[100000];
   int a2[100000];
@@ -11,6 +12,10 @@ int main( ) {
   int a8[100000];
   int a9[100000];
   int a0[100000];
+  int a;
+  for ( a = 0 ; a < 100000 ; a++ ) {
+    a1[a] = __VERIFIER_nondet_int();
+  }
   int i;
   for ( i = 0 ; i < 100000 ; i++ ) {
     a2[i] = a1[i];

--- a/c/array-examples/standard_find_ground_false-def-behavior.c
+++ b/c/array-examples/standard_find_ground_false-def-behavior.c
@@ -1,12 +1,13 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
 int main ( ) {
-  int a[N]; int e;
+  int a[N]; int e = __VERIFIER_nondet_int();
   int i = 0;
-  while( i < N && a[i] != e ) { // use of uninitialized e
+  while( i < N && a[i] != e ) {
     i = i + 1;
   }
   

--- a/c/array-examples/standard_find_ground_false-def-behavior.i
+++ b/c/array-examples/standard_find_ground_false-def-behavior.i
@@ -1,7 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main ( ) {
-  int a[100000]; int e;
+  int a[100000]; int e = __VERIFIER_nondet_int();
   int i = 0;
   while( i < 100000 && a[i] != e ) {
     i = i + 1;

--- a/c/array-examples/standard_sentinel_false-def-behavior.c
+++ b/c/array-examples/standard_sentinel_false-def-behavior.c
@@ -1,21 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define N 100000
 
 int main ( ) {
   int a[N];
-  int marker; 
-  int pos;
-  if ( pos >= 0 && pos < N ) { // use of uninitialized pos
-    a[ pos ] = marker; // use of uninitialized marker
+  int marker = __VERIFIER_nondet_int();
+  int pos = __VERIFIER_nondet_int();
+  if ( pos >= 0 && pos < N ) {
+    a[ pos ] = marker;
 
     int i = 0;
-    while( a[ i ] != marker ) { // use of uninitialized marker
+    while( a[ i ] != marker ) {
       i = i + 1;
     }
    
-    __VERIFIER_assert(  i <= pos  ); // use of uninitialized pos
+    __VERIFIER_assert(  i <= pos  );
   }
   return 0;
 }

--- a/c/array-examples/standard_sentinel_false-def-behavior.i
+++ b/c/array-examples/standard_sentinel_false-def-behavior.i
@@ -1,9 +1,10 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main ( ) {
   int a[100000];
-  int marker;
-  int pos;
+  int marker = __VERIFIER_nondet_int();
+  int pos = __VERIFIER_nondet_int();
   if ( pos >= 0 && pos < 100000 ) {
     a[ pos ] = marker;
     int i = 0;

--- a/c/array-examples/standard_two_index_01_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_01_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 10000
 int main()
@@ -8,7 +9,14 @@ int main()
   int b[size];
   int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 0;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+1;

--- a/c/array-examples/standard_two_index_01_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_01_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
   int a[10000];
   int b[10000];
   int i = 0;
   int j = 0;
+  while( i < 10000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 0;
   while( i < 10000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_02_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_02_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 100000
 int main()
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+2;

--- a/c/array-examples/standard_two_index_02_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_02_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main()
 {
   int a[100000];
   int b[100000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 100000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 1;
   while( i < 100000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_03_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_03_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 10000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+3;

--- a/c/array-examples/standard_two_index_03_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_03_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[10000];
   int b[10000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 10000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 1;
   while( i < 10000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_04_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_04_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 100000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+4;

--- a/c/array-examples/standard_two_index_04_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_04_true-unreach-call.i
@@ -1,11 +1,19 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[100000];
   int b[100000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 100000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
   while( i < 100000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_05_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_05_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 100000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+5;

--- a/c/array-examples/standard_two_index_05_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_05_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[100000];

--- a/c/array-examples/standard_two_index_05_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_05_true-unreach-call.i
@@ -4,8 +4,15 @@ int main( )
 {
   int a[100000];
   int b[100000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 100000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
   while( i < 100000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_06_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_06_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 10000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+6;

--- a/c/array-examples/standard_two_index_06_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_06_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[10000];
   int b[10000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 10000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 1;
   while( i < 10000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_07_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_07_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 100000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+7;

--- a/c/array-examples/standard_two_index_07_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_07_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[100000];
   int b[100000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 100000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 1;
   while( i < 100000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_08_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_08_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 100000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+8;

--- a/c/array-examples/standard_two_index_08_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_08_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[100000];
   int b[100000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 100000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 1;
   while( i < 100000 )
   {
  a[j] = b[i];

--- a/c/array-examples/standard_two_index_09_true-unreach-call.c
+++ b/c/array-examples/standard_two_index_09_true-unreach-call.c
@@ -1,14 +1,22 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 
 #define size 100000
 int main( )
 {
   int a[size];
   int b[size];
-  int i = 1;
+  int i = 0;
   int j = 0;
-  while( i < size ) 
+  while( i < size )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+
+  i = 1;
+  while( i < size )
   {
 	a[j] = b[i];
         i = i+9;

--- a/c/array-examples/standard_two_index_09_true-unreach-call.i
+++ b/c/array-examples/standard_two_index_09_true-unreach-call.i
@@ -1,11 +1,18 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern int __VERIFIER_nondet_int();
 int main( )
 {
   int a[100000];
   int b[100000];
-  int i = 1;
+  int i = 0;
   int j = 0;
+  while( i < 100000 )
+  {
+	b[i] = __VERIFIER_nondet_int();
+    i = i+1;
+  }
+  i = 1;
   while( i < 100000 )
   {
  a[j] = b[i];


### PR DESCRIPTION
These changes add loops to initialise arrays in a collection of similar benchmarks in array-examples. Without the initialisation some of the arrays are used before being assigned, which leads to undefined behaviour.