### PR TITLE
Fix bug in two tasks incorrectly labeled as true-valid-memsafety.

### DIFF
--- a/c/ldv-memsafety/memleaks-notpreprocessed/memleaks_test23_1_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memleaks-notpreprocessed/memleaks_test23_1_true-valid-memsafety.c
@@ -90,6 +90,9 @@ int hid_open_report(struct hid_device *device) {
 	}
 	parser->device = device;
 	parser->report_id = ldv_positive();
+        if (parser->report_id < 256) {
+          parser->report_id = 256;
+        }
 	
 	static int (*dispatch_type[])(struct hid_parser *parser,
 				      struct hid_item *item) = {

--- a/c/ldv-memsafety/memleaks-notpreprocessed/memleaks_test23_3_true-valid-memsafety.c
+++ b/c/ldv-memsafety/memleaks-notpreprocessed/memleaks_test23_3_true-valid-memsafety.c
@@ -90,6 +90,9 @@ int hid_open_report(struct hid_device *device) {
 	}
 	parser->device = device;
 	parser->report_id = ldv_positive();
+        if (parser->report_id < 256) {
+          parser->report_id = 256;
+        }
 	
 	while(fetch_item(&item)!=-1) {
 		if (hid_parser_main(parser, &item)) {

--- a/c/ldv-memsafety/memleaks_test23_1_true-valid-memsafety.i
+++ b/c/ldv-memsafety/memleaks_test23_1_true-valid-memsafety.i
@@ -1508,6 +1508,9 @@ int hid_open_report(struct hid_device *device) {
  }
  parser->device = device;
  parser->report_id = ldv_positive();
+ if (parser->report_id < 256) {
+   parser->report_id = 256;
+ }
 
  static int (*dispatch_type[])(struct hid_parser *parser,
           struct hid_item *item) = {

--- a/c/ldv-memsafety/memleaks_test23_3_true-valid-memsafety.i
+++ b/c/ldv-memsafety/memleaks_test23_3_true-valid-memsafety.i
@@ -1508,6 +1508,9 @@ int hid_open_report(struct hid_device *device) {
  }
  parser->device = device;
  parser->report_id = ldv_positive();
+ if (parser->report_id < 256) {
+   parser->report_id = 256;
+ }
 
  while(fetch_item(&item)!=-1) {
   if (hid_parser_main(parser, &item)) {


### PR DESCRIPTION
The bug is already preserved in two other tasks. This fixes #521.