### PR TITLE
Loops undef

### DIFF
--- a/c/loops/nec20_false-unreach-call_true-termination.c
+++ b/c/loops/nec20_false-unreach-call_true-termination.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+int __VERIFIER_nondet_int();
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -20,6 +21,9 @@ int main(){
    }
 
    i=0;
+   j=__VERIFIER_nondet_int();
+   if (j > 10000)
+     return 0;
 
    while ( i <= n){
       i++;

--- a/c/loops/nec20_false-unreach-call_true-termination.i
+++ b/c/loops/nec20_false-unreach-call_true-termination.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+int __VERIFIER_nondet_int();
 
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -20,6 +21,9 @@ int main(){
    }
 
    i=0;
+   j=__VERIFIER_nondet_int();
+   if (j < 10000)
+     return 0;
 
    while ( i <= n){
       i++;

--- a/c/loops/nec20_false-unreach-call_true-termination.i
+++ b/c/loops/nec20_false-unreach-call_true-termination.i
@@ -22,7 +22,7 @@ int main(){
 
    i=0;
    j=__VERIFIER_nondet_int();
-   if (j < 10000)
+   if (j > 10000)
      return 0;
 
    while ( i <= n){


### PR DESCRIPTION
Make sure that `j` is initialised since it is used in the following loop. Limit the value of `j` so that the subsequent code can't overflow.
