### PR TITLE
make the loop body of terminator_02_true reachable

### DIFF
--- a/c/loops/terminator_02_true-unreach-call_true-termination.c
+++ b/c/loops/terminator_02_true-unreach-call_true-termination.c
@@ -13,13 +13,12 @@ _Bool __VERIFIER_nondet_bool();
 int main()
 {
     int x=__VERIFIER_nondet_int();
-    int y=__VERIFIER_nondet_int();
     int z=__VERIFIER_nondet_int();
-    if (!(x<100)) return 0;
     if (!(x>-100)) return 0;
-    if (!(z<100)) return 0;
-    if (!(z>-100)) return 0;
-    while(x<100 && 100<z) 
+    if (!(x<200)) return 0;
+    if (!(z>100)) return 0;
+    if (!(z<200)) return 0;
+    while(x<100 && z>100) 
     {
         _Bool tmp=__VERIFIER_nondet_bool();
         if (tmp) {

--- a/c/loops/terminator_02_true-unreach-call_true-termination.i
+++ b/c/loops/terminator_02_true-unreach-call_true-termination.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
@@ -8,16 +9,16 @@ void __VERIFIER_assert(int cond) {
 }
 int __VERIFIER_nondet_int();
 _Bool __VERIFIER_nondet_bool();
+
 int main()
 {
     int x=__VERIFIER_nondet_int();
-    int y=__VERIFIER_nondet_int();
     int z=__VERIFIER_nondet_int();
-    if (!(x<100)) return 0;
     if (!(x>-100)) return 0;
-    if (!(z<100)) return 0;
-    if (!(z>-100)) return 0;
-    while(x<100 && 100<z)
+    if (!(x<200)) return 0;
+    if (!(z>100)) return 0;
+    if (!(z<200)) return 0;
+    while(x<100 && z>100)
     {
         _Bool tmp=__VERIFIER_nondet_bool();
         if (tmp) {
@@ -27,6 +28,8 @@ int main()
             z--;
         }
     }
+
     __VERIFIER_assert(x>=100 || z<=100);
+
     return 0;
 }


### PR DESCRIPTION
Replace the if-statements by assume statements to make the
loop body of terminator_02_true-unreach-call_true-termination.c
reachable and avoid signed overflows.

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [ ] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [ ] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
