### PR TITLE
Add assumes to avoid undefined behaviour in loop-industry-pattern

### DIFF
--- a/c/loop-industry-pattern/ofuf_1_true-unreach-call.c
+++ b/c/loop-industry-pattern/ofuf_1_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 struct Od_SubIndex;
 struct Od_Index;
 struct Od_IndexTable;
@@ -280,6 +281,7 @@ return Id_MCDC_108;
 }
 while(Id_MCDC_137 != 0)
 {
+__VERIFIER_assume(Id_MCDC_136 != 0);
 ("32_39888_4294972284" , __VERIFIER_assert(( long long  ) (Id_MCDC_135 / Id_MCDC_136) >= 0 && ( long long  ) (Id_MCDC_135 / Id_MCDC_136) <= 4294967295)) , Id_MCDC_138 = ( UINT32 ) (Id_MCDC_135 / Id_MCDC_136);
 Id_MCDC_137 = Id_MCDC_135 - (Id_MCDC_138 * Id_MCDC_136);
 Id_MCDC_135 = Id_MCDC_136;
@@ -304,6 +306,7 @@ else
 Id_MCDC_140 = Id_MCDC_112[1];
 }
 Id_MCDC_139 = Id_MCDC_110(Id_MCDC_112[0], Id_MCDC_140);
+__VERIFIER_assume(Id_MCDC_139 != 0);
 return ((Id_MCDC_112[0] * Id_MCDC_140) / Id_MCDC_139);
 }
 UINT32 Id_MCDC_114(UINT16 Id_MCDC_100, UINT8 Id_MCDC_101, UINT32* Id_MCDC_102, UINT32* Id_MCDC_103, INT32* Id_MCDC_104, void ** Id_MCDC_105)

--- a/c/loop-industry-pattern/ofuf_2_true-unreach-call.c
+++ b/c/loop-industry-pattern/ofuf_2_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 struct Od_SubIndex;
 struct Od_Index;
 struct Od_IndexTable;
@@ -255,6 +256,7 @@ return Id_MCDC_90;
 }
 while(Id_MCDC_119 != 0)
 {
+__VERIFIER_assume(Id_MCDC_118 != 0);
 Id_MCDC_120 = ( UINT32 ) (Id_MCDC_117 / Id_MCDC_118);
 ("33_39889_4294972293" , __VERIFIER_assert(( long long  ) (Id_MCDC_117 - (Id_MCDC_120 * Id_MCDC_118)) >= 0 && ( long long  ) (Id_MCDC_117 - (Id_MCDC_120 * Id_MCDC_118)) <= 4294967295)) , Id_MCDC_119 = Id_MCDC_117 - (Id_MCDC_120 * Id_MCDC_118);
 Id_MCDC_117 = Id_MCDC_118;
@@ -279,6 +281,7 @@ else
 Id_MCDC_122 = Id_MCDC_94[1];
 }
 Id_MCDC_121 = Id_MCDC_92(Id_MCDC_94[0], Id_MCDC_122);
+__VERIFIER_assume(Id_MCDC_121 != 0);
 return ((Id_MCDC_94[0] * Id_MCDC_122) / Id_MCDC_121);
 }
 UINT32 Id_MCDC_96(UINT16 Id_MCDC_82, UINT8 Id_MCDC_83, UINT32* Id_MCDC_84, UINT32* Id_MCDC_85, INT32* Id_MCDC_86, void ** Id_MCDC_87)

--- a/c/loop-industry-pattern/ofuf_3_true-unreach-call.c
+++ b/c/loop-industry-pattern/ofuf_3_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 struct Od_SubIndex;
 struct Od_Index;
 struct Od_IndexTable;
@@ -255,6 +256,7 @@ return Id_MCDC_90;
 }
 while(Id_MCDC_119 != 0)
 {
+__VERIFIER_assume(Id_MCDC_118 != 0);
 Id_MCDC_120 = ( UINT32 ) (Id_MCDC_117 / Id_MCDC_118);
 ("34_39889_4294972292" , __VERIFIER_assert(( long long  ) (Id_MCDC_120 * Id_MCDC_118) >= 0 && ( long long  ) (Id_MCDC_120 * Id_MCDC_118) <= 4294967295)) , Id_MCDC_119 = Id_MCDC_117 - (Id_MCDC_120 * Id_MCDC_118);
 Id_MCDC_117 = Id_MCDC_118;
@@ -279,6 +281,7 @@ else
 Id_MCDC_122 = Id_MCDC_94[1];
 }
 Id_MCDC_121 = Id_MCDC_92(Id_MCDC_94[0], Id_MCDC_122);
+__VERIFIER_assume(Id_MCDC_121 != 0);
 return ((Id_MCDC_94[0] * Id_MCDC_122) / Id_MCDC_121);
 }
 UINT32 Id_MCDC_96(UINT16 Id_MCDC_82, UINT8 Id_MCDC_83, UINT32* Id_MCDC_84, UINT32* Id_MCDC_85, INT32* Id_MCDC_86, void ** Id_MCDC_87)

--- a/c/loop-industry-pattern/ofuf_4_true-unreach-call.c
+++ b/c/loop-industry-pattern/ofuf_4_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 struct Od_SubIndex;
 struct Od_Index;
 struct Od_IndexTable;
@@ -255,6 +256,7 @@ return Id_MCDC_90;
 }
 while(Id_MCDC_119 != 0)
 {
+__VERIFIER_assume(Id_MCDC_118 != 0);
 Id_MCDC_120 = ( UINT32 ) (Id_MCDC_117 / Id_MCDC_118);
 Id_MCDC_119 = Id_MCDC_117 - (Id_MCDC_120 * Id_MCDC_118);
 Id_MCDC_117 = Id_MCDC_118;
@@ -279,6 +281,7 @@ else
 Id_MCDC_122 = Id_MCDC_94[1];
 }
 Id_MCDC_121 = Id_MCDC_92(Id_MCDC_94[0], Id_MCDC_122);
+__VERIFIER_assume(Id_MCDC_121 != 0);
 return ("35_39854_4294972318" , __VERIFIER_assert(( long long  ) ((Id_MCDC_94[0] * Id_MCDC_122) / Id_MCDC_121) >= 0 && ( long long  ) ((Id_MCDC_94[0] * Id_MCDC_122) / Id_MCDC_121) <= 4294967295)) , ((Id_MCDC_94[0] * Id_MCDC_122) / Id_MCDC_121);
 }
 UINT32 Id_MCDC_96(UINT16 Id_MCDC_82, UINT8 Id_MCDC_83, UINT32* Id_MCDC_84, UINT32* Id_MCDC_85, INT32* Id_MCDC_86, void ** Id_MCDC_87)

--- a/c/loop-industry-pattern/ofuf_5_true-unreach-call.c
+++ b/c/loop-industry-pattern/ofuf_5_true-unreach-call.c
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+extern void __VERIFIER_assume(int);
 struct Od_SubIndex;
 struct Od_Index;
 struct Od_IndexTable;
@@ -255,6 +256,7 @@ return Id_MCDC_90;
 }
 while(Id_MCDC_119 != 0)
 {
+__VERIFIER_assume(Id_MCDC_118 != 0);
 Id_MCDC_120 = ( UINT32 ) (Id_MCDC_117 / Id_MCDC_118);
 Id_MCDC_119 = Id_MCDC_117 - (Id_MCDC_120 * Id_MCDC_118);
 Id_MCDC_117 = Id_MCDC_118;
@@ -279,6 +281,7 @@ else
 Id_MCDC_122 = Id_MCDC_94[1];
 }
 Id_MCDC_121 = Id_MCDC_92(Id_MCDC_94[0], Id_MCDC_122);
+__VERIFIER_assume(Id_MCDC_121 != 0);
 return ("36_39854_4294972316" , __VERIFIER_assert(( long long  ) (Id_MCDC_94[0] * Id_MCDC_122) >= 0 && ( long long  ) (Id_MCDC_94[0] * Id_MCDC_122) <= 4294967295)) , ((Id_MCDC_94[0] * Id_MCDC_122) / Id_MCDC_121);
 }
 UINT32 Id_MCDC_96(UINT16 Id_MCDC_82, UINT8 Id_MCDC_83, UINT32* Id_MCDC_84, UINT32* Id_MCDC_85, INT32* Id_MCDC_86, void ** Id_MCDC_87)


### PR DESCRIPTION
Add the assume statement as __VERIFIER_assume(y!=0)
for each operation of the type x/y to avoid undefined behavior
in the loop-industry-pattern benchmarks.

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [ ] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [ ] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [ ] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [ ] intended property matches the corresponding `.prp` file
- [ ] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [ ] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [ ] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [ ] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
