### PR TITLE
busybox: define stat() function in date benchmark

### DIFF
--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1642,6 +1642,18 @@ static void * xmalloc(unsigned long int size)
   return ptr;
 }
 
+// model stat function, in this benchmark there is used
+// only the st_mtim.tv_sec variable
+int stat(const char *__file, struct stat *__buf)
+{
+  __buf->st_mtim.tv_sec = __VERIFIER_nondet_long();
+  if (__VERIFIER_nondet_char())
+    return -1;
+
+  __VERIFIER_assume(__buf->st_mtim.tv_sec >= 0);
+  return 0;
+}
+
 // file libbb/xfuncs_printf.c line 469
 static void xstat(const char *name, struct stat *stat_buf)
 {

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3658,6 +3658,15 @@ static void * xmalloc(unsigned long int size)
   }
   return ptr;
 }
+int stat(const char *__file, struct stat *__buf)
+{
+  __buf->st_mtim.tv_sec = __VERIFIER_nondet_long();
+  if (__VERIFIER_nondet_char())
+    return -1;
+
+  __VERIFIER_assume(__buf->st_mtim.tv_sec >= 0);
+  return 0;
+}
 static void xstat(const char *name, struct stat *stat_buf)
 {
   signed int return_value_stat$1;


### PR DESCRIPTION
stat() is a POSIX function. The definition used is taken from
the who benchmark, adjusted to use mtim field instead of atim field.