### PR TITLE
Define s->version field in ssh client benchmarks

### DIFF
--- a/c/loops/s3_false-unreach-call.i
+++ b/c/loops/s3_false-unreach-call.i
@@ -5,6 +5,7 @@ extern void *malloc(unsigned int sz);
 
 
 extern int __VERIFIER_nondet_int(void);
+extern void *__VERIFIER_nondet_pointer(void);
 
 typedef unsigned int size_t;
 typedef long __time_t;
@@ -1065,13 +1066,14 @@ int main(void)
   s = malloc (sizeof (SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);
 }
 }
 int ssl3_connect(SSL *s )
-{ BUF_MEM *buf ;
+{ BUF_MEM *buf = __VERIFIER_nondet_pointer();
   unsigned long tmp ;
   unsigned long l ;
   long num1 ;
@@ -1081,8 +1083,8 @@ int ssl3_connect(SSL *s )
   int state ;
   int skip ;
   int *tmp___0 ;
-  int tmp___1 ;
-  int tmp___2 ;
+  int tmp___1 = __VERIFIER_nondet_int();
+  int tmp___2 = __VERIFIER_nondet_int();
   int tmp___3 ;
   int tmp___4 ;
   int tmp___5 ;

--- a/c/loops/s3_false-unreach-call.i
+++ b/c/loops/s3_false-unreach-call.i
@@ -1065,6 +1065,7 @@ int main(void)
   {
   s = malloc (sizeof (SSL));
   s->s3 = malloc(sizeof(struct ssl3_state_st));
+  s->ctx = malloc(sizeof(SSL_CTX));
   s->state = 12292;
   s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);

--- a/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
@@ -1071,6 +1071,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);

--- a/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
@@ -1070,6 +1070,7 @@ int main(void)
   s->ctx = malloc(sizeof(SSL_CTX));
   s->session = malloc(sizeof(SSL_SESSION));
   s->state = 12292;
+  s->version = __VERIFIER_nondet_int();
   ssl3_connect(s);
   }
   return (0);


### PR DESCRIPTION
In all of these benchmarks if `s->version` is not initialised then the bevhaviour is undefined but includes a path that leads to the `((s->version & 65280) != 768)` condition being true which causes the program to immediately exit. A tool is free to choose this path given the undefined behaviour. These fixes initialise `s->version` so that this condition is defined.

In the s3 benchmark some other temporary variables are now initialised to remove some other warnings.

Fixes #488
