### PR TITLE
Add assume statements to avoid undefined behavior in seq-mthreaded

### DIFF
--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
@@ -156,6 +156,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -292,6 +293,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
@@ -160,6 +160,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -296,6 +297,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
@@ -163,6 +163,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -299,6 +300,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
@@ -171,6 +171,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -307,6 +308,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt !=0 );
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M1.c
@@ -169,6 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -315,6 +316,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M1.c
@@ -169,6 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -312,6 +313,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
@@ -158,6 +158,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -294,6 +295,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
@@ -162,6 +162,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN * args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -298,6 +299,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M1.c
@@ -169,6 +169,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN * args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -311,7 +312,8 @@ void OSEK_Task_ts1(void)
   gyro_offset += tmp___0;
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
-  if (tmp___1 - cal_start_time >= 1000U) {
+  if (tmp___1 - cal_start_time >= 1000U) {   
+    __VERIFIER_assume(avg_cnt != 0); 
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M4.c
@@ -173,6 +173,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -316,6 +317,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
@@ -150,6 +150,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -281,6 +282,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
@@ -150,6 +150,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -281,6 +282,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
@@ -157,6 +157,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -295,6 +296,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
@@ -161,6 +161,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -299,6 +300,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
@@ -150,6 +150,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -281,6 +282,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
@@ -150,6 +150,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -281,6 +282,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
@@ -155,6 +155,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -286,6 +287,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
@@ -159,6 +159,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -290,6 +291,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
@@ -157,6 +157,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -295,6 +296,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
@@ -161,6 +161,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -299,6 +300,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
@@ -151,6 +151,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -287,6 +288,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
@@ -157,6 +157,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -293,6 +294,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M1.c
@@ -164,6 +164,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -307,6 +308,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
@@ -153,6 +153,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -289,6 +290,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M1.c
@@ -164,6 +164,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -307,6 +308,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M1.c
@@ -164,6 +164,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -310,6 +311,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
@@ -146,6 +146,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -277,6 +278,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
@@ -152,6 +152,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -290,6 +291,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
@@ -146,6 +146,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -277,6 +278,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
@@ -150,6 +150,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -281,6 +282,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
@@ -152,6 +152,7 @@ void balance_control(unsigned int args_cmd_forward , unsigned int args_cmd_turn 
   tmp_0 ++;
   tmp_pwm_r_limiter += (tmp[tmp_0] - tmp_theta_0[tmp_0]) * K_F[tmp_0];
   tmp_0 ++;
+  __VERIFIER_assume(((BATTERY_GAIN*args_battery) - BATTERY_OFFSET) != 0);
   tmp_pwm_r_limiter = (float )((K_I * ud_err_theta + tmp_pwm_r_limiter) / (unsigned int )(BATTERY_GAIN * (unsigned int const   )args_battery - BATTERY_OFFSET)) * 100.0F;
   tmp_pwm_turn = ((float )args_cmd_turn / 100.0F) * (float )K_PHIDOT;
   tmp_pwm_l_limiter = tmp_pwm_r_limiter + tmp_pwm_turn;
@@ -290,6 +291,7 @@ void OSEK_Task_ts1(void)
   avg_cnt ++;
   tmp___1 = ecrobot_get_systick_ms();
   if (tmp___1 - cal_start_time >= 1000U) {
+    __VERIFIER_assume(avg_cnt != 0);
     gyro_offset /= avg_cnt;
     ecrobot_sound_tone(440U, 500U, 30);
     __startrek_write_nxtway_gs_mode(2);


### PR DESCRIPTION
Add the assume statement as __VERIFIER_assume(y!=0) for each operation
of the type x/y to avoid undefined behavior in the seq-mthreaded
benchmarks.

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [ ] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [ ] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
