### PR TITLE
Fix memory leak in two benchmarks with false-valid-deref verdict

### DIFF
--- a/c/array-memsafety/cstrchr_unsafe_false-valid-deref.c
+++ b/c/array-memsafety/cstrchr_unsafe_false-valid-deref.c
@@ -33,7 +33,10 @@ char *(cstrchr)(const char *s, int c)
  }
 
 int main() {
-    return *cstrchr(build_nondet_String(),__VERIFIER_nondet_int());
+  char* s = build_nondet_String();
+  int res = *cstrchr(s,__VERIFIER_nondet_int());
+  free(s);
+  return res;
 }
 
 

--- a/c/array-memsafety/cstrchr_unsafe_false-valid-deref.i
+++ b/c/array-memsafety/cstrchr_unsafe_false-valid-deref.i
@@ -553,5 +553,8 @@ char *(cstrchr)(const char *s, int c)
      return ( (*s == c) ? (char *) s : 0 );
  }
 int main() {
-    return *cstrchr(build_nondet_String(),__VERIFIER_nondet_int());
+  char* s = build_nondet_String();
+  int res = *cstrchr(s,__VERIFIER_nondet_int());
+  free(s);
+  return res;
 }

--- a/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.c
+++ b/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.c
@@ -39,7 +39,12 @@ char *(cstrpbrk)(const char *s1, const char *s2)
  }
 
 int main() {
-    return *cstrpbrk(build_nondet_String(),build_nondet_String());
+  char* s1 = build_nondet_String();
+  char* s2 = build_nondet_String();
+  int res = *cstrpbrk(s1,s2);
+  free(s1);
+  free(s2);
+  return res;
 }
 
 

--- a/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.i
+++ b/c/array-memsafety/cstrpbrk_unsafe_false-valid-deref.i
@@ -562,5 +562,10 @@ char *(cstrpbrk)(const char *s1, const char *s2)
      return 0;
  }
 int main() {
-    return *cstrpbrk(build_nondet_String(),build_nondet_String());
+  char* s1 = build_nondet_String();
+  char* s2 = build_nondet_String();
+  int res = *cstrpbrk(s1,s2);
+  free(s1);
+  free(s2);
+  return res;
 }


### PR DESCRIPTION
Same fix as the one in 68cc7e62.

Signed-off-by: Mikhail Ramalho <mikhail.ramalho@gmail.com>