### PR TITLE
Fix an overflow in almost all busybox tasks

### DIFF
--- a/c/Systems_BusyBox_NoOverflows.set
+++ b/c/Systems_BusyBox_NoOverflows.set
@@ -1,3 +1,3 @@
-#busybox-1.22.0/*_false-no-overflow*.i
+busybox-1.22.0/*_false-no-overflow*.i
 busybox-1.22.0/*_true-no-overflow*.i
 

--- a/c/busybox-1.22.0-todo/TODO
+++ b/c/busybox-1.22.0-todo/TODO
@@ -1,0 +1,18 @@
+TODO:
+
+- Apply the fix for the overflow when outputing an error message where strlen of the strerror(*) string is saved in strerr_len and used in a signed addition.
+  But the error string could in theory be very large => overflow
+  The fix was applied to the regular busybox tasks with this command:
+
+    for file in $(grep -l bb_verror_msg c/busybox-1.22.0/*);
+    do
+    if [[ $file != *"false-valid-deref"* ]]; then
+      cp $file $(echo $file | perl -pe "s/(.*?_)(.*)(\..*)/\1false-no-overflow\3/g");
+    fi
+    perl -0777pi -e "s/(applet_len;\n  )(signed int strerr_len;\n)/\1un\2/g" $file;
+    done
+
+  It still needs to be applied to the tasks in this folder!
+
+
+Note: This list is not exhaustive. Finishing all to-dos in this file does not imply that the tasks can be moved out of the todo folder!

--- a/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.c
@@ -1,0 +1,278 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 1112
+signed int chown_main(signed int, char **);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/chgrp.c line 42
+signed int __main(signed int argc, char **argv)
+{
+  char **p = argv;
+  do
+  {
+    p = p + 1l;
+
+    if(*p == ((char *)NULL))
+      break;
+
+
+    if(!((signed int)*(*p) == 45))
+    {
+      p[(signed long int)0]=xasprintf(":%s", p[(signed long int)0]);
+      break;
+    }
+
+  }
+  while((_Bool)1);
+  signed int return_value_chown_main$1;
+  return_value_chown_main$1=chown_main(argc, argv);
+  return return_value_chown_main$1;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  va_start(p, format);
+  r=vasprintf(&string_ptr, format, p);
+  va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  return string_ptr;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.i
@@ -1,0 +1,2503 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+signed int chown_main(signed int, char **);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static char * xasprintf(const char *format, ...);
+static void xfunc_die(void);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+signed int __main(signed int argc, char **argv)
+{
+  char **p = argv;
+  do
+  {
+    p = p + 1l;
+    if(*p == ((char *)((void *)0)))
+      break;
+    if(!((signed int)*(*p) == 45))
+    {
+      p[(signed long int)0]=xasprintf(":%s", p[(signed long int)0]);
+      break;
+    }
+  }
+  while((_Bool)1);
+  signed int return_value_chown_main$1;
+  return_value_chown_main$1=chown_main(argc, argv);
+  return return_value_chown_main$1;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  __builtin_va_start(p,format);
+  r=vasprintf(&string_ptr, format, p);
+  __builtin_va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+  return string_ptr;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.c
+++ b/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.c
@@ -90,7 +90,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.i
+++ b/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.i
@@ -2238,7 +2238,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.c
@@ -1,0 +1,368 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <pwd.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file libbb/execable.c line 72
+static signed int BB_EXECVP(const char *file, char * const *argv);
+// file libbb/execable.c line 80
+static signed int BB_EXECVP_or_die(char **argv);
+// file include/pwd_.h line 70
+struct passwd * bb_internal_getpwuid(unsigned int);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 1165
+signed int find_applet_by_name(const char *);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file libbb/get_shell_name.c line 11
+static const char * get_shell_name(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 466
+static void xchdir(const char *path);
+// file libbb/xfuncs_printf.c line 388
+static void xchroot(const char *path);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/messages.c line 38
+static const char bb_busybox_exec_path[15l] = { (const char)47, (const char)112, (const char)114, (const char)111, (const char)99, (const char)47, (const char)115, (const char)101, (const char)108, (const char)102, (const char)47, (const char)101, (const char)120, (const char)101, (const char)0 };
+// file libbb/messages.c line 39
+static const char bb_default_login_shell[9l] = { (const char)45, (const char)47, (const char)98, (const char)105, (const char)110, (const char)47, (const char)115, (const char)104, (const char)0 };
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file libbb/execable.c line 72
+static signed int BB_EXECVP(const char *file, char * const *argv)
+{
+  signed int return_value_find_applet_by_name$1;
+  return_value_find_applet_by_name$1=find_applet_by_name(file);
+  if(return_value_find_applet_by_name$1 >= 0)
+    execvp(bb_busybox_exec_path, argv);
+
+  signed int return_value_execvp$2;
+  return_value_execvp$2=execvp(file, argv);
+  return return_value_execvp$2;
+}
+
+// file libbb/execable.c line 80
+static signed int BB_EXECVP_or_die(char **argv)
+{
+  BB_EXECVP(argv[(signed long int)0], argv);
+  xfunc_error_retval = (unsigned char)(*bb_errno == 2 ? 127 : 126);
+  bb_perror_msg_and_die("can't execute '%s'", argv[(signed long int)0]);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/chroot.c line 28
+signed int __main(signed int argc, char **argv)
+{
+  argv = argv + 1l;
+
+  if(*argv == ((char *)NULL))
+    return 1;
+
+
+  xchroot(*argv);
+  argv = argv + 1l;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - (signed long int)2;
+    const char *return_value_get_shell_name$1;
+    return_value_get_shell_name$1=get_shell_name();
+
+    argv[(signed long int)0] = (char *)return_value_get_shell_name$1;
+
+    argv[(signed long int)1] = (char *)"-i";
+  }
+
+  BB_EXECVP_or_die(argv);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file libbb/get_shell_name.c line 11
+static const char * get_shell_name(void)
+{
+  struct passwd *pw;
+  char *shell;
+  shell=getenv("SHELL");
+  if(!(shell == ((char *)NULL)))
+  {
+    if(!((signed int)*shell == 0))
+      return shell;
+
+  }
+
+  unsigned int return_value_getuid$1;
+  return_value_getuid$1=getuid();
+  pw=bb_internal_getpwuid(return_value_getuid$1);
+  if(!(pw == ((struct passwd *)NULL)))
+  {
+    if(!(pw->pw_shell == ((char *)NULL)))
+    {
+      if(!((signed int)*pw->pw_shell == 0))
+        return pw->pw_shell;
+
+    }
+
+  }
+
+  return bb_default_login_shell + (signed long int)1;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 466
+static void xchdir(const char *path)
+{
+  signed int return_value_chdir$1;
+  return_value_chdir$1=chdir(path);
+  if(!(return_value_chdir$1 == 0))
+    bb_perror_msg_and_die("can't change directory to '%s'", path);
+
+}
+
+// file libbb/xfuncs_printf.c line 388
+static void xchroot(const char *path)
+{
+  signed int return_value_chroot$1;
+  return_value_chroot$1=chroot(path);
+  if(!(return_value_chroot$1 == 0))
+    bb_perror_msg_and_die("can't change root directory to '%s'", path);
+
+  xchdir("/");
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+#include "busybox_sv_comp-getpwnam.h"
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
@@ -1,0 +1,2617 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef __gid_t gid_t;
+typedef __uid_t uid_t;
+struct passwd
+{
+  char *pw_name;
+  char *pw_passwd;
+  __uid_t pw_uid;
+  __gid_t pw_gid;
+  char *pw_gecos;
+  char *pw_dir;
+  char *pw_shell;
+};
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+extern void setpwent (void);
+extern void endpwent (void);
+extern struct passwd *getpwent (void);
+extern struct passwd *fgetpwent (FILE *__stream);
+extern int putpwent (const struct passwd *__restrict __p,
+       FILE *__restrict __f);
+extern struct passwd *getpwuid (__uid_t __uid);
+extern struct passwd *getpwnam (const char *__name);
+extern int getpwent_r (struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int getpwuid_r (__uid_t __uid,
+         struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int getpwnam_r (const char *__restrict __name,
+         struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int fgetpwent_r (FILE *__restrict __stream,
+   struct passwd *__restrict __resultbuf,
+   char *__restrict __buffer, size_t __buflen,
+   struct passwd **__restrict __result);
+extern int getpw (__uid_t __uid, char *__buffer);
+
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static signed int BB_EXECVP(const char *file, char * const *argv);
+static signed int BB_EXECVP_or_die(char **argv);
+struct passwd * bb_internal_getpwuid(unsigned int);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+signed int find_applet_by_name(const char *);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static const char * get_shell_name(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void xchdir(const char *path);
+static void xchroot(const char *path);
+static void xfunc_die(void);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static const char bb_busybox_exec_path[15l] = { (const char)47, (const char)112, (const char)114, (const char)111, (const char)99, (const char)47, (const char)115, (const char)101, (const char)108, (const char)102, (const char)47, (const char)101, (const char)120, (const char)101, (const char)0 };
+static const char bb_default_login_shell[9l] = { (const char)45, (const char)47, (const char)98, (const char)105, (const char)110, (const char)47, (const char)115, (const char)104, (const char)0 };
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static signed int BB_EXECVP(const char *file, char * const *argv)
+{
+  signed int return_value_find_applet_by_name$1;
+  return_value_find_applet_by_name$1=find_applet_by_name(file);
+  if(return_value_find_applet_by_name$1 >= 0)
+    execvp(bb_busybox_exec_path, argv);
+  signed int return_value_execvp$2;
+  return_value_execvp$2=execvp(file, argv);
+  return return_value_execvp$2;
+}
+static signed int BB_EXECVP_or_die(char **argv)
+{
+  BB_EXECVP(argv[(signed long int)0], argv);
+  xfunc_error_retval = (unsigned char)(*bb_errno == 2 ? 127 : 126);
+  bb_perror_msg_and_die("can't execute '%s'", argv[(signed long int)0]);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+signed int __main(signed int argc, char **argv)
+{
+  argv = argv + 1l;
+  if(*argv == ((char *)((void *)0)))
+    return 1;
+  xchroot(*argv);
+  argv = argv + 1l;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - (signed long int)2;
+    const char *return_value_get_shell_name$1;
+    return_value_get_shell_name$1=get_shell_name();
+    argv[(signed long int)0] = (char *)return_value_get_shell_name$1;
+    argv[(signed long int)1] = (char *)"-i";
+  }
+  BB_EXECVP_or_die(argv);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static const char * get_shell_name(void)
+{
+  struct passwd *pw;
+  char *shell;
+  shell=getenv("SHELL");
+  if(!(shell == ((char *)((void *)0))))
+  {
+    if(!((signed int)*shell == 0))
+      return shell;
+  }
+  unsigned int return_value_getuid$1;
+  return_value_getuid$1=getuid();
+  pw=bb_internal_getpwuid(return_value_getuid$1);
+  if(!(pw == ((struct passwd *)((void *)0))))
+  {
+    if(!(pw->pw_shell == ((char *)((void *)0))))
+    {
+      if(!((signed int)*pw->pw_shell == 0))
+        return pw->pw_shell;
+    }
+  }
+  return bb_default_login_shell + (signed long int)1;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void xchdir(const char *path)
+{
+  signed int return_value_chdir$1;
+  return_value_chdir$1=chdir(path);
+  if(!(return_value_chdir$1 == 0))
+    bb_perror_msg_and_die("can't change directory to '%s'", path);
+}
+static void xchroot(const char *path)
+{
+  signed int return_value_chroot$1;
+  return_value_chroot$1=chroot(path);
+  if(!(return_value_chroot$1 == 0))
+    bb_perror_msg_and_die("can't change root directory to '%s'", path);
+  xchdir("/");
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+struct passwd *bb_internal_getpwnam(const char *name)
+{
+  (void)name;
+  static struct passwd p;
+  p.pw_name = "";
+  p.pw_passwd = "";
+  p.pw_uid = __VERIFIER_nondet_uint();
+  p.pw_gid = __VERIFIER_nondet_uint();
+  p.pw_gecos = "";
+  p.pw_dir = "";
+  p.pw_shell = "";
+  return &p;
+}
+struct passwd *bb_internal_getpwuid(uid_t uid)
+{
+  (void)uid;
+  return bb_internal_getpwnam(0);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.c
@@ -142,7 +142,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -2310,7 +2310,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/cut_false-no-overflow.c
+++ b/c/busybox-1.22.0/cut_false-no-overflow.c
@@ -1,0 +1,1518 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file coreutils/cut.c line 42
+struct cut_list;
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file coreutils/cut.c line 53
+static signed int cmpfunc(const void *a, const void *b);
+// file coreutils/cut.c line 59
+static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lists, unsigned int nlists);
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/get_line_from_file.c line 53
+static char * xmalloc_fgetline(struct _IO_FILE *file);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file include/libbb.h line 707
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct cut_list
+{
+  // startpos
+  signed int startpos;
+  // endpos
+  signed int endpos;
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file coreutils/cut.c line 35
+static const char optstring[11l] = { (const char)98, (const char)58, (const char)99, (const char)58, (const char)102, (const char)58, (const char)100, (const char)58, (const char)115, (const char)110, (const char)0 };
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)NULL;
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=getc(file);
+    if(ch == -1)
+      break;
+
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+
+    if(!(end == ((signed int *)NULL)))
+    {
+      if(ch == 10)
+        break;
+
+    }
+
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)NULL)))
+    *end = (signed int)idx;
+
+  if(!(linebuf == ((char *)NULL)))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+
+  return linebuf;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/cut.c line 53
+static signed int cmpfunc(const void *a, const void *b)
+{
+  if(!(a == NULL))
+    (void)0;
+
+  else
+    /* assertion !(a == ((void*)0)) */
+    __VERIFIER_error();
+  if(!(b == NULL))
+    (void)0;
+
+  else
+    /* assertion !(b == ((void*)0)) */
+    __VERIFIER_error();
+  return ((struct cut_list *)a)->startpos - ((struct cut_list *)b)->startpos;
+}
+
+// file coreutils/cut.c line 59
+static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lists, unsigned int nlists)
+{
+  char *line;
+  unsigned int linenum = (unsigned int)0;
+  _Bool tmp_if_expr$3;
+  char *tmp_statement_expression$6;
+  _Bool tmp_if_expr$5;
+  char __r0;
+  char __r1;
+  char __r2;
+  char *return_value___strsep_g$7;
+  do
+  {
+    line=xmalloc_fgetline(file);
+    if(line == ((char *)NULL))
+      break;
+
+    signed int linelen;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(line);
+    linelen = (signed int)return_value_strlen$1;
+    char *printed;
+    void *return_value_xzalloc$2;
+    return_value_xzalloc$2=xzalloc((unsigned long int)(linelen + 1));
+    printed = (char *)return_value_xzalloc$2;
+    char *orig_line = line;
+    unsigned int cl_pos = (unsigned int)0;
+    signed int spos;
+    if(!((3u & option_mask32) == 0u))
+      for( ; !(cl_pos >= nlists); cl_pos = cl_pos + 1u)
+      {
+
+        spos = (cut_lists + (signed long int)cl_pos)->startpos;
+        while(!(spos >= linelen))
+        {
+
+          if((signed int)printed[(signed long int)spos] == 0)
+          {
+            printed[(signed long int)spos] = (char)88;
+
+            putchar((signed int)line[(signed long int)spos]);
+          }
+
+          spos = spos + 1;
+
+          if(!((cut_lists + (signed long int)cl_pos)->endpos >= spos))
+            break;
+
+        }
+      }
+
+    else
+      if((signed int)delim == 10)
+      {
+
+        spos = (cut_lists + (signed long int)cl_pos)->startpos;
+        if(cl_pos >= nlists || !((signed int)linenum >= spos))
+          goto next_line;
+
+        while(!(spos >= (signed int)linenum))
+        {
+          spos = spos + 1;
+
+          if(!((cut_lists + (signed long int)cl_pos)->endpos >= spos))
+            tmp_if_expr$3 = 1 != 0;
+
+          else
+          {
+
+            tmp_if_expr$3 = ((cut_lists + (signed long int)cl_pos)->endpos == -1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          if(!(tmp_if_expr$3 == (_Bool)0))
+          {
+            cl_pos = cl_pos + 1u;
+            if(cl_pos >= nlists)
+              goto next_line;
+
+
+            spos = (cut_lists + (signed long int)cl_pos)->startpos;
+            if(!((signed int)linenum >= spos))
+              goto next_line;
+
+          }
+
+        }
+        puts(line);
+        goto next_line;
+      }
+
+      else
+      {
+        signed int ndelim = -1;
+        signed int nfields_printed = 0;
+        char *field = (char *)NULL;
+        char delimiter[2l];
+        delimiter[(signed long int)0] = delim;
+        delimiter[(signed long int)1] = (char)0;
+        char *return_value___builtin_strchr$4;
+        return_value___builtin_strchr$4=strchr(line, (signed int)delim);
+        if(return_value___builtin_strchr$4 == ((char *)NULL))
+        {
+          if((16u & option_mask32) == 0u)
+            puts(line);
+
+          goto next_line;
+        }
+
+        for( ; !(line == ((char *)NULL)) && !(cl_pos >= nlists); cl_pos = cl_pos + 1u)
+        {
+
+          spos = (cut_lists + (signed long int)cl_pos)->startpos;
+          do
+          {
+
+          __CPROVER_DUMP_L35:
+            ;
+            if(line == ((char *)NULL))
+              break;
+
+            if(ndelim >= spos)
+              break;
+
+            return_value___strsep_g$7=strsep(&line, delimiter);
+            tmp_statement_expression$6 = return_value___strsep_g$7;
+            field = tmp_statement_expression$6;
+            ndelim = ndelim + 1;
+          }
+          while((_Bool)1);
+          if(!(field == ((char *)NULL)))
+          {
+            if(ndelim == spos)
+            {
+
+              if((signed int)printed[(signed long int)ndelim] == 0)
+              {
+                if(nfields_printed > 0)
+                  putchar((signed int)delim);
+
+                fputs(field, stdout);
+
+                printed[(signed long int)ndelim] = (char)88;
+                nfields_printed = nfields_printed + 1;
+              }
+
+            }
+
+          }
+
+          spos = spos + 1;
+
+          if((cut_lists + (signed long int)cl_pos)->endpos >= spos && !(line == ((char *)NULL)))
+            tmp_if_expr$5 = ((cut_lists + (signed long int)cl_pos)->endpos != -1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+          else
+            tmp_if_expr$5 = 0 != 0;
+          if(!(tmp_if_expr$5 == (_Bool)0))
+            goto __CPROVER_DUMP_L35;
+
+        __CPROVER_DUMP_L47:
+          ;
+        }
+      }
+    putchar(10);
+
+  next_line:
+    ;
+    linenum = linenum + 1u;
+    free((void *)printed);
+    free((void *)orig_line);
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/cut.c line 185
+signed int __main(signed int argc, char **argv)
+{
+  struct cut_list *cut_lists = (struct cut_list *)NULL;
+  unsigned int nlists = (unsigned int)0;
+  char delim = (char)9;
+  char *sopt;
+  char *ltok;
+  unsigned int opt;
+  opt_complementary = "b--bcf:c--bcf:f--bcf";
+  opt=getopt32(argv, optstring, &sopt, &sopt, &sopt, &ltok);
+  argv = argv + (signed long int)optind;
+  if((7u & opt) == 0u)
+    bb_error_msg_and_die("expected a list of bytes, characters, or fields");
+
+  if(!((8u & opt) == 0u))
+  {
+
+    if(!((signed int)*ltok == 0))
+    {
+
+      if(!((signed int)*(1l + ltok) == 0))
+        bb_error_msg_and_die("the delimiter must be a single character");
+
+    }
+
+
+    delim = ltok[(signed long int)0];
+  }
+
+  if((4u & opt) == 0u)
+  {
+    static const char _op_on_field[31l] = { (const char)32, (const char)111, (const char)110, (const char)108, (const char)121, (const char)32, (const char)119, (const char)104, (const char)101, (const char)110, (const char)32, (const char)111, (const char)112, (const char)101, (const char)114, (const char)97, (const char)116, (const char)105, (const char)110, (const char)103, (const char)32, (const char)111, (const char)110, (const char)32, (const char)102, (const char)105, (const char)101, (const char)108, (const char)100, (const char)115, (const char)0 };
+    if(!((16u & opt) == 0u))
+      bb_error_msg_and_die("suppressing non-delimited lines makes sense%s", (const void *)_op_on_field);
+
+    if(!((signed int)delim == 9))
+      bb_error_msg_and_die("a delimiter may be specified%s", (const void *)_op_on_field);
+
+  }
+
+  char *ntok;
+  signed int s = 0;
+  signed int e = 0;
+  char *tmp_statement_expression$1;
+  _Bool tmp_if_expr$2;
+  char *tmp_if_expr$5;
+  char *return_value___strsep_1c$3;
+  char *return_value___strsep_g$4;
+  char *tmp_statement_expression$6;
+  _Bool tmp_if_expr$7;
+  char *tmp_if_expr$10;
+  char *return_value___strsep_1c$8;
+  char *return_value___strsep_g$9;
+  do
+  {
+    ltok = strsep(&sopt, ",");
+    if(ltok == ((char *)NULL))
+      break;
+
+
+    if(!((signed int)*ltok == 0))
+    {
+      ntok = strsep(&ltok, "-");
+
+      if((signed int)*ntok == 0)
+        s = 0;
+
+      else
+      {
+        s=xatoi_positive(ntok);
+        if(!(s == 0))
+          s = s - 1;
+
+      }
+      if(ltok == ((char *)NULL))
+        e = -1;
+
+      else
+      {
+
+        if((signed int)*ltok == 0)
+          e = 2147483647;
+
+        else
+        {
+          e=xatoi_positive(ltok);
+          if(e == 0)
+            e = 2147483647;
+
+          e = e - 1;
+          if(e == s)
+            e = -1;
+
+        }
+      }
+      void *return_value_xrealloc_vector_helper$11;
+      return_value_xrealloc_vector_helper$11=xrealloc_vector_helper((void *)cut_lists, (unsigned int)((sizeof(struct cut_list) /*8ul*/  << 8) + (unsigned long int)4), (signed int)nlists);
+      cut_lists = (struct cut_list *)return_value_xrealloc_vector_helper$11;
+
+      (cut_lists + (signed long int)nlists)->startpos = s;
+
+      (cut_lists + (signed long int)nlists)->endpos = e;
+      nlists = nlists + 1u;
+    }
+
+  }
+  while((_Bool)1);
+  if(nlists == 0u)
+    bb_error_msg_and_die("missing list of positions");
+
+  qsort((void *)cut_lists, (unsigned long int)nlists, sizeof(struct cut_list) /*8ul*/ , cmpfunc);
+  signed int retval = 0;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)"-";
+  }
+
+  do
+  {
+    struct _IO_FILE *file;
+
+    file=fopen_or_warn_stdin(*argv);
+    if(file == ((struct _IO_FILE *)NULL))
+      retval = 1;
+
+    else
+    {
+      cut_file(file, delim, cut_lists, nlists);
+      fclose_if_not_stdin(file);
+    }
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  // fflush_stdout_and_exit(retval); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return retval;
+}
+
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+
+  return r;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/get_line_from_file.c line 53
+static char * xmalloc_fgetline(struct _IO_FILE *file)
+{
+  signed int i;
+  char *c;
+  c=bb_get_chunk_from_file(file, &i);
+  if(!(i == 0))
+  {
+    i = i - 1;
+    if((signed int)c[(signed long int)i] == 10)
+      c[(signed long int)i] = (char)0;
+
+  }
+
+  return c;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 707
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx)
+{
+  signed int mask = 1 << (signed int)(unsigned char)sizeof_and_shift;
+  if((-1 + mask & idx) == 0)
+  {
+    sizeof_and_shift = sizeof_and_shift >> 8;
+    vector=xrealloc(vector, (unsigned long int)(sizeof_and_shift * (unsigned int)(idx + mask + 1)));
+    memset((void *)((char *)vector + (signed long int)(sizeof_and_shift * (unsigned int)idx)), 0, (unsigned long int)(sizeof_and_shift * (unsigned int)(mask + 1)));
+  }
+
+  return vector;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/cut_false-no-overflow.i
+++ b/c/busybox-1.22.0/cut_false-no-overflow.i
@@ -1,0 +1,3410 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct cut_list;
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int cmpfunc(const void *a, const void *b);
+static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lists, unsigned int nlists);
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_fgetline(struct _IO_FILE *file);
+static void * xrealloc(void *ptr, unsigned long int size);
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct cut_list
+{
+  signed int startpos;
+  signed int endpos;
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static const char optstring[11l] = { (const char)98, (const char)58, (const char)99, (const char)58, (const char)102, (const char)58, (const char)100, (const char)58, (const char)115, (const char)110, (const char)0 };
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)((void *)0);
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=_IO_getc (file);
+    if(ch == -1)
+      break;
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+    if(!(end == ((signed int *)((void *)0))))
+    {
+      if(ch == 10)
+        break;
+    }
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)((void *)0))))
+    *end = (signed int)idx;
+  if(!(linebuf == ((char *)((void *)0))))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+  return linebuf;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int cmpfunc(const void *a, const void *b)
+{
+  if(!(a == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  if(!(b == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  return ((struct cut_list *)a)->startpos - ((struct cut_list *)b)->startpos;
+}
+static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lists, unsigned int nlists)
+{
+  char *line;
+  unsigned int linenum = (unsigned int)0;
+  _Bool tmp_if_expr$3;
+  char *tmp_statement_expression$6;
+  _Bool tmp_if_expr$5;
+  char __r0;
+  char __r1;
+  char __r2;
+  char *return_value___strsep_g$7;
+  do
+  {
+    line=xmalloc_fgetline(file);
+    if(line == ((char *)((void *)0)))
+      break;
+    signed int linelen;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(line);
+    linelen = (signed int)return_value_strlen$1;
+    char *printed;
+    void *return_value_xzalloc$2;
+    return_value_xzalloc$2=xzalloc((unsigned long int)(linelen + 1));
+    printed = (char *)return_value_xzalloc$2;
+    char *orig_line = line;
+    unsigned int cl_pos = (unsigned int)0;
+    signed int spos;
+    if(!((3u & option_mask32) == 0u))
+      for( ; !(cl_pos >= nlists); cl_pos = cl_pos + 1u)
+      {
+        spos = (cut_lists + (signed long int)cl_pos)->startpos;
+        while(!(spos >= linelen))
+        {
+          if((signed int)printed[(signed long int)spos] == 0)
+          {
+            printed[(signed long int)spos] = (char)88;
+            putchar((signed int)line[(signed long int)spos]);
+          }
+          spos = spos + 1;
+          if(!((cut_lists + (signed long int)cl_pos)->endpos >= spos))
+            break;
+        }
+      }
+    else
+      if((signed int)delim == 10)
+      {
+        spos = (cut_lists + (signed long int)cl_pos)->startpos;
+        if(cl_pos >= nlists || !((signed int)linenum >= spos))
+          goto next_line;
+        while(!(spos >= (signed int)linenum))
+        {
+          spos = spos + 1;
+          if(!((cut_lists + (signed long int)cl_pos)->endpos >= spos))
+            tmp_if_expr$3 = 1 != 0;
+          else
+          {
+            tmp_if_expr$3 = ((cut_lists + (signed long int)cl_pos)->endpos == -1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          if(!(tmp_if_expr$3 == (_Bool)0))
+          {
+            cl_pos = cl_pos + 1u;
+            if(cl_pos >= nlists)
+              goto next_line;
+            spos = (cut_lists + (signed long int)cl_pos)->startpos;
+            if(!((signed int)linenum >= spos))
+              goto next_line;
+          }
+        }
+        puts(line);
+        goto next_line;
+      }
+      else
+      {
+        signed int ndelim = -1;
+        signed int nfields_printed = 0;
+        char *field = (char *)((void *)0);
+        char delimiter[2l];
+        delimiter[(signed long int)0] = delim;
+        delimiter[(signed long int)1] = (char)0;
+        char *return_value___builtin_strchr$4;
+        return_value___builtin_strchr$4=strchr(line, (signed int)delim);
+        if(return_value___builtin_strchr$4 == ((char *)((void *)0)))
+        {
+          if((16u & option_mask32) == 0u)
+            puts(line);
+          goto next_line;
+        }
+        for( ; !(line == ((char *)((void *)0))) && !(cl_pos >= nlists); cl_pos = cl_pos + 1u)
+        {
+          spos = (cut_lists + (signed long int)cl_pos)->startpos;
+          do
+          {
+          __CPROVER_DUMP_L35:
+            ;
+            if(line == ((char *)((void *)0)))
+              break;
+            if(ndelim >= spos)
+              break;
+            return_value___strsep_g$7=strsep(&line, delimiter);
+            tmp_statement_expression$6 = return_value___strsep_g$7;
+            field = tmp_statement_expression$6;
+            ndelim = ndelim + 1;
+          }
+          while((_Bool)1);
+          if(!(field == ((char *)((void *)0))))
+          {
+            if(ndelim == spos)
+            {
+              if((signed int)printed[(signed long int)ndelim] == 0)
+              {
+                if(nfields_printed > 0)
+                  putchar((signed int)delim);
+                fputs(field, stdout);
+                printed[(signed long int)ndelim] = (char)88;
+                nfields_printed = nfields_printed + 1;
+              }
+            }
+          }
+          spos = spos + 1;
+          if((cut_lists + (signed long int)cl_pos)->endpos >= spos && !(line == ((char *)((void *)0))))
+            tmp_if_expr$5 = ((cut_lists + (signed long int)cl_pos)->endpos != -1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          else
+            tmp_if_expr$5 = 0 != 0;
+          if(!(tmp_if_expr$5 == (_Bool)0))
+            goto __CPROVER_DUMP_L35;
+        __CPROVER_DUMP_L47:
+          ;
+        }
+      }
+    putchar(10);
+  next_line:
+    ;
+    linenum = linenum + 1u;
+    free((void *)printed);
+    free((void *)orig_line);
+  }
+  while((_Bool)1);
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct cut_list *cut_lists = (struct cut_list *)((void *)0);
+  unsigned int nlists = (unsigned int)0;
+  char delim = (char)9;
+  char *sopt;
+  char *ltok;
+  unsigned int opt;
+  opt_complementary = "b--bcf:c--bcf:f--bcf";
+  opt=getopt32(argv, optstring, &sopt, &sopt, &sopt, &ltok);
+  argv = argv + (signed long int)optind;
+  if((7u & opt) == 0u)
+    bb_error_msg_and_die("expected a list of bytes, characters, or fields");
+  if(!((8u & opt) == 0u))
+  {
+    if(!((signed int)*ltok == 0))
+    {
+      if(!((signed int)*(1l + ltok) == 0))
+        bb_error_msg_and_die("the delimiter must be a single character");
+    }
+    delim = ltok[(signed long int)0];
+  }
+  if((4u & opt) == 0u)
+  {
+    static const char _op_on_field[31l] = { (const char)32, (const char)111, (const char)110, (const char)108, (const char)121, (const char)32, (const char)119, (const char)104, (const char)101, (const char)110, (const char)32, (const char)111, (const char)112, (const char)101, (const char)114, (const char)97, (const char)116, (const char)105, (const char)110, (const char)103, (const char)32, (const char)111, (const char)110, (const char)32, (const char)102, (const char)105, (const char)101, (const char)108, (const char)100, (const char)115, (const char)0 };
+    if(!((16u & opt) == 0u))
+      bb_error_msg_and_die("suppressing non-delimited lines makes sense%s", (const void *)_op_on_field);
+    if(!((signed int)delim == 9))
+      bb_error_msg_and_die("a delimiter may be specified%s", (const void *)_op_on_field);
+  }
+  char *ntok;
+  signed int s = 0;
+  signed int e = 0;
+  char *tmp_statement_expression$1;
+  _Bool tmp_if_expr$2;
+  char *tmp_if_expr$5;
+  char *return_value___strsep_1c$3;
+  char *return_value___strsep_g$4;
+  char *tmp_statement_expression$6;
+  _Bool tmp_if_expr$7;
+  char *tmp_if_expr$10;
+  char *return_value___strsep_1c$8;
+  char *return_value___strsep_g$9;
+  do
+  {
+    ltok = strsep(&sopt, ",");
+    if(ltok == ((char *)((void *)0)))
+      break;
+    if(!((signed int)*ltok == 0))
+    {
+      ntok = strsep(&ltok, "-");
+      if((signed int)*ntok == 0)
+        s = 0;
+      else
+      {
+        s=xatoi_positive(ntok);
+        if(!(s == 0))
+          s = s - 1;
+      }
+      if(ltok == ((char *)((void *)0)))
+        e = -1;
+      else
+      {
+        if((signed int)*ltok == 0)
+          e = 2147483647;
+        else
+        {
+          e=xatoi_positive(ltok);
+          if(e == 0)
+            e = 2147483647;
+          e = e - 1;
+          if(e == s)
+            e = -1;
+        }
+      }
+      void *return_value_xrealloc_vector_helper$11;
+      return_value_xrealloc_vector_helper$11=xrealloc_vector_helper((void *)cut_lists, (unsigned int)((sizeof(struct cut_list) << 8) + (unsigned long int)4), (signed int)nlists);
+      cut_lists = (struct cut_list *)return_value_xrealloc_vector_helper$11;
+      (cut_lists + (signed long int)nlists)->startpos = s;
+      (cut_lists + (signed long int)nlists)->endpos = e;
+      nlists = nlists + 1u;
+    }
+  }
+  while((_Bool)1);
+  if(nlists == 0u)
+    bb_error_msg_and_die("missing list of positions");
+  qsort((void *)cut_lists, (unsigned long int)nlists, sizeof(struct cut_list) , cmpfunc);
+  signed int retval = 0;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)"-";
+  }
+  do
+  {
+    struct _IO_FILE *file;
+    file=fopen_or_warn_stdin(*argv);
+    if(file == ((struct _IO_FILE *)((void *)0)))
+      retval = 1;
+    else
+    {
+      cut_file(file, delim, cut_lists, nlists);
+      fclose_if_not_stdin(file);
+    }
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  fflush(stdout);
+  return retval;
+}
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+  return r;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_fgetline(struct _IO_FILE *file)
+{
+  signed int i;
+  char *c;
+  c=bb_get_chunk_from_file(file, &i);
+  if(!(i == 0))
+  {
+    i = i - 1;
+    if((signed int)c[(signed long int)i] == 10)
+      c[(signed long int)i] = (char)0;
+  }
+  return c;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx)
+{
+  signed int mask = 1 << (signed int)(unsigned char)sizeof_and_shift;
+  if((-1 + mask & idx) == 0)
+  {
+    sizeof_and_shift = sizeof_and_shift >> 8;
+    vector=xrealloc(vector, (unsigned long int)(sizeof_and_shift * (unsigned int)(idx + mask + 1)));
+    memset((void *)((char *)vector + (signed long int)(sizeof_and_shift * (unsigned int)idx)), 0, (unsigned long int)(sizeof_and_shift * (unsigned int)(mask + 1)));
+  }
+  return vector;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -315,7 +315,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2325,7 +2325,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/date_false-no-overflow.c
+++ b/c/busybox-1.22.0/date_false-no-overflow.c
@@ -1,0 +1,1745 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/xatonum.h line 135
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base);
+// file libbb/bb_strtonum.c line 73
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+// file libbb/compare_string_array.c line 54
+static signed int index_in_substrings(const char *strings, const char *key);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file coreutils/date.c line 155
+static void maybe_set_utc(signed int opt);
+// file libbb/time.c line 11
+static void parse_datestr(const char *date_str, struct tm *ptm);
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file libbb/time.c line 202
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xfuncs_printf.c line 469
+static void xstat(const char *name, struct stat *stat_buf);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/messages.c line 66
+static char bb_common_bufsiz1[8193l];
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 26
+static const char bb_msg_invalid_date[18l] = { (const char)105, (const char)110, (const char)118, (const char)97, (const char)108, (const char)105, (const char)100, (const char)32, (const char)100, (const char)97, (const char)116, (const char)101, (const char)32, (const char)39, (const char)37, (const char)115, (const char)39, (const char)0 };
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file coreutils/date.c line 162
+static const char date_longopts[53l] = { (const char)114, (const char)102, (const char)99, (const char)45, (const char)56, (const char)50, (const char)50, (const char)0, (const char)0, (const char)82, (const char)114, (const char)102, (const char)99, (const char)45, (const char)50, (const char)56, (const char)50, (const char)50, (const char)0, (const char)0, (const char)82, (const char)115, (const char)101, (const char)116, (const char)0, (const char)1, (const char)115, (const char)117, (const char)116, (const char)99, (const char)0, (const char)0, (const char)117, (const char)100, (const char)97, (const char)116, (const char)101, (const char)0, (const char)1, (const char)100, (const char)114, (const char)101, (const char)102, (const char)101, (const char)114, (const char)101, (const char)110, (const char)99, (const char)101, (const char)0, (const char)1, (const char)114, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/xatonum.h line 135
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base)
+{
+  signed long long int return_value_bb_strtoll$1;
+  return_value_bb_strtoll$1=bb_strtoll(arg, endp, base);
+  return return_value_bb_strtoll$1;
+}
+
+// file libbb/bb_strtonum.c line 73
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed long long int)return_value_ret_ERANGE$2;
+  }
+
+  *bb_errno = 0;
+  signed long long int return_value_strtoll$4;
+  return_value_strtoll$4=strtoll(arg, endp, base);
+  v = (unsigned long long int)return_value_strtoll$4;
+  unsigned long long int return_value_handle_errors$5;
+  return_value_handle_errors$5=handle_errors(v, endp);
+  return (signed long long int)return_value_handle_errors$5;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/date.c line 174
+signed int __main(signed int argc, char **argv)
+{
+  struct timespec ts;
+  struct tm tm_time;
+  char buf_fmt_dt2str[64l];
+  unsigned int opt;
+  signed int ifmt = -1;
+  char *date_str;
+  char *fmt_dt2str;
+  char *fmt_str2dt;
+  char *filename;
+  char *isofmt_arg = (char *)NULL;
+  opt_complementary = "d--s:s--d:R--I:I--R";
+  applet_long_options = date_longopts;
+  opt=getopt32(argv, "Rs:ud:r:I::D:", &date_str, &date_str, &filename, &isofmt_arg, &fmt_str2dt);
+  argv = argv + (signed long int)optind;
+  maybe_set_utc((signed int)opt);
+  if(!((32u & opt) == 0u))
+  {
+    ifmt = 0;
+    if(!(isofmt_arg == ((char *)NULL)))
+    {
+      static const char isoformats[28l] = { (const char)100, (const char)97, (const char)116, (const char)101, (const char)0, (const char)104, (const char)111, (const char)117, (const char)114, (const char)115, (const char)0, (const char)109, (const char)105, (const char)110, (const char)117, (const char)116, (const char)101, (const char)115, (const char)0, (const char)115, (const char)101, (const char)99, (const char)111, (const char)110, (const char)100, (const char)115, (const char)0, (const char)0 };
+      ifmt=index_in_substrings(isoformats, isofmt_arg);
+      if(ifmt < 0)
+        bb_show_usage();
+
+    }
+
+  }
+
+  fmt_dt2str = (char *)NULL;
+
+  if(!(*argv == ((char *)NULL)))
+  {
+
+    if((signed int)*(*argv) == 43)
+    {
+      fmt_dt2str = &argv[(signed long int)0][(signed long int)1];
+      argv = argv + 1l;
+    }
+
+  }
+
+  signed int tmp_statement_expression$1;
+  unsigned long int tmp_if_expr$9;
+  unsigned long int tmp_if_expr$7;
+  unsigned long int tmp_if_expr$6;
+  unsigned long int return_value___strspn_c1$2;
+  unsigned long int tmp_if_expr$5;
+  unsigned long int return_value___strspn_c2$3;
+  unsigned long int return_value___builtin_strspn$4;
+  unsigned long int return_value___builtin_strspn$8;
+  _Bool tmp_if_expr$13;
+  _Bool tmp_if_expr$10;
+  _Bool tmp_if_expr$11;
+  _Bool tmp_if_expr$12;
+  if((10u & opt) == 0u)
+  {
+    opt = opt | (unsigned int)2;
+
+    date_str = argv[(signed long int)0];
+    if(!(date_str == ((char *)NULL)))
+    {
+      signed int len;
+      len = strspn(date_str, "0123456789");
+
+      if((signed int)date_str[(signed long int)len] == 0)
+        tmp_if_expr$13 = 1 != 0;
+
+      else
+      {
+
+        if((signed int)date_str[(signed long int)len] == 46)
+        {
+
+          tmp_if_expr$10 = ((signed int)(unsigned char)((signed int)date_str[(signed long int)(len + 1)] - 48) <= 9 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$10 = 0 != 0;
+        if(!(tmp_if_expr$10 == (_Bool)0))
+        {
+
+          tmp_if_expr$11 = ((signed int)(unsigned char)((signed int)date_str[(signed long int)(len + 2)] - 48) <= 9 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$11 = 0 != 0;
+        if(!(tmp_if_expr$11 == (_Bool)0))
+        {
+
+          tmp_if_expr$12 = ((signed int)date_str[(signed long int)(len + 3)] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$12 = 0 != 0;
+        tmp_if_expr$13 = (tmp_if_expr$12 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$13 == (_Bool)0))
+      {
+        len = len - 8;
+        if(!(len < 0))
+        {
+          if(len > 4)
+            goto __CPROVER_DUMP_L39;
+
+          if((1 & len) != 0)
+            goto __CPROVER_DUMP_L39;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L39:
+          ;
+          bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+        }
+        if(!(len == 0))
+        {
+          char buf[4l];
+          memcpy((void *)buf, (const void *)(date_str + (signed long int)8), (unsigned long int)len);
+          memmove((void *)(date_str + (signed long int)len), (const void *)date_str, (unsigned long int)8);
+          memcpy((void *)date_str, (const void *)buf, (unsigned long int)len);
+        }
+
+      }
+
+      argv = argv + 1l;
+    }
+
+  }
+
+
+  if(!(*argv == ((char *)NULL)))
+    bb_show_usage();
+
+  if(!((16u & opt) == 0u))
+  {
+    struct stat statbuf;
+    xstat(filename, &statbuf);
+    ts.tv_sec = statbuf.st_mtim.tv_sec;
+  }
+
+  else
+    time(&ts.tv_sec);
+  localtime_r(&ts.tv_sec, &tm_time);
+  signed int return_value_stime$15;
+  if(!(date_str == ((char *)NULL)))
+  {
+    tm_time.tm_sec = 0;
+    tm_time.tm_min = 0;
+    tm_time.tm_hour = 0;
+    if((_Bool)1)
+    {
+      if((64u & opt) == 0u)
+        goto __CPROVER_DUMP_L49;
+
+      char *return_value_strptime$14;
+      return_value_strptime$14=strptime(date_str, fmt_str2dt, &tm_time);
+      if(return_value_strptime$14 == ((char *)NULL))
+        bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L49:
+      ;
+      parse_datestr(date_str, &tm_time);
+    }
+
+    if(!((signed int)*date_str == 64))
+      tm_time.tm_isdst = -1;
+
+    ts.tv_sec=validate_tm_time(date_str, &tm_time);
+    maybe_set_utc((signed int)opt);
+    if(!((2u & opt) == 0u))
+    {
+      return_value_stime$15=stime(&ts.tv_sec);
+      if(return_value_stime$15 < 0)
+        bb_perror_msg("can't set date");
+
+    }
+
+  }
+
+  signed int tmp_post$16;
+  signed int tmp_post$17;
+  if(fmt_dt2str == ((char *)NULL))
+  {
+    signed int i;
+    fmt_dt2str = buf_fmt_dt2str;
+    if((_Bool)1)
+    {
+      if(!(ifmt >= 0))
+        goto __CPROVER_DUMP_L57;
+
+      strcpy(fmt_dt2str, "%Y-%m-%dT%H:%M:%S");
+      i = 8 + 3 * ifmt;
+      if(!(ifmt == 0))
+      {
+
+      format_utc:
+        ;
+        tmp_post$16 = i;
+        i = i + 1;
+        fmt_dt2str[(signed long int)tmp_post$16] = (char)37;
+        tmp_post$17 = i;
+        i = i + 1;
+        fmt_dt2str[(signed long int)tmp_post$17] = (char)((opt & (unsigned int)4) != 0u ? 90 : 122);
+      }
+
+      fmt_dt2str[(signed long int)i] = (char)0;
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L57:
+      ;
+      if(!((1u & opt) == 0u))
+      {
+        strcpy(fmt_dt2str, "%a, %d %b %Y %H:%M:%S ");
+        i = (signed int)(sizeof(char [23l]) /*23ul*/  - (unsigned long int)1);
+        goto format_utc;
+      }
+
+      else
+        fmt_dt2str = (char *)"%a %b %e %H:%M:%S %Z %Y";
+    }
+  }
+
+
+  signed int tmp_if_expr$25;
+  signed int tmp_statement_expression$19;
+  _Bool tmp_if_expr$20;
+  signed int tmp_if_expr$23;
+  signed int tmp_statement_expression$21;
+  signed int return_value___builtin_strcmp$22;
+  signed int return_value_strncmp$24;
+  if((signed int)*fmt_dt2str == 0)
+    bb_common_bufsiz1[(signed long int)0] = (char)0;
+
+  else
+  {
+    unsigned long int return_value_strlen$18;
+    return_value_strlen$18=strlen("%f");
+    if(return_value_strlen$18 < 2ul)
+    {
+      unsigned long int __s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("%f" + 1l) + -((unsigned long int)"%f") == 1ul))
+          goto __CPROVER_DUMP_L64;
+
+        __s2_len=strlen("%f");
+        tmp_if_expr$20 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L64:
+        ;
+        tmp_if_expr$20 = 0 != 0;
+      }
+      if(!(tmp_if_expr$20 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)fmt_dt2str;
+        signed int __result;
+
+        __result = (signed int)((const char *)"%f")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+
+
+            __result = (signed int)((const char *)"%f")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+
+
+                __result = (signed int)((const char *)"%f")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+
+                    /* assertion (_Bool)0 */
+                    __VERIFIER_error();
+
+                    __result = (signed int)((const char *)"%f")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+
+        tmp_statement_expression$21 = __result;
+        tmp_if_expr$23 = -tmp_statement_expression$21;
+      }
+
+      else
+      {
+        return_value___builtin_strcmp$22=strcmp(fmt_dt2str, "%f");
+        tmp_if_expr$23 = return_value___builtin_strcmp$22;
+      }
+      tmp_statement_expression$19 = tmp_if_expr$23;
+      tmp_if_expr$25 = tmp_statement_expression$19;
+    }
+
+    else
+    {
+      return_value_strncmp$24=strncmp(fmt_dt2str, "%f", (unsigned long int)2);
+      tmp_if_expr$25 = return_value_strncmp$24;
+    }
+    if(tmp_if_expr$25 == 0)
+      fmt_dt2str = (char *)"%Y.%m.%d-%H:%M:%S";
+
+    strftime(bb_common_bufsiz1, sizeof(char [8193l]) /*8193ul*/ , fmt_dt2str, &tm_time);
+  }
+  puts(bb_common_bufsiz1);
+  return 0;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+
+    *bb_errno = 22;
+  }
+
+  return v;
+}
+
+// file libbb/compare_string_array.c line 54
+static signed int index_in_substrings(const char *strings, const char *key)
+{
+  signed int matched_idx = -1;
+  signed int len;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(key);
+  len = (const signed int)return_value_strlen$1;
+  if(!(len == 0))
+  {
+    signed int idx = 0;
+    while(!((signed int)*strings == 0))
+    {
+      signed int return_value_strncmp$2;
+      return_value_strncmp$2=strncmp(strings, key, (unsigned long int)len);
+      if(return_value_strncmp$2 == 0)
+      {
+        if((signed int)strings[(signed long int)len] == 0)
+          return idx;
+
+        if(matched_idx >= 0)
+          return -1;
+
+        matched_idx = idx;
+      }
+
+      unsigned long int return_value_strlen$3;
+      return_value_strlen$3=strlen(strings);
+      strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+      idx = idx + 1;
+    }
+  }
+
+  return matched_idx;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file coreutils/date.c line 155
+static void maybe_set_utc(signed int opt)
+{
+  if(!((4 & opt) == 0))
+    putenv((char *)"TZ=UTC0");
+
+}
+
+// file libbb/time.c line 11
+static void parse_datestr(const char *date_str, struct tm *ptm)
+{
+  char end = (char)0;
+  const char *last_colon;
+  last_colon=strrchr(date_str, 58);
+  signed int return_value_sscanf$5;
+  signed int return_value_sscanf$2;
+  _Bool tmp_if_expr$4;
+  signed int return_value_sscanf$3;
+  _Bool tmp_if_expr$1;
+  char *return_value___builtin_strchr$23;
+  _Bool tmp_if_expr$27;
+  signed int return_value_sscanf$24;
+  _Bool tmp_if_expr$26;
+  signed int return_value_sscanf$25;
+  _Bool tmp_if_expr$20;
+  signed int return_value_sscanf$19;
+  _Bool tmp_if_expr$18;
+  signed int return_value_sscanf$17;
+  _Bool tmp_if_expr$16;
+  signed int return_value_sscanf$15;
+  _Bool tmp_if_expr$14;
+  signed int return_value_sscanf$13;
+  _Bool tmp_if_expr$12;
+  signed int return_value_sscanf$11;
+  _Bool tmp_if_expr$10;
+  signed int return_value_sscanf$9;
+  if(!(last_colon == ((const char *)NULL)))
+  {
+    const char *endp;
+    signed int return_value_sscanf$6;
+    return_value_sscanf$6=sscanf(date_str, "%u:%u%c", &ptm->tm_hour, &ptm->tm_min, &end);
+    if(!(return_value_sscanf$6 >= 2))
+    {
+      return_value_sscanf$5=sscanf(date_str, "%u.%u-%u:%u%c", &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+      if(return_value_sscanf$5 >= 4)
+        ptm->tm_mon = ptm->tm_mon - 1;
+
+      else
+      {
+        return_value_sscanf$2=sscanf(date_str, "%u.%u.%u-%u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+        if(return_value_sscanf$2 >= 5)
+          tmp_if_expr$4 = 1 != 0;
+
+        else
+        {
+          return_value_sscanf$3=sscanf(date_str, "%u-%u-%u %u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+          tmp_if_expr$4 = (return_value_sscanf$3 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$4 == (_Bool)0))
+        {
+          ptm->tm_year = ptm->tm_year - 1900;
+          ptm->tm_mon = ptm->tm_mon - 1;
+        }
+
+        else
+        {
+          endp=strptime(date_str, "%b %d %T %Y", ptm);
+          if(!(endp == ((const char *)NULL)))
+            tmp_if_expr$1 = ((signed int)*endp == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+          else
+            tmp_if_expr$1 = 0 != 0;
+          if(!(tmp_if_expr$1 == (_Bool)0))
+            return;
+
+          else
+            bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+        }
+      }
+    }
+
+    if((signed int)end == 58)
+    {
+      signed int return_value_sscanf$7;
+      return_value_sscanf$7=sscanf(last_colon + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+      if(return_value_sscanf$7 == 1)
+        end = (char)0;
+
+    }
+
+  }
+
+  else
+  {
+    return_value___builtin_strchr$23=strchr(date_str, 45);
+    if(!(return_value___builtin_strchr$23 == ((char *)NULL)))
+    {
+      return_value_sscanf$24=sscanf(date_str, "%u-%u-%u %u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &end);
+      if(return_value_sscanf$24 >= 4)
+        tmp_if_expr$26 = 1 != 0;
+
+      else
+      {
+        return_value_sscanf$25=sscanf(date_str, "%u-%u-%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &end);
+        tmp_if_expr$26 = (return_value_sscanf$25 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      tmp_if_expr$27 = (tmp_if_expr$26 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+
+    else
+      tmp_if_expr$27 = 0 != 0;
+    if(!(tmp_if_expr$27 == (_Bool)0))
+    {
+      ptm->tm_year = ptm->tm_year - 1900;
+      ptm->tm_mon = ptm->tm_mon - 1;
+    }
+
+    else
+      if((signed int)*date_str == 64)
+      {
+        signed long int t;
+        t=bb_strtol(date_str + (signed long int)1, (char **)NULL, 10);
+        if(*bb_errno == 0)
+        {
+          struct tm *lt;
+          lt=localtime(&t);
+          if(!(lt == ((struct tm *)NULL)))
+          {
+            *ptm = *lt;
+            return;
+          }
+
+        }
+
+        end = (char)49;
+      }
+
+      else
+      {
+        unsigned int cur_year = (unsigned int)ptm->tm_year;
+        signed int len;
+        char *return_value_strchrnul$8;
+        return_value_strchrnul$8=strchrnul(date_str, 46);
+        len = (signed int)(return_value_strchrnul$8 - date_str);
+        if(len == 2)
+        {
+          return_value_sscanf$19=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)12, &ptm->tm_min, &end);
+          tmp_if_expr$20 = (return_value_sscanf$19 >= 1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$20 = 0 != 0;
+        if(tmp_if_expr$20 == (_Bool)0)
+        {
+          if(len == 4)
+          {
+            return_value_sscanf$17=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)9, &ptm->tm_hour, &ptm->tm_min, &end);
+            tmp_if_expr$18 = (return_value_sscanf$17 >= 2 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+
+          else
+            tmp_if_expr$18 = 0 != 0;
+          if(tmp_if_expr$18 == (_Bool)0)
+          {
+            if(len == 6)
+            {
+              return_value_sscanf$15=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)6, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+              tmp_if_expr$16 = (return_value_sscanf$15 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+            }
+
+            else
+              tmp_if_expr$16 = 0 != 0;
+            if(tmp_if_expr$16 == (_Bool)0)
+            {
+              if(len == 8)
+              {
+                return_value_sscanf$13=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)3, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                tmp_if_expr$14 = (return_value_sscanf$13 >= 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+              }
+
+              else
+                tmp_if_expr$14 = 0 != 0;
+              if(!(tmp_if_expr$14 == (_Bool)0))
+                ptm->tm_mon = ptm->tm_mon - 1;
+
+              else
+              {
+                if(len == 10)
+                {
+                  return_value_sscanf$11=sscanf(date_str, "%2u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                  tmp_if_expr$12 = (return_value_sscanf$11 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                }
+
+                else
+                  tmp_if_expr$12 = 0 != 0;
+                if(!(tmp_if_expr$12 == (_Bool)0))
+                {
+                  ptm->tm_mon = ptm->tm_mon - 1;
+                  if((signed int)cur_year >= 50)
+                  {
+                    ptm->tm_year = ptm->tm_year + (signed int)((cur_year / (unsigned int)100) * (unsigned int)100);
+                    if(!((unsigned int)ptm->tm_year >= 4294967246u + cur_year))
+                      ptm->tm_year = ptm->tm_year + 100;
+
+                    if(!(50u + cur_year >= (unsigned int)ptm->tm_year))
+                      ptm->tm_year = ptm->tm_year - 100;
+
+                  }
+
+                }
+
+                else
+                {
+                  if(len == 12)
+                  {
+                    return_value_sscanf$9=sscanf(date_str, "%4u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                    tmp_if_expr$10 = (return_value_sscanf$9 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  }
+
+                  else
+                    tmp_if_expr$10 = 0 != 0;
+                  if(!(tmp_if_expr$10 == (_Bool)0))
+                  {
+                    ptm->tm_year = ptm->tm_year - 1900;
+                    ptm->tm_mon = ptm->tm_mon - 1;
+                  }
+
+                  else
+                    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+                }
+              }
+            }
+
+          }
+
+        }
+
+        if((signed int)end == 46)
+        {
+          char *return_value___builtin_strchr$21;
+          return_value___builtin_strchr$21=strchr(date_str, 46);
+          signed int return_value_sscanf$22;
+          return_value_sscanf$22=sscanf(return_value___builtin_strchr$21 + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+          if(return_value_sscanf$22 == 1)
+            end = (char)0;
+
+        }
+
+      }
+  }
+  if(!((signed int)end == 0))
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+
+}
+
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file libbb/time.c line 202
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm)
+{
+  signed long int t;
+  t=mktime(ptm);
+  if(t == -1l)
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+
+  return t;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xfuncs_printf.c line 469
+static void xstat(const char *name, struct stat *stat_buf)
+{
+  signed int return_value_stat$1;
+  return_value_stat$1=stat(name, stat_buf);
+  if(!(return_value_stat$1 == 0))
+    bb_perror_msg_and_die("can't stat '%s'", name);
+
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/date_false-no-overflow.i
+++ b/c/busybox-1.22.0/date_false-no-overflow.i
@@ -1,0 +1,3851 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static inline signed int bb_ascii_isalnum(unsigned char a);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base);
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+static signed int index_in_substrings(const char *strings, const char *key);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static void maybe_set_utc(signed int opt);
+static void parse_datestr(const char *date_str, struct tm *ptm);
+static unsigned long long int ret_ERANGE(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static void xstat(const char *name, struct stat *stat_buf);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static char bb_common_bufsiz1[8193l];
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_invalid_date[18l] = { (const char)105, (const char)110, (const char)118, (const char)97, (const char)108, (const char)105, (const char)100, (const char)32, (const char)100, (const char)97, (const char)116, (const char)101, (const char)32, (const char)39, (const char)37, (const char)115, (const char)39, (const char)0 };
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static const char date_longopts[53l] = { (const char)114, (const char)102, (const char)99, (const char)45, (const char)56, (const char)50, (const char)50, (const char)0, (const char)0, (const char)82, (const char)114, (const char)102, (const char)99, (const char)45, (const char)50, (const char)56, (const char)50, (const char)50, (const char)0, (const char)0, (const char)82, (const char)115, (const char)101, (const char)116, (const char)0, (const char)1, (const char)115, (const char)117, (const char)116, (const char)99, (const char)0, (const char)0, (const char)117, (const char)100, (const char)97, (const char)116, (const char)101, (const char)0, (const char)1, (const char)100, (const char)114, (const char)101, (const char)102, (const char)101, (const char)114, (const char)101, (const char)110, (const char)99, (const char)101, (const char)0, (const char)1, (const char)114, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base)
+{
+  signed long long int return_value_bb_strtoll$1;
+  return_value_bb_strtoll$1=bb_strtoll(arg, endp, base);
+  return return_value_bb_strtoll$1;
+}
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed long long int)return_value_ret_ERANGE$2;
+  }
+  *bb_errno = 0;
+  signed long long int return_value_strtoll$4;
+  return_value_strtoll$4=strtoll(arg, endp, base);
+  v = (unsigned long long int)return_value_strtoll$4;
+  unsigned long long int return_value_handle_errors$5;
+  return_value_handle_errors$5=handle_errors(v, endp);
+  return (signed long long int)return_value_handle_errors$5;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct timespec ts;
+  struct tm tm_time;
+  char buf_fmt_dt2str[64l];
+  unsigned int opt;
+  signed int ifmt = -1;
+  char *date_str;
+  char *fmt_dt2str;
+  char *fmt_str2dt;
+  char *filename;
+  char *isofmt_arg = (char *)((void *)0);
+  opt_complementary = "d--s:s--d:R--I:I--R";
+  applet_long_options = date_longopts;
+  opt=getopt32(argv, "Rs:ud:r:I::D:", &date_str, &date_str, &filename, &isofmt_arg, &fmt_str2dt);
+  argv = argv + (signed long int)optind;
+  maybe_set_utc((signed int)opt);
+  if(!((32u & opt) == 0u))
+  {
+    ifmt = 0;
+    if(!(isofmt_arg == ((char *)((void *)0))))
+    {
+      static const char isoformats[28l] = { (const char)100, (const char)97, (const char)116, (const char)101, (const char)0, (const char)104, (const char)111, (const char)117, (const char)114, (const char)115, (const char)0, (const char)109, (const char)105, (const char)110, (const char)117, (const char)116, (const char)101, (const char)115, (const char)0, (const char)115, (const char)101, (const char)99, (const char)111, (const char)110, (const char)100, (const char)115, (const char)0, (const char)0 };
+      ifmt=index_in_substrings(isoformats, isofmt_arg);
+      if(ifmt < 0)
+        bb_show_usage();
+    }
+  }
+  fmt_dt2str = (char *)((void *)0);
+  if(!(*argv == ((char *)((void *)0))))
+  {
+    if((signed int)*(*argv) == 43)
+    {
+      fmt_dt2str = &argv[(signed long int)0][(signed long int)1];
+      argv = argv + 1l;
+    }
+  }
+  signed int tmp_statement_expression$1;
+  unsigned long int tmp_if_expr$9;
+  unsigned long int tmp_if_expr$7;
+  unsigned long int tmp_if_expr$6;
+  unsigned long int return_value___strspn_c1$2;
+  unsigned long int tmp_if_expr$5;
+  unsigned long int return_value___strspn_c2$3;
+  unsigned long int return_value___builtin_strspn$4;
+  unsigned long int return_value___builtin_strspn$8;
+  _Bool tmp_if_expr$13;
+  _Bool tmp_if_expr$10;
+  _Bool tmp_if_expr$11;
+  _Bool tmp_if_expr$12;
+  if((10u & opt) == 0u)
+  {
+    opt = opt | (unsigned int)2;
+    date_str = argv[(signed long int)0];
+    if(!(date_str == ((char *)((void *)0))))
+    {
+      signed int len;
+      len = strspn(date_str, "0123456789");
+      if((signed int)date_str[(signed long int)len] == 0)
+        tmp_if_expr$13 = 1 != 0;
+      else
+      {
+        if((signed int)date_str[(signed long int)len] == 46)
+        {
+          tmp_if_expr$10 = ((signed int)(unsigned char)((signed int)date_str[(signed long int)(len + 1)] - 48) <= 9 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$10 = 0 != 0;
+        if(!(tmp_if_expr$10 == (_Bool)0))
+        {
+          tmp_if_expr$11 = ((signed int)(unsigned char)((signed int)date_str[(signed long int)(len + 2)] - 48) <= 9 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$11 = 0 != 0;
+        if(!(tmp_if_expr$11 == (_Bool)0))
+        {
+          tmp_if_expr$12 = ((signed int)date_str[(signed long int)(len + 3)] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$12 = 0 != 0;
+        tmp_if_expr$13 = (tmp_if_expr$12 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$13 == (_Bool)0))
+      {
+        len = len - 8;
+        if(!(len < 0))
+        {
+          if(len > 4)
+            goto __CPROVER_DUMP_L39;
+          if((1 & len) != 0)
+            goto __CPROVER_DUMP_L39;
+        }
+        else
+        {
+        __CPROVER_DUMP_L39:
+          ;
+          bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+        }
+        if(!(len == 0))
+        {
+          char buf[4l];
+          memcpy((void *)buf, (const void *)(date_str + (signed long int)8), (unsigned long int)len);
+          memmove((void *)(date_str + (signed long int)len), (const void *)date_str, (unsigned long int)8);
+          memcpy((void *)date_str, (const void *)buf, (unsigned long int)len);
+        }
+      }
+      argv = argv + 1l;
+    }
+  }
+  if(!(*argv == ((char *)((void *)0))))
+    bb_show_usage();
+  if(!((16u & opt) == 0u))
+  {
+    struct stat statbuf;
+    xstat(filename, &statbuf);
+    ts.tv_sec = statbuf.st_mtim.tv_sec;
+  }
+  else
+    time(&ts.tv_sec);
+  localtime_r(&ts.tv_sec, &tm_time);
+  signed int return_value_stime$15;
+  if(!(date_str == ((char *)((void *)0))))
+  {
+    tm_time.tm_sec = 0;
+    tm_time.tm_min = 0;
+    tm_time.tm_hour = 0;
+    if((_Bool)1)
+    {
+      if((64u & opt) == 0u)
+        goto __CPROVER_DUMP_L49;
+      char *return_value_strptime$14;
+      return_value_strptime$14=strptime(date_str, fmt_str2dt, &tm_time);
+      if(return_value_strptime$14 == ((char *)((void *)0)))
+        bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+    }
+    else
+    {
+    __CPROVER_DUMP_L49:
+      ;
+      parse_datestr(date_str, &tm_time);
+    }
+    if(!((signed int)*date_str == 64))
+      tm_time.tm_isdst = -1;
+    ts.tv_sec=validate_tm_time(date_str, &tm_time);
+    maybe_set_utc((signed int)opt);
+    if(!((2u & opt) == 0u))
+    {
+      return_value_stime$15=stime(&ts.tv_sec);
+      if(return_value_stime$15 < 0)
+        bb_perror_msg("can't set date");
+    }
+  }
+  signed int tmp_post$16;
+  signed int tmp_post$17;
+  if(fmt_dt2str == ((char *)((void *)0)))
+  {
+    signed int i;
+    fmt_dt2str = buf_fmt_dt2str;
+    if((_Bool)1)
+    {
+      if(!(ifmt >= 0))
+        goto __CPROVER_DUMP_L57;
+      strcpy(fmt_dt2str, "%Y-%m-%dT%H:%M:%S");
+      i = 8 + 3 * ifmt;
+      if(!(ifmt == 0))
+      {
+      format_utc:
+        ;
+        tmp_post$16 = i;
+        i = i + 1;
+        fmt_dt2str[(signed long int)tmp_post$16] = (char)37;
+        tmp_post$17 = i;
+        i = i + 1;
+        fmt_dt2str[(signed long int)tmp_post$17] = (char)((opt & (unsigned int)4) != 0u ? 90 : 122);
+      }
+      fmt_dt2str[(signed long int)i] = (char)0;
+    }
+    else
+    {
+    __CPROVER_DUMP_L57:
+      ;
+      if(!((1u & opt) == 0u))
+      {
+        strcpy(fmt_dt2str, "%a, %d %b %Y %H:%M:%S ");
+        i = (signed int)(sizeof(char [23l]) - (unsigned long int)1);
+        goto format_utc;
+      }
+      else
+        fmt_dt2str = (char *)"%a %b %e %H:%M:%S %Z %Y";
+    }
+  }
+  signed int tmp_if_expr$25;
+  signed int tmp_statement_expression$19;
+  _Bool tmp_if_expr$20;
+  signed int tmp_if_expr$23;
+  signed int tmp_statement_expression$21;
+  signed int return_value___builtin_strcmp$22;
+  signed int return_value_strncmp$24;
+  if((signed int)*fmt_dt2str == 0)
+    bb_common_bufsiz1[(signed long int)0] = (char)0;
+  else
+  {
+    unsigned long int return_value_strlen$18;
+    return_value_strlen$18=strlen("%f");
+    if(return_value_strlen$18 < 2ul)
+    {
+      unsigned long int __s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("%f" + 1l) + -((unsigned long int)"%f") == 1ul))
+          goto __CPROVER_DUMP_L64;
+        __s2_len=strlen("%f");
+        tmp_if_expr$20 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      else
+      {
+      __CPROVER_DUMP_L64:
+        ;
+        tmp_if_expr$20 = 0 != 0;
+      }
+      if(!(tmp_if_expr$20 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)fmt_dt2str;
+        signed int __result;
+        __result = (signed int)((const char *)"%f")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+            __result = (signed int)((const char *)"%f")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"%f")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+                    __VERIFIER_error();
+                    __result = (signed int)((const char *)"%f")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+                }
+              }
+            }
+          }
+        }
+        tmp_statement_expression$21 = __result;
+        tmp_if_expr$23 = -tmp_statement_expression$21;
+      }
+      else
+      {
+        return_value___builtin_strcmp$22=strcmp(fmt_dt2str, "%f");
+        tmp_if_expr$23 = return_value___builtin_strcmp$22;
+      }
+      tmp_statement_expression$19 = tmp_if_expr$23;
+      tmp_if_expr$25 = tmp_statement_expression$19;
+    }
+    else
+    {
+      return_value_strncmp$24=strncmp(fmt_dt2str, "%f", (unsigned long int)2);
+      tmp_if_expr$25 = return_value_strncmp$24;
+    }
+    if(tmp_if_expr$25 == 0)
+      fmt_dt2str = (char *)"%Y.%m.%d-%H:%M:%S";
+    strftime(bb_common_bufsiz1, sizeof(char [8193l]) , fmt_dt2str, &tm_time);
+  }
+  puts(bb_common_bufsiz1);
+  return 0;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+    *bb_errno = 22;
+  }
+  return v;
+}
+static signed int index_in_substrings(const char *strings, const char *key)
+{
+  signed int matched_idx = -1;
+  signed int len;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(key);
+  len = (const signed int)return_value_strlen$1;
+  if(!(len == 0))
+  {
+    signed int idx = 0;
+    while(!((signed int)*strings == 0))
+    {
+      signed int return_value_strncmp$2;
+      return_value_strncmp$2=strncmp(strings, key, (unsigned long int)len);
+      if(return_value_strncmp$2 == 0)
+      {
+        if((signed int)strings[(signed long int)len] == 0)
+          return idx;
+        if(matched_idx >= 0)
+          return -1;
+        matched_idx = idx;
+      }
+      unsigned long int return_value_strlen$3;
+      return_value_strlen$3=strlen(strings);
+      strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+      idx = idx + 1;
+    }
+  }
+  return matched_idx;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static void maybe_set_utc(signed int opt)
+{
+  if(!((4 & opt) == 0))
+    putenv((char *)"TZ=UTC0");
+}
+static void parse_datestr(const char *date_str, struct tm *ptm)
+{
+  char end = (char)0;
+  const char *last_colon;
+  last_colon=strrchr(date_str, 58);
+  signed int return_value_sscanf$5;
+  signed int return_value_sscanf$2;
+  _Bool tmp_if_expr$4;
+  signed int return_value_sscanf$3;
+  _Bool tmp_if_expr$1;
+  char *return_value___builtin_strchr$23;
+  _Bool tmp_if_expr$27;
+  signed int return_value_sscanf$24;
+  _Bool tmp_if_expr$26;
+  signed int return_value_sscanf$25;
+  _Bool tmp_if_expr$20;
+  signed int return_value_sscanf$19;
+  _Bool tmp_if_expr$18;
+  signed int return_value_sscanf$17;
+  _Bool tmp_if_expr$16;
+  signed int return_value_sscanf$15;
+  _Bool tmp_if_expr$14;
+  signed int return_value_sscanf$13;
+  _Bool tmp_if_expr$12;
+  signed int return_value_sscanf$11;
+  _Bool tmp_if_expr$10;
+  signed int return_value_sscanf$9;
+  if(!(last_colon == ((const char *)((void *)0))))
+  {
+    const char *endp;
+    signed int return_value_sscanf$6;
+    return_value_sscanf$6=sscanf(date_str, "%u:%u%c", &ptm->tm_hour, &ptm->tm_min, &end);
+    if(!(return_value_sscanf$6 >= 2))
+    {
+      return_value_sscanf$5=sscanf(date_str, "%u.%u-%u:%u%c", &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+      if(return_value_sscanf$5 >= 4)
+        ptm->tm_mon = ptm->tm_mon - 1;
+      else
+      {
+        return_value_sscanf$2=sscanf(date_str, "%u.%u.%u-%u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+        if(return_value_sscanf$2 >= 5)
+          tmp_if_expr$4 = 1 != 0;
+        else
+        {
+          return_value_sscanf$3=sscanf(date_str, "%u-%u-%u %u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+          tmp_if_expr$4 = (return_value_sscanf$3 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$4 == (_Bool)0))
+        {
+          ptm->tm_year = ptm->tm_year - 1900;
+          ptm->tm_mon = ptm->tm_mon - 1;
+        }
+        else
+        {
+          endp=strptime(date_str, "%b %d %T %Y", ptm);
+          if(!(endp == ((const char *)((void *)0))))
+            tmp_if_expr$1 = ((signed int)*endp == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          else
+            tmp_if_expr$1 = 0 != 0;
+          if(!(tmp_if_expr$1 == (_Bool)0))
+            return;
+          else
+            bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+        }
+      }
+    }
+    if((signed int)end == 58)
+    {
+      signed int return_value_sscanf$7;
+      return_value_sscanf$7=sscanf(last_colon + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+      if(return_value_sscanf$7 == 1)
+        end = (char)0;
+    }
+  }
+  else
+  {
+    return_value___builtin_strchr$23=strchr(date_str, 45);
+    if(!(return_value___builtin_strchr$23 == ((char *)((void *)0))))
+    {
+      return_value_sscanf$24=sscanf(date_str, "%u-%u-%u %u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &end);
+      if(return_value_sscanf$24 >= 4)
+        tmp_if_expr$26 = 1 != 0;
+      else
+      {
+        return_value_sscanf$25=sscanf(date_str, "%u-%u-%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &end);
+        tmp_if_expr$26 = (return_value_sscanf$25 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      tmp_if_expr$27 = (tmp_if_expr$26 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    else
+      tmp_if_expr$27 = 0 != 0;
+    if(!(tmp_if_expr$27 == (_Bool)0))
+    {
+      ptm->tm_year = ptm->tm_year - 1900;
+      ptm->tm_mon = ptm->tm_mon - 1;
+    }
+    else
+      if((signed int)*date_str == 64)
+      {
+        signed long int t;
+        t=bb_strtol(date_str + (signed long int)1, (char **)((void *)0), 10);
+        if(*bb_errno == 0)
+        {
+          struct tm *lt;
+          lt=localtime(&t);
+          if(!(lt == ((struct tm *)((void *)0))))
+          {
+            *ptm = *lt;
+            return;
+          }
+        }
+        end = (char)49;
+      }
+      else
+      {
+        unsigned int cur_year = (unsigned int)ptm->tm_year;
+        signed int len;
+        char *return_value_strchrnul$8;
+        return_value_strchrnul$8=strchrnul(date_str, 46);
+        len = (signed int)(return_value_strchrnul$8 - date_str);
+        if(len == 2)
+        {
+          return_value_sscanf$19=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)12, &ptm->tm_min, &end);
+          tmp_if_expr$20 = (return_value_sscanf$19 >= 1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$20 = 0 != 0;
+        if(tmp_if_expr$20 == (_Bool)0)
+        {
+          if(len == 4)
+          {
+            return_value_sscanf$17=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)9, &ptm->tm_hour, &ptm->tm_min, &end);
+            tmp_if_expr$18 = (return_value_sscanf$17 >= 2 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          else
+            tmp_if_expr$18 = 0 != 0;
+          if(tmp_if_expr$18 == (_Bool)0)
+          {
+            if(len == 6)
+            {
+              return_value_sscanf$15=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)6, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+              tmp_if_expr$16 = (return_value_sscanf$15 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+            }
+            else
+              tmp_if_expr$16 = 0 != 0;
+            if(tmp_if_expr$16 == (_Bool)0)
+            {
+              if(len == 8)
+              {
+                return_value_sscanf$13=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)3, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                tmp_if_expr$14 = (return_value_sscanf$13 >= 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+              }
+              else
+                tmp_if_expr$14 = 0 != 0;
+              if(!(tmp_if_expr$14 == (_Bool)0))
+                ptm->tm_mon = ptm->tm_mon - 1;
+              else
+              {
+                if(len == 10)
+                {
+                  return_value_sscanf$11=sscanf(date_str, "%2u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                  tmp_if_expr$12 = (return_value_sscanf$11 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                }
+                else
+                  tmp_if_expr$12 = 0 != 0;
+                if(!(tmp_if_expr$12 == (_Bool)0))
+                {
+                  ptm->tm_mon = ptm->tm_mon - 1;
+                  if((signed int)cur_year >= 50)
+                  {
+                    ptm->tm_year = ptm->tm_year + (signed int)((cur_year / (unsigned int)100) * (unsigned int)100);
+                    if(!((unsigned int)ptm->tm_year >= 4294967246u + cur_year))
+                      ptm->tm_year = ptm->tm_year + 100;
+                    if(!(50u + cur_year >= (unsigned int)ptm->tm_year))
+                      ptm->tm_year = ptm->tm_year - 100;
+                  }
+                }
+                else
+                {
+                  if(len == 12)
+                  {
+                    return_value_sscanf$9=sscanf(date_str, "%4u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                    tmp_if_expr$10 = (return_value_sscanf$9 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  }
+                  else
+                    tmp_if_expr$10 = 0 != 0;
+                  if(!(tmp_if_expr$10 == (_Bool)0))
+                  {
+                    ptm->tm_year = ptm->tm_year - 1900;
+                    ptm->tm_mon = ptm->tm_mon - 1;
+                  }
+                  else
+                    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+                }
+              }
+            }
+          }
+        }
+        if((signed int)end == 46)
+        {
+          char *return_value___builtin_strchr$21;
+          return_value___builtin_strchr$21=strchr(date_str, 46);
+          signed int return_value_sscanf$22;
+          return_value_sscanf$22=sscanf(return_value___builtin_strchr$21 + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+          if(return_value_sscanf$22 == 1)
+            end = (char)0;
+        }
+      }
+  }
+  if(!((signed int)end == 0))
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+}
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm)
+{
+  signed long int t;
+  t=mktime(ptm);
+  if(t == -1l)
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+  return t;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void xstat(const char *name, struct stat *stat_buf)
+{
+  signed int return_value_stat$1;
+  return_value_stat$1=stat(name, stat_buf);
+  if(!(return_value_stat$1 == 0))
+    bb_perror_msg_and_die("can't stat '%s'", name);
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -303,7 +303,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2550,7 +2550,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/du_false-no-overflow.c
+++ b/c/busybox-1.22.0/du_false-no-overflow.c
@@ -1,0 +1,1471 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <dirent.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/ptr_to_globals.c line 10
+struct globals;
+
+// file libbb/inode_hash.c line 13
+struct ino_dev_hash_bucket_struct;
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1368
+static void add_to_ino_dev_hashtable(struct stat *statbuf, const char *name);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/concat_path_file.c line 19
+static char * concat_path_file(const char *path, const char *filename);
+// file libbb/concat_subpath_file.c line 18
+static char * concat_subpath_file(const char *path, const char *f);
+// file coreutils/du.c line 115
+static unsigned long long int du(const char *filename);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1367
+static char * is_in_ino_dev_hashtable(struct stat *statbuf);
+// file include/libbb.h line 388
+static char * last_char_is(const char *s, signed int c);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/human_readable.c line 33
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit);
+// file coreutils/du.c line 96
+static void print(unsigned long long int size, const char *filename);
+// file libbb/inode_hash.c line 72
+static void reset_ino_dev_hashtable(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file libbb/xfuncs_printf.c line 396
+static struct __dirstream * warn_opendir(const char *path);
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct globals
+{
+  // disp_hr
+  unsigned long int disp_hr;
+  // max_print_depth
+  signed int max_print_depth;
+  // status
+  _Bool status;
+  // slink_depth
+  signed int slink_depth;
+  // du_depth
+  signed int du_depth;
+  // dir_dev
+  unsigned long int dir_dev;
+};
+
+struct ino_dev_hash_bucket_struct
+{
+  // next
+  struct ino_dev_hash_bucket_struct *next;
+  // ino
+  unsigned long int ino;
+  // dev
+  unsigned long int dev;
+  // name
+  char name[1l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/messages.c line 66
+static char bb_common_bufsiz1[8193l];
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/inode_hash.c line 24
+static struct ino_dev_hash_bucket_struct **ino_dev_hashtable;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1368
+static void add_to_ino_dev_hashtable(struct stat *statbuf, const char *name)
+{
+  signed int i;
+  struct ino_dev_hash_bucket_struct *bucket;
+  i = (signed int)(statbuf->st_ino % (unsigned long int)311);
+  if(name == ((const char *)NULL))
+    name = "";
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(name);
+  void *return_value_xmalloc$2;
+  return_value_xmalloc$2=xmalloc(sizeof(struct ino_dev_hash_bucket_struct) /*32ul*/  + return_value_strlen$1);
+  bucket = (struct ino_dev_hash_bucket_struct *)return_value_xmalloc$2;
+  bucket->ino = statbuf->st_ino;
+  bucket->dev = statbuf->st_dev;
+  strcpy(bucket->name, name);
+  void *return_value_xzalloc$3;
+  if(ino_dev_hashtable == ((struct ino_dev_hash_bucket_struct **)NULL))
+  {
+    return_value_xzalloc$3=xzalloc((unsigned long int)311 * sizeof(struct ino_dev_hash_bucket_struct *) /*8ul*/ );
+    ino_dev_hashtable = (struct ino_dev_hash_bucket_struct **)return_value_xzalloc$3;
+  }
+
+  bucket->next = ino_dev_hashtable[(signed long int)i];
+  ino_dev_hashtable[(signed long int)i] = bucket;
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/concat_path_file.c line 19
+static char * concat_path_file(const char *path, const char *filename)
+{
+  char *lc;
+  if(path == ((const char *)NULL))
+    path = "";
+
+  lc=last_char_is(path, 47);
+  for( ; (signed int)*filename == 47; filename = filename + 1l)
+    ;
+  char *return_value_xasprintf$1;
+  return_value_xasprintf$1=xasprintf("%s%s%s", path, lc == (char *)NULL ? "/" : "", filename);
+  return return_value_xasprintf$1;
+}
+
+// file libbb/concat_subpath_file.c line 18
+static char * concat_subpath_file(const char *path, const char *f)
+{
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  if(!(f == ((const char *)NULL)))
+  {
+    if((signed int)*f == 46)
+    {
+      if((signed int)*(1l + f) == 0)
+        tmp_if_expr$2 = 1 != 0;
+
+      else
+      {
+        if((signed int)*(1l + f) == 46)
+          tmp_if_expr$1 = (!((signed int)f[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+        else
+          tmp_if_expr$1 = 0 != 0;
+        tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        return (char *)NULL;
+
+    }
+
+  }
+
+  char *return_value_concat_path_file$3;
+  return_value_concat_path_file$3=concat_path_file(path, f);
+  return return_value_concat_path_file$3;
+}
+
+// file coreutils/du.c line 115
+static unsigned long long int du(const char *filename)
+{
+  struct stat statbuf;
+  unsigned long long int sum;
+  signed int return_value_lstat$1;
+  return_value_lstat$1=lstat(filename, &statbuf);
+  if(!(return_value_lstat$1 == 0))
+  {
+    bb_simple_perror_msg(filename);
+    ((struct globals *)&bb_common_bufsiz1)->status = 1 != 0;
+    return (unsigned long long int)0;
+  }
+
+  if(!((32u & option_mask32) == 0u))
+  {
+    if(((struct globals *)&bb_common_bufsiz1)->du_depth == 0)
+      ((struct globals *)&bb_common_bufsiz1)->dir_dev = statbuf.st_dev;
+
+    else
+      if(!(((struct globals *)&bb_common_bufsiz1)->dir_dev == statbuf.st_dev))
+        return (unsigned long long int)0;
+
+  }
+
+  sum = (unsigned long long int)statbuf.st_blocks;
+  if((61440u & statbuf.st_mode) == 40960u)
+  {
+    if(!(((struct globals *)&bb_common_bufsiz1)->du_depth >= ((struct globals *)&bb_common_bufsiz1)->slink_depth))
+    {
+      signed int return_value_stat$2;
+      return_value_stat$2=stat(filename, &statbuf);
+      if(!(return_value_stat$2 == 0))
+      {
+        bb_simple_perror_msg(filename);
+        ((struct globals *)&bb_common_bufsiz1)->status = 1 != 0;
+        return (unsigned long long int)0;
+      }
+
+      sum = (unsigned long long int)statbuf.st_blocks;
+      if(((struct globals *)&bb_common_bufsiz1)->slink_depth == 1)
+        ((struct globals *)&bb_common_bufsiz1)->slink_depth = 2147483647;
+
+    }
+
+  }
+
+  if((128u & option_mask32) == 0u)
+  {
+    if(statbuf.st_nlink > 1ul)
+    {
+      char *return_value_is_in_ino_dev_hashtable$3;
+      return_value_is_in_ino_dev_hashtable$3=is_in_ino_dev_hashtable(&statbuf);
+      if(!(return_value_is_in_ino_dev_hashtable$3 == ((char *)NULL)))
+        return (unsigned long long int)0;
+
+      add_to_ino_dev_hashtable(&statbuf, (const char *)NULL);
+    }
+
+  }
+
+  if((61440u & statbuf.st_mode) == 16384u)
+  {
+    struct __dirstream *dir;
+    struct dirent *entry;
+    char *newfile;
+    dir=warn_opendir(filename);
+    if(dir == ((struct __dirstream *)NULL))
+    {
+      ((struct globals *)&bb_common_bufsiz1)->status = 1 != 0;
+      return sum;
+    }
+
+    do
+    {
+      entry=readdir(dir);
+      if(entry == ((struct dirent *)NULL))
+        break;
+
+      newfile=concat_subpath_file(filename, entry->d_name);
+      if(!(newfile == ((char *)NULL)))
+      {
+        ((struct globals *)&bb_common_bufsiz1)->du_depth = ((struct globals *)&bb_common_bufsiz1)->du_depth + 1;
+        unsigned long long int return_value_du$4;
+        return_value_du$4=du(newfile);
+        sum = sum + return_value_du$4;
+        ((struct globals *)&bb_common_bufsiz1)->du_depth = ((struct globals *)&bb_common_bufsiz1)->du_depth - 1;
+        free((void *)newfile);
+      }
+
+    }
+    while((_Bool)1);
+    closedir(dir);
+  }
+
+  else
+    if((1u & option_mask32) == 0u)
+    {
+      if(!(((struct globals *)&bb_common_bufsiz1)->du_depth == 0))
+        return sum;
+
+    }
+
+  if(((struct globals *)&bb_common_bufsiz1)->max_print_depth >= ((struct globals *)&bb_common_bufsiz1)->du_depth)
+    print(sum, filename);
+
+  return sum;
+}
+
+// file coreutils/du.c line 193
+signed int __main(signed int argc, char **argv)
+{
+  unsigned long long int total;
+  signed int slink_depth_save;
+  unsigned int opt;
+  ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)1024;
+  char *return_value_getenv$1;
+  return_value_getenv$1=getenv("POSIXLY_CORRECT");
+  if(!(return_value_getenv$1 == ((char *)NULL)))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)512;
+
+  ((struct globals *)&bb_common_bufsiz1)->max_print_depth = 2147483647;
+  opt_complementary = "h-km:k-hm:m-hk:H-L:L-H:s-d:d-s:d+";
+  opt=getopt32(argv, "aHkLsxd:lchm", &((struct globals *)&bb_common_bufsiz1)->max_print_depth);
+  argv = argv + (signed long int)optind;
+  if(!((512u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)0;
+
+  if(!((1024u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)(1024 * 1024);
+
+  if(!((4u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)1024;
+
+  if(!((2u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->slink_depth = 1;
+
+  if(!((8u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->slink_depth = 2147483647;
+
+  if(!((16u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->max_print_depth = 0;
+
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)".";
+    if(((struct globals *)&bb_common_bufsiz1)->slink_depth == 1)
+      ((struct globals *)&bb_common_bufsiz1)->slink_depth = 0;
+
+  }
+
+  slink_depth_save = ((struct globals *)&bb_common_bufsiz1)->slink_depth;
+  total = (unsigned long long int)0;
+  do
+  {
+    unsigned long long int return_value_du$2;
+
+    return_value_du$2=du(*argv);
+    total = total + return_value_du$2;
+    reset_ino_dev_hashtable();
+    ((struct globals *)&bb_common_bufsiz1)->slink_depth = slink_depth_save;
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  if(!((256u & opt) == 0u))
+    print(total, "total");
+
+  // fflush_stdout_and_exit((signed int)((struct globals *)&bb_common_bufsiz1)->status); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return ((signed int)((struct globals *)&bb_common_bufsiz1)->status);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1367
+static char * is_in_ino_dev_hashtable(struct stat *statbuf)
+{
+  struct ino_dev_hash_bucket_struct *bucket;
+  if(ino_dev_hashtable == ((struct ino_dev_hash_bucket_struct **)NULL))
+    return (char *)NULL;
+
+  bucket = ino_dev_hashtable[(signed long int)(statbuf->st_ino % (unsigned long int)311)];
+  for( ; !(bucket == ((struct ino_dev_hash_bucket_struct *)NULL)); bucket = bucket->next)
+    if(bucket->ino == statbuf->st_ino)
+    {
+      if(bucket->dev == statbuf->st_dev)
+        return bucket->name;
+
+    }
+
+  return (char *)NULL;
+}
+
+// file include/libbb.h line 388
+static char * last_char_is(const char *s, signed int c)
+{
+  if(!(s == ((const char *)NULL)))
+  {
+    if(!((signed int)*s == 0))
+    {
+      unsigned long int sz;
+      unsigned long int return_value_strlen$1;
+      return_value_strlen$1=strlen(s);
+      sz = return_value_strlen$1 - (unsigned long int)1;
+      s = s + (signed long int)sz;
+      if((signed int)*s == c)
+        return (char *)s;
+
+    }
+
+  }
+
+  return (char *)NULL;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/human_readable.c line 33
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit)
+{
+  unsigned int frac;
+  const char *u;
+  const char *fmt;
+  if(val == 0ul)
+    return "0";
+
+  fmt = "%llu";
+  if(block_size > 1ul)
+    val = val * block_size;
+
+  frac = (unsigned int)0;
+  static const char unit_chars[9l] = { (const char)0, (const char)75, (const char)77, (const char)71, (const char)84, (const char)80, (const char)69, (const char)90, (const char)89 };
+  u = unit_chars;
+  if(!(display_unit == 0ul))
+  {
+    val = val + display_unit / (unsigned long int)2;
+    val = val / display_unit;
+  }
+
+  else
+  {
+    for( ; val >= 1024ul; val = val / (unsigned long long int)1024)
+    {
+      fmt = "%llu.%u%c";
+      u = u + 1l;
+      frac = (((unsigned int)val % (unsigned int)1024) * (unsigned int)10 + (unsigned int)(1024 / 2)) / (unsigned int)1024;
+    }
+    if(frac >= 10u)
+    {
+      val = val + 1ull;
+      frac = (unsigned int)0;
+    }
+
+    if(block_size == 0ul)
+    {
+      if(frac >= 5u)
+        val = val + 1ull;
+
+      fmt = "%llu%*c";
+      frac = (unsigned int)1;
+    }
+
+  }
+  static char *str;
+  if(str == ((char *)NULL))
+  {
+    void *return_value_xmalloc$1;
+    return_value_xmalloc$1=xmalloc(sizeof(unsigned long long int) /*8ul*/  * (unsigned long int)3 + (unsigned long int)2 + (unsigned long int)3);
+    str = (char *)return_value_xmalloc$1;
+  }
+
+  sprintf(str, fmt, val, frac, *u);
+  return str;
+}
+
+// file coreutils/du.c line 96
+static void print(unsigned long long int size, const char *filename)
+{
+  const char *return_value_make_human_readable_str$1;
+  return_value_make_human_readable_str$1=make_human_readable_str(size, (unsigned long int)512, ((struct globals *)&bb_common_bufsiz1)->disp_hr);
+  printf("%s\t%s\n", return_value_make_human_readable_str$1, filename);
+}
+
+// file libbb/inode_hash.c line 72
+static void reset_ino_dev_hashtable(void)
+{
+  signed int i;
+  struct ino_dev_hash_bucket_struct *bucket;
+  i = 0;
+  for( ; i < 311 && !(ino_dev_hashtable == ((struct ino_dev_hash_bucket_struct **)NULL)); i = i + 1)
+    for( ; !(ino_dev_hashtable[(signed long int)i] == ((struct ino_dev_hash_bucket_struct *)NULL)); ino_dev_hashtable[(signed long int)i] = bucket)
+    {
+      bucket = ino_dev_hashtable[(signed long int)i]->next;
+      free((void *)ino_dev_hashtable[(signed long int)i]);
+    }
+  free((void *)ino_dev_hashtable);
+  ino_dev_hashtable = (struct ino_dev_hash_bucket_struct **)NULL;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file libbb/xfuncs_printf.c line 396
+static struct __dirstream * warn_opendir(const char *path)
+{
+  struct __dirstream *dp;
+  dp=opendir(path);
+  if(dp == ((struct __dirstream *)NULL))
+    bb_perror_msg("can't open '%s'", path);
+
+  return dp;
+}
+
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  va_start(p, format);
+  r=vasprintf(&string_ptr, format, p);
+  va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  return string_ptr;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/du_false-no-overflow.i
+++ b/c/busybox-1.22.0/du_false-no-overflow.i
@@ -1,0 +1,3698 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+struct dirent
+  {
+    __ino_t d_ino;
+    __off_t d_off;
+    unsigned short int d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+  };
+struct dirent64
+  {
+    __ino64_t d_ino;
+    __off64_t d_off;
+    unsigned short int d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+  };
+enum
+  {
+    DT_UNKNOWN = 0,
+    DT_FIFO = 1,
+    DT_CHR = 2,
+    DT_DIR = 4,
+    DT_BLK = 6,
+    DT_REG = 8,
+    DT_LNK = 10,
+    DT_SOCK = 12,
+    DT_WHT = 14
+  };
+typedef struct __dirstream DIR;
+extern DIR *opendir (const char *__name) __attribute__ ((__nonnull__ (1)));
+extern DIR *fdopendir (int __fd);
+extern int closedir (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern struct dirent *readdir (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern struct dirent64 *readdir64 (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern int readdir_r (DIR *__restrict __dirp,
+        struct dirent *__restrict __entry,
+        struct dirent **__restrict __result)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int readdir64_r (DIR *__restrict __dirp,
+   struct dirent64 *__restrict __entry,
+   struct dirent64 **__restrict __result)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern void rewinddir (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void seekdir (DIR *__dirp, long int __pos) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int telldir (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int dirfd (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+typedef long unsigned int size_t;
+extern int scandir (const char *__restrict __dir,
+      struct dirent ***__restrict __namelist,
+      int (*__selector) (const struct dirent *),
+      int (*__cmp) (const struct dirent **,
+      const struct dirent **))
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int scandir64 (const char *__restrict __dir,
+        struct dirent64 ***__restrict __namelist,
+        int (*__selector) (const struct dirent64 *),
+        int (*__cmp) (const struct dirent64 **,
+        const struct dirent64 **))
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int scandirat (int __dfd, const char *__restrict __dir,
+        struct dirent ***__restrict __namelist,
+        int (*__selector) (const struct dirent *),
+        int (*__cmp) (const struct dirent **,
+        const struct dirent **))
+     __attribute__ ((__nonnull__ (2, 3)));
+extern int scandirat64 (int __dfd, const char *__restrict __dir,
+   struct dirent64 ***__restrict __namelist,
+   int (*__selector) (const struct dirent64 *),
+   int (*__cmp) (const struct dirent64 **,
+          const struct dirent64 **))
+     __attribute__ ((__nonnull__ (2, 3)));
+extern int alphasort (const struct dirent **__e1,
+        const struct dirent **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int alphasort64 (const struct dirent64 **__e1,
+   const struct dirent64 **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern __ssize_t getdirentries (int __fd, char *__restrict __buf,
+    size_t __nbytes,
+    __off_t *__restrict __basep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern __ssize_t getdirentries64 (int __fd, char *__restrict __buf,
+      size_t __nbytes,
+      __off64_t *__restrict __basep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int versionsort (const struct dirent **__e1,
+   const struct dirent **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int versionsort64 (const struct dirent64 **__e1,
+     const struct dirent64 **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct globals;
+struct ino_dev_hash_bucket_struct;
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void add_to_ino_dev_hashtable(struct stat *statbuf, const char *name);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static char * concat_path_file(const char *path, const char *filename);
+static char * concat_subpath_file(const char *path, const char *f);
+static unsigned long long int du(const char *filename);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static char * is_in_ino_dev_hashtable(struct stat *statbuf);
+static char * last_char_is(const char *s, signed int c);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit);
+static void print(unsigned long long int size, const char *filename);
+static void reset_ino_dev_hashtable(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static struct __dirstream * warn_opendir(const char *path);
+static char * xasprintf(const char *format, ...);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct globals
+{
+  unsigned long int disp_hr;
+  signed int max_print_depth;
+  _Bool status;
+  signed int slink_depth;
+  signed int du_depth;
+  unsigned long int dir_dev;
+};
+struct ino_dev_hash_bucket_struct
+{
+  struct ino_dev_hash_bucket_struct *next;
+  unsigned long int ino;
+  unsigned long int dev;
+  char name[1l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static char bb_common_bufsiz1[8193l];
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static struct ino_dev_hash_bucket_struct **ino_dev_hashtable;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void add_to_ino_dev_hashtable(struct stat *statbuf, const char *name)
+{
+  signed int i;
+  struct ino_dev_hash_bucket_struct *bucket;
+  i = (signed int)(statbuf->st_ino % (unsigned long int)311);
+  if(name == ((const char *)((void *)0)))
+    name = "";
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(name);
+  void *return_value_xmalloc$2;
+  return_value_xmalloc$2=xmalloc(sizeof(struct ino_dev_hash_bucket_struct) + return_value_strlen$1);
+  bucket = (struct ino_dev_hash_bucket_struct *)return_value_xmalloc$2;
+  bucket->ino = statbuf->st_ino;
+  bucket->dev = statbuf->st_dev;
+  strcpy(bucket->name, name);
+  void *return_value_xzalloc$3;
+  if(ino_dev_hashtable == ((struct ino_dev_hash_bucket_struct **)((void *)0)))
+  {
+    return_value_xzalloc$3=xzalloc((unsigned long int)311 * sizeof(struct ino_dev_hash_bucket_struct *) );
+    ino_dev_hashtable = (struct ino_dev_hash_bucket_struct **)return_value_xzalloc$3;
+  }
+  bucket->next = ino_dev_hashtable[(signed long int)i];
+  ino_dev_hashtable[(signed long int)i] = bucket;
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static char * concat_path_file(const char *path, const char *filename)
+{
+  char *lc;
+  if(path == ((const char *)((void *)0)))
+    path = "";
+  lc=last_char_is(path, 47);
+  for( ; (signed int)*filename == 47; filename = filename + 1l)
+    ;
+  char *return_value_xasprintf$1;
+  return_value_xasprintf$1=xasprintf("%s%s%s", path, lc == (char *)((void *)0) ? "/" : "", filename);
+  return return_value_xasprintf$1;
+}
+static char * concat_subpath_file(const char *path, const char *f)
+{
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  if(!(f == ((const char *)((void *)0))))
+  {
+    if((signed int)*f == 46)
+    {
+      if((signed int)*(1l + f) == 0)
+        tmp_if_expr$2 = 1 != 0;
+      else
+      {
+        if((signed int)*(1l + f) == 46)
+          tmp_if_expr$1 = (!((signed int)f[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        else
+          tmp_if_expr$1 = 0 != 0;
+        tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        return (char *)((void *)0);
+    }
+  }
+  char *return_value_concat_path_file$3;
+  return_value_concat_path_file$3=concat_path_file(path, f);
+  return return_value_concat_path_file$3;
+}
+static unsigned long long int du(const char *filename)
+{
+  struct stat statbuf;
+  unsigned long long int sum;
+  signed int return_value_lstat$1;
+  return_value_lstat$1=lstat(filename, &statbuf);
+  if(!(return_value_lstat$1 == 0))
+  {
+    bb_simple_perror_msg(filename);
+    ((struct globals *)&bb_common_bufsiz1)->status = 1 != 0;
+    return (unsigned long long int)0;
+  }
+  if(!((32u & option_mask32) == 0u))
+  {
+    if(((struct globals *)&bb_common_bufsiz1)->du_depth == 0)
+      ((struct globals *)&bb_common_bufsiz1)->dir_dev = statbuf.st_dev;
+    else
+      if(!(((struct globals *)&bb_common_bufsiz1)->dir_dev == statbuf.st_dev))
+        return (unsigned long long int)0;
+  }
+  sum = (unsigned long long int)statbuf.st_blocks;
+  if((61440u & statbuf.st_mode) == 40960u)
+  {
+    if(!(((struct globals *)&bb_common_bufsiz1)->du_depth >= ((struct globals *)&bb_common_bufsiz1)->slink_depth))
+    {
+      signed int return_value_stat$2;
+      return_value_stat$2=stat(filename, &statbuf);
+      if(!(return_value_stat$2 == 0))
+      {
+        bb_simple_perror_msg(filename);
+        ((struct globals *)&bb_common_bufsiz1)->status = 1 != 0;
+        return (unsigned long long int)0;
+      }
+      sum = (unsigned long long int)statbuf.st_blocks;
+      if(((struct globals *)&bb_common_bufsiz1)->slink_depth == 1)
+        ((struct globals *)&bb_common_bufsiz1)->slink_depth = 2147483647;
+    }
+  }
+  if((128u & option_mask32) == 0u)
+  {
+    if(statbuf.st_nlink > 1ul)
+    {
+      char *return_value_is_in_ino_dev_hashtable$3;
+      return_value_is_in_ino_dev_hashtable$3=is_in_ino_dev_hashtable(&statbuf);
+      if(!(return_value_is_in_ino_dev_hashtable$3 == ((char *)((void *)0))))
+        return (unsigned long long int)0;
+      add_to_ino_dev_hashtable(&statbuf, (const char *)((void *)0));
+    }
+  }
+  if((61440u & statbuf.st_mode) == 16384u)
+  {
+    struct __dirstream *dir;
+    struct dirent *entry;
+    char *newfile;
+    dir=warn_opendir(filename);
+    if(dir == ((struct __dirstream *)((void *)0)))
+    {
+      ((struct globals *)&bb_common_bufsiz1)->status = 1 != 0;
+      return sum;
+    }
+    do
+    {
+      entry=readdir(dir);
+      if(entry == ((struct dirent *)((void *)0)))
+        break;
+      newfile=concat_subpath_file(filename, entry->d_name);
+      if(!(newfile == ((char *)((void *)0))))
+      {
+        ((struct globals *)&bb_common_bufsiz1)->du_depth = ((struct globals *)&bb_common_bufsiz1)->du_depth + 1;
+        unsigned long long int return_value_du$4;
+        return_value_du$4=du(newfile);
+        sum = sum + return_value_du$4;
+        ((struct globals *)&bb_common_bufsiz1)->du_depth = ((struct globals *)&bb_common_bufsiz1)->du_depth - 1;
+        free((void *)newfile);
+      }
+    }
+    while((_Bool)1);
+    closedir(dir);
+  }
+  else
+    if((1u & option_mask32) == 0u)
+    {
+      if(!(((struct globals *)&bb_common_bufsiz1)->du_depth == 0))
+        return sum;
+    }
+  if(((struct globals *)&bb_common_bufsiz1)->max_print_depth >= ((struct globals *)&bb_common_bufsiz1)->du_depth)
+    print(sum, filename);
+  return sum;
+}
+signed int __main(signed int argc, char **argv)
+{
+  unsigned long long int total;
+  signed int slink_depth_save;
+  unsigned int opt;
+  ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)1024;
+  char *return_value_getenv$1;
+  return_value_getenv$1=getenv("POSIXLY_CORRECT");
+  if(!(return_value_getenv$1 == ((char *)((void *)0))))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)512;
+  ((struct globals *)&bb_common_bufsiz1)->max_print_depth = 2147483647;
+  opt_complementary = "h-km:k-hm:m-hk:H-L:L-H:s-d:d-s:d+";
+  opt=getopt32(argv, "aHkLsxd:lchm", &((struct globals *)&bb_common_bufsiz1)->max_print_depth);
+  argv = argv + (signed long int)optind;
+  if(!((512u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)0;
+  if(!((1024u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)(1024 * 1024);
+  if(!((4u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->disp_hr = (unsigned long int)1024;
+  if(!((2u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->slink_depth = 1;
+  if(!((8u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->slink_depth = 2147483647;
+  if(!((16u & opt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->max_print_depth = 0;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)".";
+    if(((struct globals *)&bb_common_bufsiz1)->slink_depth == 1)
+      ((struct globals *)&bb_common_bufsiz1)->slink_depth = 0;
+  }
+  slink_depth_save = ((struct globals *)&bb_common_bufsiz1)->slink_depth;
+  total = (unsigned long long int)0;
+  do
+  {
+    unsigned long long int return_value_du$2;
+    return_value_du$2=du(*argv);
+    total = total + return_value_du$2;
+    reset_ino_dev_hashtable();
+    ((struct globals *)&bb_common_bufsiz1)->slink_depth = slink_depth_save;
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  if(!((256u & opt) == 0u))
+    print(total, "total");
+  fflush(stdout);
+  return ((signed int)((struct globals *)&bb_common_bufsiz1)->status);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static char * is_in_ino_dev_hashtable(struct stat *statbuf)
+{
+  struct ino_dev_hash_bucket_struct *bucket;
+  if(ino_dev_hashtable == ((struct ino_dev_hash_bucket_struct **)((void *)0)))
+    return (char *)((void *)0);
+  bucket = ino_dev_hashtable[(signed long int)(statbuf->st_ino % (unsigned long int)311)];
+  for( ; !(bucket == ((struct ino_dev_hash_bucket_struct *)((void *)0))); bucket = bucket->next)
+    if(bucket->ino == statbuf->st_ino)
+    {
+      if(bucket->dev == statbuf->st_dev)
+        return bucket->name;
+    }
+  return (char *)((void *)0);
+}
+static char * last_char_is(const char *s, signed int c)
+{
+  if(!(s == ((const char *)((void *)0))))
+  {
+    if(!((signed int)*s == 0))
+    {
+      unsigned long int sz;
+      unsigned long int return_value_strlen$1;
+      return_value_strlen$1=strlen(s);
+      sz = return_value_strlen$1 - (unsigned long int)1;
+      s = s + (signed long int)sz;
+      if((signed int)*s == c)
+        return (char *)s;
+    }
+  }
+  return (char *)((void *)0);
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit)
+{
+  unsigned int frac;
+  const char *u;
+  const char *fmt;
+  if(val == 0ul)
+    return "0";
+  fmt = "%llu";
+  if(block_size > 1ul)
+    val = val * block_size;
+  frac = (unsigned int)0;
+  static const char unit_chars[9l] = { (const char)0, (const char)75, (const char)77, (const char)71, (const char)84, (const char)80, (const char)69, (const char)90, (const char)89 };
+  u = unit_chars;
+  if(!(display_unit == 0ul))
+  {
+    val = val + display_unit / (unsigned long int)2;
+    val = val / display_unit;
+  }
+  else
+  {
+    for( ; val >= 1024ul; val = val / (unsigned long long int)1024)
+    {
+      fmt = "%llu.%u%c";
+      u = u + 1l;
+      frac = (((unsigned int)val % (unsigned int)1024) * (unsigned int)10 + (unsigned int)(1024 / 2)) / (unsigned int)1024;
+    }
+    if(frac >= 10u)
+    {
+      val = val + 1ull;
+      frac = (unsigned int)0;
+    }
+    if(block_size == 0ul)
+    {
+      if(frac >= 5u)
+        val = val + 1ull;
+      fmt = "%llu%*c";
+      frac = (unsigned int)1;
+    }
+  }
+  static char *str;
+  if(str == ((char *)((void *)0)))
+  {
+    void *return_value_xmalloc$1;
+    return_value_xmalloc$1=xmalloc(sizeof(unsigned long long int) * (unsigned long int)3 + (unsigned long int)2 + (unsigned long int)3);
+    str = (char *)return_value_xmalloc$1;
+  }
+  sprintf(str, fmt, val, frac, *u);
+  return str;
+}
+static void print(unsigned long long int size, const char *filename)
+{
+  const char *return_value_make_human_readable_str$1;
+  return_value_make_human_readable_str$1=make_human_readable_str(size, (unsigned long int)512, ((struct globals *)&bb_common_bufsiz1)->disp_hr);
+  printf("%s\t%s\n", return_value_make_human_readable_str$1, filename);
+}
+static void reset_ino_dev_hashtable(void)
+{
+  signed int i;
+  struct ino_dev_hash_bucket_struct *bucket;
+  i = 0;
+  for( ; i < 311 && !(ino_dev_hashtable == ((struct ino_dev_hash_bucket_struct **)((void *)0))); i = i + 1)
+    for( ; !(ino_dev_hashtable[(signed long int)i] == ((struct ino_dev_hash_bucket_struct *)((void *)0))); ino_dev_hashtable[(signed long int)i] = bucket)
+    {
+      bucket = ino_dev_hashtable[(signed long int)i]->next;
+      free((void *)ino_dev_hashtable[(signed long int)i]);
+    }
+  free((void *)ino_dev_hashtable);
+  ino_dev_hashtable = (struct ino_dev_hash_bucket_struct **)((void *)0);
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static struct __dirstream * warn_opendir(const char *path)
+{
+  struct __dirstream *dp;
+  dp=opendir(path);
+  if(dp == ((struct __dirstream *)((void *)0)))
+    bb_perror_msg("can't open '%s'", path);
+  return dp;
+}
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  __builtin_va_start(p,format);
+  r=vasprintf(&string_ptr, format, p);
+  __builtin_va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+  return string_ptr;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.c
@@ -324,7 +324,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.i
@@ -2647,7 +2647,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/echo_false-no-overflow.c
+++ b/c/busybox-1.22.0/echo_false-no-overflow.c
@@ -1,0 +1,510 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 374
+static char bb_process_escape_sequence(const char **ptr);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 374
+static char bb_process_escape_sequence(const char **ptr)
+{
+  const char *q;
+  unsigned int num_digits;
+  unsigned int n;
+  unsigned int base;
+  n = (unsigned int)0;
+  num_digits = n;
+  base = (unsigned int)8;
+  q = *ptr;
+  if((signed int)*q == 120)
+  {
+    q = q + 1l;
+    base = (unsigned int)16;
+    num_digits = num_digits + 1u;
+  }
+
+  do
+  {
+    unsigned int r;
+    unsigned int d = (unsigned int)((signed int)(unsigned char)((signed int)*q | (signed int)(char)32) - 48);
+    if(d >= 10u)
+      d = d + (unsigned int)((48 - 97) + 10);
+
+    if(d >= base)
+    {
+      if(base == 16u)
+      {
+        num_digits = num_digits - 1u;
+        if(num_digits == 0u)
+          return (char)92;
+
+      }
+
+      break;
+    }
+
+    r = n * base + d;
+    if(r > 255u)
+      break;
+
+    n = r;
+    q = q + 1l;
+    num_digits = num_digits + 1u;
+  }
+  while(num_digits < 3u);
+  if(num_digits == 0u)
+  {
+    static const char charmap[20l] = { (const char)97, (const char)98, (const char)101, (const char)102, (const char)110, (const char)114, (const char)116, (const char)118, (const char)92, (const char)0, (const char)7, (const char)8, (const char)27, (const char)12, (const char)10, (const char)13, (const char)9, (const char)11, (const char)92, (const char)92 };
+    const char *p = charmap;
+    while((_Bool)1)
+    {
+      if(*p == *q)
+      {
+        q = q + 1l;
+        break;
+      }
+
+      p = p + 1l;
+      if((signed int)*p == 0)
+        break;
+
+    }
+    n = (unsigned int)p[(signed long int)(sizeof(const char [20l]) /*20ul*/  / (unsigned long int)2)];
+  }
+
+  *ptr = q;
+  return (char)n;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/echo.c line 66
+signed int __main(signed int argc, char **argv)
+{
+  char **pp;
+  const char *arg;
+  char *out;
+  char *buffer;
+  unsigned int buflen;
+  char nflag = (char)1;
+  char eflag = (char)0;
+  do
+  {
+    argv = argv + 1l;
+
+    arg = *argv;
+    if(arg == ((const char *)NULL))
+      break;
+
+    char n;
+    char e;
+
+    if(!((signed int)*arg == 45))
+      break;
+
+    arg = arg + 1l;
+    n = nflag;
+    e = eflag;
+    while((_Bool)1)
+    {
+
+      if((signed int)*arg == 110)
+        n = (char)0;
+
+      else
+      {
+
+        if((signed int)*arg == 101)
+          e = (char)92;
+
+        else
+        {
+
+          if((signed int)*arg != 69)
+            goto just_echo;
+
+        }
+      }
+      arg = arg + 1l;
+
+      if((signed int)*arg == 0)
+        break;
+
+    }
+    nflag = n;
+    eflag = e;
+  }
+  while((_Bool)1);
+
+just_echo:
+  ;
+  buflen = (unsigned int)0;
+  pp = argv;
+  while((_Bool)1)
+  {
+
+    arg = *pp;
+    if(arg == ((const char *)NULL))
+      break;
+
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(arg);
+    buflen = buflen + (unsigned int)(return_value_strlen$1 + (unsigned long int)1);
+    pp = pp + 1l;
+  }
+  void *return_value_xmalloc$2;
+  return_value_xmalloc$2=xmalloc((unsigned long int)(buflen + (unsigned int)1));
+  buffer = (char *)return_value_xmalloc$2;
+  out = buffer;
+  const char *tmp_post$3;
+  char *tmp_post$5;
+  char *tmp_post$6;
+  while((_Bool)1)
+  {
+
+    arg = *argv;
+    if(arg == ((const char *)NULL))
+      break;
+
+    signed int c;
+    if((signed int)eflag == 0)
+      out=stpcpy(out, arg);
+
+    else
+      do
+      {
+        tmp_post$3 = arg;
+        arg = arg + 1l;
+
+        c = (signed int)*tmp_post$3;
+        if(c == 0)
+          break;
+
+        if(c == (signed int)eflag)
+        {
+
+          if((signed int)*arg == 99)
+            goto do_write;
+
+          if((signed int)*arg == 48)
+          {
+
+            if(208 + (signed int)(unsigned char)(signed int)*(1l + arg) < 8)
+              arg = arg + 1l;
+
+          }
+
+          const char *z = arg;
+          char return_value_bb_process_escape_sequence$4;
+          return_value_bb_process_escape_sequence$4=bb_process_escape_sequence(&z);
+          c = (signed int)return_value_bb_process_escape_sequence$4;
+          arg = z;
+        }
+
+        tmp_post$5 = out;
+        out = out + 1l;
+
+        *tmp_post$5 = (char)c;
+      }
+      while((_Bool)1);
+    argv = argv + 1l;
+
+    if(*argv == ((char *)NULL))
+      break;
+
+    tmp_post$6 = out;
+    out = out + 1l;
+
+    *tmp_post$6 = (char)32;
+  }
+  char *tmp_post$7;
+  if(!((signed int)nflag == 0))
+  {
+    tmp_post$7 = out;
+    out = out + 1l;
+
+    *tmp_post$7 = (char)10;
+  }
+
+do_write:
+  ;
+
+  *bb_errno = 0;
+  full_write(1, (const void *)buffer, (unsigned long int)(out - buffer));
+  free((void *)buffer);
+
+  if(!(*bb_errno == 0))
+  {
+    bb_perror_msg("write error");
+    return 1;
+  }
+
+  return 0;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+#include "busybox_sv_comp-stpcpy.h"
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/echo_false-no-overflow.i
+++ b/c/busybox-1.22.0/echo_false-no-overflow.i
@@ -1,0 +1,2692 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static char bb_process_escape_sequence(const char **ptr);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static char bb_process_escape_sequence(const char **ptr)
+{
+  const char *q;
+  unsigned int num_digits;
+  unsigned int n;
+  unsigned int base;
+  n = (unsigned int)0;
+  num_digits = n;
+  base = (unsigned int)8;
+  q = *ptr;
+  if((signed int)*q == 120)
+  {
+    q = q + 1l;
+    base = (unsigned int)16;
+    num_digits = num_digits + 1u;
+  }
+  do
+  {
+    unsigned int r;
+    unsigned int d = (unsigned int)((signed int)(unsigned char)((signed int)*q | (signed int)(char)32) - 48);
+    if(d >= 10u)
+      d = d + (unsigned int)((48 - 97) + 10);
+    if(d >= base)
+    {
+      if(base == 16u)
+      {
+        num_digits = num_digits - 1u;
+        if(num_digits == 0u)
+          return (char)92;
+      }
+      break;
+    }
+    r = n * base + d;
+    if(r > 255u)
+      break;
+    n = r;
+    q = q + 1l;
+    num_digits = num_digits + 1u;
+  }
+  while(num_digits < 3u);
+  if(num_digits == 0u)
+  {
+    static const char charmap[20l] = { (const char)97, (const char)98, (const char)101, (const char)102, (const char)110, (const char)114, (const char)116, (const char)118, (const char)92, (const char)0, (const char)7, (const char)8, (const char)27, (const char)12, (const char)10, (const char)13, (const char)9, (const char)11, (const char)92, (const char)92 };
+    const char *p = charmap;
+    while((_Bool)1)
+    {
+      if(*p == *q)
+      {
+        q = q + 1l;
+        break;
+      }
+      p = p + 1l;
+      if((signed int)*p == 0)
+        break;
+    }
+    n = (unsigned int)p[(signed long int)(sizeof(const char [20l]) / (unsigned long int)2)];
+  }
+  *ptr = q;
+  return (char)n;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+signed int __main(signed int argc, char **argv)
+{
+  char **pp;
+  const char *arg;
+  char *out;
+  char *buffer;
+  unsigned int buflen;
+  char nflag = (char)1;
+  char eflag = (char)0;
+  do
+  {
+    argv = argv + 1l;
+    arg = *argv;
+    if(arg == ((const char *)((void *)0)))
+      break;
+    char n;
+    char e;
+    if(!((signed int)*arg == 45))
+      break;
+    arg = arg + 1l;
+    n = nflag;
+    e = eflag;
+    while((_Bool)1)
+    {
+      if((signed int)*arg == 110)
+        n = (char)0;
+      else
+      {
+        if((signed int)*arg == 101)
+          e = (char)92;
+        else
+        {
+          if((signed int)*arg != 69)
+            goto just_echo;
+        }
+      }
+      arg = arg + 1l;
+      if((signed int)*arg == 0)
+        break;
+    }
+    nflag = n;
+    eflag = e;
+  }
+  while((_Bool)1);
+just_echo:
+  ;
+  buflen = (unsigned int)0;
+  pp = argv;
+  while((_Bool)1)
+  {
+    arg = *pp;
+    if(arg == ((const char *)((void *)0)))
+      break;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(arg);
+    buflen = buflen + (unsigned int)(return_value_strlen$1 + (unsigned long int)1);
+    pp = pp + 1l;
+  }
+  void *return_value_xmalloc$2;
+  return_value_xmalloc$2=xmalloc((unsigned long int)(buflen + (unsigned int)1));
+  buffer = (char *)return_value_xmalloc$2;
+  out = buffer;
+  const char *tmp_post$3;
+  char *tmp_post$5;
+  char *tmp_post$6;
+  while((_Bool)1)
+  {
+    arg = *argv;
+    if(arg == ((const char *)((void *)0)))
+      break;
+    signed int c;
+    if((signed int)eflag == 0)
+      out=stpcpy(out, arg);
+    else
+      do
+      {
+        tmp_post$3 = arg;
+        arg = arg + 1l;
+        c = (signed int)*tmp_post$3;
+        if(c == 0)
+          break;
+        if(c == (signed int)eflag)
+        {
+          if((signed int)*arg == 99)
+            goto do_write;
+          if((signed int)*arg == 48)
+          {
+            if(208 + (signed int)(unsigned char)(signed int)*(1l + arg) < 8)
+              arg = arg + 1l;
+          }
+          const char *z = arg;
+          char return_value_bb_process_escape_sequence$4;
+          return_value_bb_process_escape_sequence$4=bb_process_escape_sequence(&z);
+          c = (signed int)return_value_bb_process_escape_sequence$4;
+          arg = z;
+        }
+        tmp_post$5 = out;
+        out = out + 1l;
+        *tmp_post$5 = (char)c;
+      }
+      while((_Bool)1);
+    argv = argv + 1l;
+    if(*argv == ((char *)((void *)0)))
+      break;
+    tmp_post$6 = out;
+    out = out + 1l;
+    *tmp_post$6 = (char)32;
+  }
+  char *tmp_post$7;
+  if(!((signed int)nflag == 0))
+  {
+    tmp_post$7 = out;
+    out = out + 1l;
+    *tmp_post$7 = (char)10;
+  }
+do_write:
+  ;
+  *bb_errno = 0;
+  full_write(1, (const void *)buffer, (unsigned long int)(out - buffer));
+  free((void *)buffer);
+  if(!(*bb_errno == 0))
+  {
+    bb_perror_msg("write error");
+    return 1;
+  }
+  return 0;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+char *stpcpy(char *dest, const char *src)
+{
+  while(*dest++ = *src++);
+  return dest - 1;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.c
@@ -182,7 +182,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.i
@@ -2315,7 +2315,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/expand_false-no-overflow.c
+++ b/c/busybox-1.22.0/expand_false-no-overflow.c
@@ -1,0 +1,1841 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+// file include/libbb.h line 671
+struct uni_stat_t;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/unicode.h line 112
+static signed int bb_wcwidth(unsigned int ucs);
+// file coreutils/expand.c line 62
+static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt);
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/unicode.h line 83
+static void init_unicode(void);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/unicode.c line 175
+static const char * mbstowc_internal(signed int *res, const char *src);
+// file include/libbb.h line 678
+static const char * printable_string(struct uni_stat_t *stats, const char *str);
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file coreutils/expand.c line 99
+static void unexpand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt);
+// file include/unicode.h line 63
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src);
+// file libbb/unicode.c line 1003
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags);
+// file include/unicode.h line 57
+static unsigned long int unicode_strwidth(const char *string);
+// file libbb/unicode.c line 88
+static unsigned long int wcrtomb_internal(char *s, signed int wc);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/get_line_from_file.c line 46
+static char * xmalloc_fgets(struct _IO_FILE *file);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file include/libbb.h line 649
+static char * xstrndup(const char *s, signed int n);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+struct uni_stat_t
+{
+  // byte_count
+  unsigned int byte_count;
+  // unicode_count
+  unsigned int unicode_count;
+  // unicode_width
+  unsigned int unicode_width;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/unicode.c line 14
+static unsigned char unicode_status;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)NULL;
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=getc(file);
+    if(ch == -1)
+      break;
+
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+
+    if(!(end == ((signed int *)NULL)))
+    {
+      if(ch == 10)
+        break;
+
+    }
+
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)NULL)))
+    *end = (signed int)idx;
+
+  if(!(linebuf == ((char *)NULL)))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+
+  return linebuf;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/unicode.h line 112
+static signed int bb_wcwidth(unsigned int ucs)
+{
+  if(ucs == 0u)
+    return 0;
+
+  if(!((4294967167u & ucs) < 32u))
+  {
+    if(ucs == 127u)
+      goto __CPROVER_DUMP_L2;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L2:
+    ;
+    return -1;
+  }
+  if(ucs > 767u)
+    return -1;
+
+  return 1;
+}
+
+// file coreutils/expand.c line 62
+static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt)
+{
+  char *line;
+  _Bool tmp_statement_expression$1;
+  do
+  {
+    line=xmalloc_fgets(file);
+    if(line == ((char *)NULL))
+      break;
+
+    unsigned char c;
+    char *ptr;
+    char *ptr_strbeg = line;
+    ptr = ptr_strbeg;
+    while((_Bool)1)
+    {
+
+      c = *ptr;
+      if((signed int)c == 0)
+        break;
+
+      if(!((1u & opt) == 0u))
+      {
+        unsigned char bb__isblank = c;
+        tmp_statement_expression$1 = (signed int)bb__isblank == 32 || (signed int)bb__isblank == 9;
+        if(tmp_statement_expression$1 == (_Bool)0)
+          break;
+
+      }
+
+      if((signed int)c == 9)
+      {
+        unsigned int len;
+
+        *ptr = (char)0;
+        unsigned long int return_value_unicode_strwidth$2;
+        return_value_unicode_strwidth$2=unicode_strwidth(ptr_strbeg);
+        len = (unsigned int)return_value_unicode_strwidth$2;
+        if(!(tab_size == 0u))
+          (void)0;
+
+        else
+          /* assertion tab_size != 0u */
+          __VERIFIER_error();
+        len = tab_size - len % tab_size;
+        printf("%s%*s", ptr_strbeg, len, "");
+        ptr_strbeg = ptr + (signed long int)1;
+      }
+
+      ptr = ptr + 1l;
+    }
+    fputs(ptr_strbeg, stdout);
+    free((void *)line);
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/expand.c line 154
+signed int __main(signed int argc, char **argv)
+{
+  const char *opt_t = "8";
+  struct _IO_FILE *file;
+  unsigned int tab_size;
+  unsigned int opt;
+  signed int exit_status = 0;
+  init_unicode();
+
+  if((signed int)*applet_name == 101)
+  {
+    static const char expand_longopts[18l] = { (const char)105, (const char)110, (const char)105, (const char)116, (const char)105, (const char)97, (const char)108, (const char)0, (const char)0, (const char)105, (const char)116, (const char)97, (const char)98, (const char)115, (const char)0, (const char)1, (const char)116, (const char)0 };
+    applet_long_options = expand_longopts;
+    opt=getopt32(argv, "it:", &opt_t);
+  }
+
+  else
+  {
+    static const char unexpand_longopts[27l] = { (const char)102, (const char)105, (const char)114, (const char)115, (const char)116, (const char)45, (const char)111, (const char)110, (const char)108, (const char)121, (const char)0, (const char)0, (const char)105, (const char)116, (const char)97, (const char)98, (const char)115, (const char)0, (const char)1, (const char)116, (const char)97, (const char)108, (const char)108, (const char)0, (const char)0, (const char)97, (const char)0 };
+    applet_long_options = unexpand_longopts;
+    opt_complementary = "ta";
+    opt=getopt32(argv, "ft:a", &opt_t);
+    if((4u & opt) == 0u)
+      opt = opt | (unsigned int)1;
+
+  }
+  tab_size=xatou_range(opt_t, (unsigned int)1, (unsigned int)2147483647 * 2u + 1u);
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)bb_msg_standard_input;
+  }
+
+  while((_Bool)1)
+  {
+
+    file=fopen_or_warn_stdin(*argv);
+    if(file == ((struct _IO_FILE *)NULL))
+      exit_status = 1;
+
+    else
+    {
+
+      if((signed int)*applet_name == 101)
+        expand(file, tab_size, opt);
+
+      else
+        unexpand(file, tab_size, opt);
+      signed int return_value_fclose_if_not_stdin$1;
+      return_value_fclose_if_not_stdin$1=fclose_if_not_stdin(file);
+      if(!(return_value_fclose_if_not_stdin$1 == 0))
+      {
+
+        bb_simple_perror_msg(*argv);
+        exit_status = 1;
+      }
+
+      if(file == stdin)
+        clearerr(file);
+
+    }
+    argv = argv + 1l;
+
+    if(*argv == ((char *)NULL))
+      break;
+
+  }
+  signed int return_value_fclose$2;
+  return_value_fclose$2=fclose(stdin);
+  if(!(return_value_fclose$2 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_input);
+
+  // fflush_stdout_and_exit(exit_status); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return exit_status;
+}
+
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+
+  return r;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/unicode.h line 83
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)NULL))
+      s=getenv("LC_CTYPE");
+
+    if(s == ((char *)NULL))
+      s=getenv("LANG");
+
+    reinit_unicode(s);
+  }
+
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/unicode.c line 175
+static const char * mbstowc_internal(signed int *res, const char *src)
+{
+  signed int bytes;
+  unsigned int c;
+  const char *tmp_post$1 = src;
+  src = src + 1l;
+  c = (unsigned int)(unsigned char)*tmp_post$1;
+  if(c <= 127u)
+  {
+    *res = (signed int)c;
+    return src;
+  }
+
+  bytes = 0;
+  do
+  {
+    c = c << 1;
+    bytes = bytes + 1;
+  }
+  while(bytes < 6 && (128u & c) != 0u);
+  if(bytes == 1)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+
+  c = (unsigned int)((signed int)(unsigned char)c >> bytes);
+  do
+  {
+    bytes = bytes - 1;
+    if(bytes == 0)
+      break;
+
+    unsigned int ch = (unsigned int)(unsigned char)*src;
+    if(!((192u & ch) == 128u))
+    {
+      *res = ~((signed int)0);
+      return src;
+    }
+
+    c = (c << 6) + (ch & (unsigned int)63);
+    src = src + 1l;
+  }
+  while((_Bool)1);
+  if(c <= 127u)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+
+  *res = (signed int)c;
+  return src;
+}
+
+// file include/libbb.h line 678
+static const char * printable_string(struct uni_stat_t *stats, const char *str)
+{
+  char *dst;
+  const char *s = str;
+  while((_Bool)1)
+  {
+    unsigned char c = *s;
+    if((signed int)c == 0)
+    {
+      if(!(stats == ((struct uni_stat_t *)NULL)))
+      {
+        stats->byte_count = (unsigned int)(s - str);
+        stats->unicode_count = (unsigned int)(s - str);
+        stats->unicode_width = (unsigned int)(s - str);
+      }
+
+      return str;
+    }
+
+    if((signed int)c < 32)
+      break;
+
+    if((signed int)c >= 127)
+      break;
+
+    s = s + 1l;
+  }
+  dst=unicode_conv_to_printable(stats, str);
+  static unsigned int cur_saved;
+  static char *saved[4l];
+  free((void *)saved[(signed long int)cur_saved]);
+  saved[(signed long int)cur_saved] = dst;
+  cur_saved = cur_saved + (unsigned int)1 & (unsigned int)(sizeof(char *[4l]) /*32ul*/  / sizeof(char *) /*8ul*/ ) - (unsigned int)1;
+  return dst;
+}
+
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)NULL))
+    tmp_if_expr$4 = 1 != 0;
+
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)NULL)))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)NULL ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+
+  unicode_status = (unsigned char)2;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/expand.c line 99
+static void unexpand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt)
+{
+  char *line;
+  unsigned int tmp_post$1;
+  unsigned int tmp_statement_expression$2;
+  unsigned long int tmp_if_expr$13;
+  unsigned long int tmp_if_expr$11;
+  unsigned long int return_value_strlen$3;
+  unsigned long int tmp_if_expr$10;
+  unsigned long int return_value___strcspn_c1$4;
+  unsigned long int tmp_if_expr$9;
+  unsigned long int return_value___strcspn_c2$5;
+  unsigned long int tmp_if_expr$8;
+  unsigned long int return_value___strcspn_c3$6;
+  unsigned long int return_value___builtin_strcspn$7;
+  unsigned long int return_value___builtin_strcspn$12;
+  do
+  {
+    line=xmalloc_fgets(file);
+    if(line == ((char *)NULL))
+      break;
+
+    char *ptr = line;
+    unsigned int column = (unsigned int)0;
+    while((_Bool)1)
+    {
+
+      if((signed int)*ptr == 0)
+        break;
+
+      unsigned int n;
+      unsigned int len = (unsigned int)0;
+      while((_Bool)1)
+      {
+
+        if(!((signed int)*ptr == 32))
+          break;
+
+        ptr = ptr + 1l;
+        len = len + 1u;
+      }
+      column = column + len;
+
+      if((signed int)*ptr == 9)
+      {
+        if(!(tab_size == 0u))
+          (void)0;
+
+        else
+          /* assertion tab_size != 0u */
+          __VERIFIER_error();
+        column = column + (tab_size - column % tab_size);
+        ptr = ptr + 1l;
+      }
+
+      else
+      {
+        if(!(tab_size == 0u))
+          (void)0;
+
+        else
+          /* assertion tab_size != 0u */
+          __VERIFIER_error();
+        n = column / tab_size;
+        if(!(n == 0u))
+        {
+          column = column % tab_size;
+          len = column;
+          do
+          {
+            tmp_post$1 = n;
+            n = n - 1u;
+            if(tmp_post$1 == 0u)
+              break;
+
+            putchar(9);
+          }
+          while((_Bool)1);
+        }
+
+        if(!((1u & opt) == 0u))
+        {
+          if(!(ptr == line))
+          {
+            printf("%*s%s", len, "", ptr);
+            break;
+          }
+
+        }
+
+        n = strcspn(ptr, "\t ");
+        printf("%*s%.*s", len, "", n, ptr);
+        char c;
+
+        c = ptr[(signed long int)n];
+        ptr[(signed long int)n] = (char)0;
+        unsigned long int return_value_unicode_strwidth$14;
+        return_value_unicode_strwidth$14=unicode_strwidth(ptr);
+        len = (unsigned int)return_value_unicode_strwidth$14;
+
+        ptr[(signed long int)n] = c;
+        ptr = ptr + (signed long int)n;
+        if(!(tab_size == 0u))
+          (void)0;
+
+        else
+          /* assertion tab_size != 0u */
+          __VERIFIER_error();
+        column = (column + len) % tab_size;
+      }
+    }
+    free((void *)line);
+  }
+  while((_Bool)1);
+}
+
+// file include/unicode.h line 63
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src)
+{
+  char *return_value_unicode_conv_to_printable2$1;
+  return_value_unicode_conv_to_printable2$1=unicode_conv_to_printable2(stats, src, (unsigned int)2147483647, 0);
+  return return_value_unicode_conv_to_printable2$1;
+}
+
+// file libbb/unicode.c line 1003
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags)
+{
+  char *dst;
+  unsigned int dst_len;
+  unsigned int uni_count;
+  unsigned int uni_width;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  if(!((signed int)unicode_status == 2))
+  {
+    char *d;
+    if(!((1 & flags) == 0))
+    {
+      void *return_value_xmalloc$1;
+      return_value_xmalloc$1=xmalloc((unsigned long int)(width + (unsigned int)1));
+      dst = (char *)return_value_xmalloc$1;
+      d = dst;
+      do
+      {
+        width = width - 1u;
+        if(!((signed int)width >= 0))
+          break;
+
+        unsigned char unicode_conv_to_printable2$$1$$1$$1$$1$$c = *src;
+        if((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c == 0)
+        {
+          do
+          {
+            tmp_post$2 = d;
+            d = d + 1l;
+            *tmp_post$2 = (char)32;
+            width = width - 1u;
+          }
+          while((signed int)width >= 0);
+          break;
+        }
+
+        tmp_post$3 = d;
+        d = d + 1l;
+        *tmp_post$3 = (char)((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c >= 32 && (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c < 127 ? (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c : 63);
+        src = src + 1l;
+      }
+      while((_Bool)1);
+      *d = (char)0;
+    }
+
+    else
+    {
+      dst=xstrndup(src, (signed int)width);
+      d = dst;
+      while(!((signed int)*d == 0))
+      {
+        unsigned char c = *d;
+        if(!((signed int)c < 32))
+        {
+          if((signed int)c >= 127)
+            goto __CPROVER_DUMP_L7;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L7:
+          ;
+          *d = (char)63;
+        }
+        d = d + 1l;
+      }
+    }
+    if(!(stats == ((struct uni_stat_t *)NULL)))
+    {
+      stats->byte_count = (unsigned int)(d - dst);
+      stats->unicode_count = (unsigned int)(d - dst);
+      stats->unicode_width = (unsigned int)(d - dst);
+    }
+
+    return dst;
+  }
+
+  dst = (char *)NULL;
+  uni_width = (unsigned int)0;
+  uni_count = uni_width;
+  dst_len = (unsigned int)0;
+  while((_Bool)1)
+  {
+    signed int w;
+    signed int wc;
+    src=mbstowc_internal(&wc, src);
+    if(!(wc == -1))
+    {
+      if(wc == 0)
+        break;
+
+      if(wc > 767)
+        goto subst;
+
+      w=bb_wcwidth((unsigned int)wc);
+      if(w <= 0)
+        goto subst;
+
+      if(w > 1)
+        goto subst;
+
+    }
+
+    else
+    {
+
+    subst:
+      ;
+      wc = 63;
+      w = 1;
+    }
+    width = width - (unsigned int)w;
+    if((signed int)width < 0)
+    {
+      width = width + (unsigned int)w;
+      break;
+    }
+
+    uni_count = uni_count + 1u;
+    uni_width = uni_width + (unsigned int)w;
+    void *return_value_xrealloc$4;
+    return_value_xrealloc$4=xrealloc((void *)dst, (unsigned long int)(dst_len + (unsigned int)6));
+    dst = (char *)return_value_xrealloc$4;
+    unsigned long int return_value_wcrtomb_internal$5;
+    return_value_wcrtomb_internal$5=wcrtomb_internal(&dst[(signed long int)dst_len], wc);
+    dst_len = dst_len + (unsigned int)return_value_wcrtomb_internal$5;
+  }
+  unsigned int tmp_post$7;
+  if(!((1 & flags) == 0))
+  {
+    void *return_value_xrealloc$6;
+    return_value_xrealloc$6=xrealloc((void *)dst, (unsigned long int)(dst_len + width + (unsigned int)1));
+    dst = (char *)return_value_xrealloc$6;
+    uni_count = uni_count + width;
+    uni_width = uni_width + width;
+    do
+    {
+      width = width - 1u;
+      if(!((signed int)width >= 0))
+        break;
+
+      tmp_post$7 = dst_len;
+      dst_len = dst_len + 1u;
+      dst[(signed long int)tmp_post$7] = (char)32;
+    }
+    while((_Bool)1);
+  }
+
+  dst[(signed long int)dst_len] = (char)0;
+  if(!(stats == ((struct uni_stat_t *)NULL)))
+  {
+    stats->byte_count = dst_len;
+    stats->unicode_count = uni_count;
+    stats->unicode_width = uni_width;
+  }
+
+  return dst;
+}
+
+// file include/unicode.h line 57
+static unsigned long int unicode_strwidth(const char *string)
+{
+  struct uni_stat_t uni_stat;
+  printable_string(&uni_stat, string);
+  return (unsigned long int)uni_stat.unicode_width;
+}
+
+// file libbb/unicode.c line 88
+static unsigned long int wcrtomb_internal(char *s, signed int wc)
+{
+  signed int n;
+  signed int i;
+  unsigned int v = (unsigned int)wc;
+  if(v <= 127u)
+  {
+    *s = (char)v;
+    return (unsigned long int)1;
+  }
+
+  n = 2;
+  for( ; v >= 2048u; n = n + 1)
+  {
+    if(!(n < 6))
+      break;
+
+    v = v >> 5;
+  }
+  i = n;
+  do
+  {
+    i = i - 1;
+    if(i == 0)
+      break;
+
+    s[(signed long int)i] = (char)(wc & 63 | 128);
+    wc = wc >> 6;
+  }
+  while((_Bool)1);
+  s[(signed long int)0] = (char)(wc | (signed int)(unsigned char)(16128 >> n));
+  return (unsigned long int)n;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/get_line_from_file.c line 46
+static char * xmalloc_fgets(struct _IO_FILE *file)
+{
+  signed int i;
+  char *return_value_bb_get_chunk_from_file$1;
+  return_value_bb_get_chunk_from_file$1=bb_get_chunk_from_file(file, &i);
+  return return_value_bb_get_chunk_from_file$1;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 649
+static char * xstrndup(const char *s, signed int n)
+{
+  signed int m;
+  char *t;
+  m = n;
+  t = (char *)s;
+  for( ; !(m == 0); t = t + 1l)
+  {
+    if((signed int)*t == 0)
+      break;
+
+    m = m - 1;
+  }
+  n = n - m;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)(n + 1));
+  t = (char *)return_value_xmalloc$1;
+  t[(signed long int)n] = (char)0;
+  void *return_value_memcpy$2;
+  return_value_memcpy$2=memcpy((void *)t, (const void *)s, (unsigned long int)n);
+  return (char *)return_value_memcpy$2;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/expand_false-no-overflow.i
+++ b/c/busybox-1.22.0/expand_false-no-overflow.i
@@ -1,0 +1,3690 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+struct uni_stat_t;
+static void bb_error_msg_and_die(const char *s, ...);
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int bb_wcwidth(unsigned int ucs);
+static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt);
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void init_unicode(void);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static const char * mbstowc_internal(signed int *res, const char *src);
+static const char * printable_string(struct uni_stat_t *stats, const char *str);
+static void reinit_unicode(const char *LANG);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void unexpand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt);
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src);
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags);
+static unsigned long int unicode_strwidth(const char *string);
+static unsigned long int wcrtomb_internal(char *s, signed int wc);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_fgets(struct _IO_FILE *file);
+static void * xrealloc(void *ptr, unsigned long int size);
+static char * xstrndup(const char *s, signed int n);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+struct uni_stat_t
+{
+  unsigned int byte_count;
+  unsigned int unicode_count;
+  unsigned int unicode_width;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char unicode_status;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)((void *)0);
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=_IO_getc (file);
+    if(ch == -1)
+      break;
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+    if(!(end == ((signed int *)((void *)0))))
+    {
+      if(ch == 10)
+        break;
+    }
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)((void *)0))))
+    *end = (signed int)idx;
+  if(!(linebuf == ((char *)((void *)0))))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+  return linebuf;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int bb_wcwidth(unsigned int ucs)
+{
+  if(ucs == 0u)
+    return 0;
+  if(!((4294967167u & ucs) < 32u))
+  {
+    if(ucs == 127u)
+      goto __CPROVER_DUMP_L2;
+  }
+  else
+  {
+  __CPROVER_DUMP_L2:
+    ;
+    return -1;
+  }
+  if(ucs > 767u)
+    return -1;
+  return 1;
+}
+static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt)
+{
+  char *line;
+  _Bool tmp_statement_expression$1;
+  do
+  {
+    line=xmalloc_fgets(file);
+    if(line == ((char *)((void *)0)))
+      break;
+    unsigned char c;
+    char *ptr;
+    char *ptr_strbeg = line;
+    ptr = ptr_strbeg;
+    while((_Bool)1)
+    {
+      c = *ptr;
+      if((signed int)c == 0)
+        break;
+      if(!((1u & opt) == 0u))
+      {
+        unsigned char bb__isblank = c;
+        tmp_statement_expression$1 = (signed int)bb__isblank == 32 || (signed int)bb__isblank == 9;
+        if(tmp_statement_expression$1 == (_Bool)0)
+          break;
+      }
+      if((signed int)c == 9)
+      {
+        unsigned int len;
+        *ptr = (char)0;
+        unsigned long int return_value_unicode_strwidth$2;
+        return_value_unicode_strwidth$2=unicode_strwidth(ptr_strbeg);
+        len = (unsigned int)return_value_unicode_strwidth$2;
+        if(!(tab_size == 0u))
+          (void)0;
+        else
+          __VERIFIER_error();
+        len = tab_size - len % tab_size;
+        printf("%s%*s", ptr_strbeg, len, "");
+        ptr_strbeg = ptr + (signed long int)1;
+      }
+      ptr = ptr + 1l;
+    }
+    fputs(ptr_strbeg, stdout);
+    free((void *)line);
+  }
+  while((_Bool)1);
+}
+signed int __main(signed int argc, char **argv)
+{
+  const char *opt_t = "8";
+  struct _IO_FILE *file;
+  unsigned int tab_size;
+  unsigned int opt;
+  signed int exit_status = 0;
+  init_unicode();
+  if((signed int)*applet_name == 101)
+  {
+    static const char expand_longopts[18l] = { (const char)105, (const char)110, (const char)105, (const char)116, (const char)105, (const char)97, (const char)108, (const char)0, (const char)0, (const char)105, (const char)116, (const char)97, (const char)98, (const char)115, (const char)0, (const char)1, (const char)116, (const char)0 };
+    applet_long_options = expand_longopts;
+    opt=getopt32(argv, "it:", &opt_t);
+  }
+  else
+  {
+    static const char unexpand_longopts[27l] = { (const char)102, (const char)105, (const char)114, (const char)115, (const char)116, (const char)45, (const char)111, (const char)110, (const char)108, (const char)121, (const char)0, (const char)0, (const char)105, (const char)116, (const char)97, (const char)98, (const char)115, (const char)0, (const char)1, (const char)116, (const char)97, (const char)108, (const char)108, (const char)0, (const char)0, (const char)97, (const char)0 };
+    applet_long_options = unexpand_longopts;
+    opt_complementary = "ta";
+    opt=getopt32(argv, "ft:a", &opt_t);
+    if((4u & opt) == 0u)
+      opt = opt | (unsigned int)1;
+  }
+  tab_size=xatou_range(opt_t, (unsigned int)1, (unsigned int)2147483647 * 2u + 1u);
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)bb_msg_standard_input;
+  }
+  while((_Bool)1)
+  {
+    file=fopen_or_warn_stdin(*argv);
+    if(file == ((struct _IO_FILE *)((void *)0)))
+      exit_status = 1;
+    else
+    {
+      if((signed int)*applet_name == 101)
+        expand(file, tab_size, opt);
+      else
+        unexpand(file, tab_size, opt);
+      signed int return_value_fclose_if_not_stdin$1;
+      return_value_fclose_if_not_stdin$1=fclose_if_not_stdin(file);
+      if(!(return_value_fclose_if_not_stdin$1 == 0))
+      {
+        bb_simple_perror_msg(*argv);
+        exit_status = 1;
+      }
+      if(file == stdin)
+        clearerr(file);
+    }
+    argv = argv + 1l;
+    if(*argv == ((char *)((void *)0)))
+      break;
+  }
+  signed int return_value_fclose$2;
+  return_value_fclose$2=fclose(stdin);
+  if(!(return_value_fclose$2 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_input);
+  fflush(stdout);
+  return exit_status;
+}
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+  return r;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LC_CTYPE");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LANG");
+    reinit_unicode(s);
+  }
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static const char * mbstowc_internal(signed int *res, const char *src)
+{
+  signed int bytes;
+  unsigned int c;
+  const char *tmp_post$1 = src;
+  src = src + 1l;
+  c = (unsigned int)(unsigned char)*tmp_post$1;
+  if(c <= 127u)
+  {
+    *res = (signed int)c;
+    return src;
+  }
+  bytes = 0;
+  do
+  {
+    c = c << 1;
+    bytes = bytes + 1;
+  }
+  while(bytes < 6 && (128u & c) != 0u);
+  if(bytes == 1)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+  c = (unsigned int)((signed int)(unsigned char)c >> bytes);
+  do
+  {
+    bytes = bytes - 1;
+    if(bytes == 0)
+      break;
+    unsigned int ch = (unsigned int)(unsigned char)*src;
+    if(!((192u & ch) == 128u))
+    {
+      *res = ~((signed int)0);
+      return src;
+    }
+    c = (c << 6) + (ch & (unsigned int)63);
+    src = src + 1l;
+  }
+  while((_Bool)1);
+  if(c <= 127u)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+  *res = (signed int)c;
+  return src;
+}
+static const char * printable_string(struct uni_stat_t *stats, const char *str)
+{
+  char *dst;
+  const char *s = str;
+  while((_Bool)1)
+  {
+    unsigned char c = *s;
+    if((signed int)c == 0)
+    {
+      if(!(stats == ((struct uni_stat_t *)((void *)0))))
+      {
+        stats->byte_count = (unsigned int)(s - str);
+        stats->unicode_count = (unsigned int)(s - str);
+        stats->unicode_width = (unsigned int)(s - str);
+      }
+      return str;
+    }
+    if((signed int)c < 32)
+      break;
+    if((signed int)c >= 127)
+      break;
+    s = s + 1l;
+  }
+  dst=unicode_conv_to_printable(stats, str);
+  static unsigned int cur_saved;
+  static char *saved[4l];
+  free((void *)saved[(signed long int)cur_saved]);
+  saved[(signed long int)cur_saved] = dst;
+  cur_saved = cur_saved + (unsigned int)1 & (unsigned int)(sizeof(char *[4l]) / sizeof(char *) ) - (unsigned int)1;
+  return dst;
+}
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)((void *)0)))
+    tmp_if_expr$4 = 1 != 0;
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)((void *)0))))
+      tmp_if_expr$3 = 1 != 0;
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)((void *)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+  unicode_status = (unsigned char)2;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void unexpand(struct _IO_FILE *file, unsigned int tab_size, unsigned int opt)
+{
+  char *line;
+  unsigned int tmp_post$1;
+  unsigned int tmp_statement_expression$2;
+  unsigned long int tmp_if_expr$13;
+  unsigned long int tmp_if_expr$11;
+  unsigned long int return_value_strlen$3;
+  unsigned long int tmp_if_expr$10;
+  unsigned long int return_value___strcspn_c1$4;
+  unsigned long int tmp_if_expr$9;
+  unsigned long int return_value___strcspn_c2$5;
+  unsigned long int tmp_if_expr$8;
+  unsigned long int return_value___strcspn_c3$6;
+  unsigned long int return_value___builtin_strcspn$7;
+  unsigned long int return_value___builtin_strcspn$12;
+  do
+  {
+    line=xmalloc_fgets(file);
+    if(line == ((char *)((void *)0)))
+      break;
+    char *ptr = line;
+    unsigned int column = (unsigned int)0;
+    while((_Bool)1)
+    {
+      if((signed int)*ptr == 0)
+        break;
+      unsigned int n;
+      unsigned int len = (unsigned int)0;
+      while((_Bool)1)
+      {
+        if(!((signed int)*ptr == 32))
+          break;
+        ptr = ptr + 1l;
+        len = len + 1u;
+      }
+      column = column + len;
+      if((signed int)*ptr == 9)
+      {
+        if(!(tab_size == 0u))
+          (void)0;
+        else
+          __VERIFIER_error();
+        column = column + (tab_size - column % tab_size);
+        ptr = ptr + 1l;
+      }
+      else
+      {
+        if(!(tab_size == 0u))
+          (void)0;
+        else
+          __VERIFIER_error();
+        n = column / tab_size;
+        if(!(n == 0u))
+        {
+          column = column % tab_size;
+          len = column;
+          do
+          {
+            tmp_post$1 = n;
+            n = n - 1u;
+            if(tmp_post$1 == 0u)
+              break;
+            putchar(9);
+          }
+          while((_Bool)1);
+        }
+        if(!((1u & opt) == 0u))
+        {
+          if(!(ptr == line))
+          {
+            printf("%*s%s", len, "", ptr);
+            break;
+          }
+        }
+        n = strcspn(ptr, "\t ");
+        printf("%*s%.*s", len, "", n, ptr);
+        char c;
+        c = ptr[(signed long int)n];
+        ptr[(signed long int)n] = (char)0;
+        unsigned long int return_value_unicode_strwidth$14;
+        return_value_unicode_strwidth$14=unicode_strwidth(ptr);
+        len = (unsigned int)return_value_unicode_strwidth$14;
+        ptr[(signed long int)n] = c;
+        ptr = ptr + (signed long int)n;
+        if(!(tab_size == 0u))
+          (void)0;
+        else
+          __VERIFIER_error();
+        column = (column + len) % tab_size;
+      }
+    }
+    free((void *)line);
+  }
+  while((_Bool)1);
+}
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src)
+{
+  char *return_value_unicode_conv_to_printable2$1;
+  return_value_unicode_conv_to_printable2$1=unicode_conv_to_printable2(stats, src, (unsigned int)2147483647, 0);
+  return return_value_unicode_conv_to_printable2$1;
+}
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags)
+{
+  char *dst;
+  unsigned int dst_len;
+  unsigned int uni_count;
+  unsigned int uni_width;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  if(!((signed int)unicode_status == 2))
+  {
+    char *d;
+    if(!((1 & flags) == 0))
+    {
+      void *return_value_xmalloc$1;
+      return_value_xmalloc$1=xmalloc((unsigned long int)(width + (unsigned int)1));
+      dst = (char *)return_value_xmalloc$1;
+      d = dst;
+      do
+      {
+        width = width - 1u;
+        if(!((signed int)width >= 0))
+          break;
+        unsigned char unicode_conv_to_printable2$$1$$1$$1$$1$$c = *src;
+        if((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c == 0)
+        {
+          do
+          {
+            tmp_post$2 = d;
+            d = d + 1l;
+            *tmp_post$2 = (char)32;
+            width = width - 1u;
+          }
+          while((signed int)width >= 0);
+          break;
+        }
+        tmp_post$3 = d;
+        d = d + 1l;
+        *tmp_post$3 = (char)((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c >= 32 && (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c < 127 ? (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c : 63);
+        src = src + 1l;
+      }
+      while((_Bool)1);
+      *d = (char)0;
+    }
+    else
+    {
+      dst=xstrndup(src, (signed int)width);
+      d = dst;
+      while(!((signed int)*d == 0))
+      {
+        unsigned char c = *d;
+        if(!((signed int)c < 32))
+        {
+          if((signed int)c >= 127)
+            goto __CPROVER_DUMP_L7;
+        }
+        else
+        {
+        __CPROVER_DUMP_L7:
+          ;
+          *d = (char)63;
+        }
+        d = d + 1l;
+      }
+    }
+    if(!(stats == ((struct uni_stat_t *)((void *)0))))
+    {
+      stats->byte_count = (unsigned int)(d - dst);
+      stats->unicode_count = (unsigned int)(d - dst);
+      stats->unicode_width = (unsigned int)(d - dst);
+    }
+    return dst;
+  }
+  dst = (char *)((void *)0);
+  uni_width = (unsigned int)0;
+  uni_count = uni_width;
+  dst_len = (unsigned int)0;
+  while((_Bool)1)
+  {
+    signed int w;
+    signed int wc;
+    src=mbstowc_internal(&wc, src);
+    if(!(wc == -1))
+    {
+      if(wc == 0)
+        break;
+      if(wc > 767)
+        goto subst;
+      w=bb_wcwidth((unsigned int)wc);
+      if(w <= 0)
+        goto subst;
+      if(w > 1)
+        goto subst;
+    }
+    else
+    {
+    subst:
+      ;
+      wc = 63;
+      w = 1;
+    }
+    width = width - (unsigned int)w;
+    if((signed int)width < 0)
+    {
+      width = width + (unsigned int)w;
+      break;
+    }
+    uni_count = uni_count + 1u;
+    uni_width = uni_width + (unsigned int)w;
+    void *return_value_xrealloc$4;
+    return_value_xrealloc$4=xrealloc((void *)dst, (unsigned long int)(dst_len + (unsigned int)6));
+    dst = (char *)return_value_xrealloc$4;
+    unsigned long int return_value_wcrtomb_internal$5;
+    return_value_wcrtomb_internal$5=wcrtomb_internal(&dst[(signed long int)dst_len], wc);
+    dst_len = dst_len + (unsigned int)return_value_wcrtomb_internal$5;
+  }
+  unsigned int tmp_post$7;
+  if(!((1 & flags) == 0))
+  {
+    void *return_value_xrealloc$6;
+    return_value_xrealloc$6=xrealloc((void *)dst, (unsigned long int)(dst_len + width + (unsigned int)1));
+    dst = (char *)return_value_xrealloc$6;
+    uni_count = uni_count + width;
+    uni_width = uni_width + width;
+    do
+    {
+      width = width - 1u;
+      if(!((signed int)width >= 0))
+        break;
+      tmp_post$7 = dst_len;
+      dst_len = dst_len + 1u;
+      dst[(signed long int)tmp_post$7] = (char)32;
+    }
+    while((_Bool)1);
+  }
+  dst[(signed long int)dst_len] = (char)0;
+  if(!(stats == ((struct uni_stat_t *)((void *)0))))
+  {
+    stats->byte_count = dst_len;
+    stats->unicode_count = uni_count;
+    stats->unicode_width = uni_width;
+  }
+  return dst;
+}
+static unsigned long int unicode_strwidth(const char *string)
+{
+  struct uni_stat_t uni_stat;
+  printable_string(&uni_stat, string);
+  return (unsigned long int)uni_stat.unicode_width;
+}
+static unsigned long int wcrtomb_internal(char *s, signed int wc)
+{
+  signed int n;
+  signed int i;
+  unsigned int v = (unsigned int)wc;
+  if(v <= 127u)
+  {
+    *s = (char)v;
+    return (unsigned long int)1;
+  }
+  n = 2;
+  for( ; v >= 2048u; n = n + 1)
+  {
+    if(!(n < 6))
+      break;
+    v = v >> 5;
+  }
+  i = n;
+  do
+  {
+    i = i - 1;
+    if(i == 0)
+      break;
+    s[(signed long int)i] = (char)(wc & 63 | 128);
+    wc = wc >> 6;
+  }
+  while((_Bool)1);
+  s[(signed long int)0] = (char)(wc | (signed int)(unsigned char)(16128 >> n));
+  return (unsigned long int)n;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_fgets(struct _IO_FILE *file)
+{
+  signed int i;
+  char *return_value_bb_get_chunk_from_file$1;
+  return_value_bb_get_chunk_from_file$1=bb_get_chunk_from_file(file, &i);
+  return return_value_bb_get_chunk_from_file$1;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xstrndup(const char *s, signed int n)
+{
+  signed int m;
+  char *t;
+  m = n;
+  t = (char *)s;
+  for( ; !(m == 0); t = t + 1l)
+  {
+    if((signed int)*t == 0)
+      break;
+    m = m - 1;
+  }
+  n = n - m;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)(n + 1));
+  t = (char *)return_value_xmalloc$1;
+  t[(signed long int)n] = (char)0;
+  void *return_value_memcpy$2;
+  return_value_memcpy$2=memcpy((void *)t, (const void *)s, (unsigned long int)n);
+  return (char *)return_value_memcpy$2;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -335,7 +335,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2335,7 +2335,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/fold_false-no-overflow.c
+++ b/c/busybox-1.22.0/fold_false-no-overflow.c
@@ -1,0 +1,1381 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file coreutils/fold.c line 34
+static signed int adjust_column(unsigned int column, char c);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/unicode.h line 83
+static void init_unicode(void);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file coreutils/fold.c line 59
+static void write2stdout(const void *buf, unsigned int size);
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/unicode.c line 14
+static unsigned char unicode_status;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file coreutils/fold.c line 34
+static signed int adjust_column(unsigned int column, char c)
+{
+  if(!((1u & option_mask32) == 0u))
+  {
+    column = column + 1u;
+    return (signed int)column;
+  }
+
+  if((signed int)c == 9)
+    return (signed int)((column + (unsigned int)8) - column % (unsigned int)8);
+
+  if((signed int)c == 8)
+  {
+    column = column - 1u;
+    if((signed int)column < 0)
+      column = (unsigned int)0;
+
+  }
+
+  else
+    if((signed int)c == 13)
+      column = (unsigned int)0;
+
+    else
+      if((signed int)unicode_status == 2)
+      {
+        if((192 & (signed int)c) != 128)
+          goto __CPROVER_DUMP_L6;
+
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L6:
+        ;
+        column = column + 1u;
+      }
+  return (signed int)column;
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+
+  return r;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file coreutils/fold.c line 65
+signed int __main(signed int argc, char **argv)
+{
+  char *line_out = (char *)NULL;
+  const char *w_opt = "80";
+  unsigned int width;
+  signed char exitcode = (signed char)0;
+  init_unicode();
+  do
+  {
+    signed int i = 1;
+    while((_Bool)1)
+    {
+
+      if(argv[(signed long int)i] == ((char *)NULL))
+        break;
+
+      const char *a = argv[(signed long int)i];
+
+      if((signed int)*a == 45)
+      {
+        a = a + 1l;
+
+        if((signed int)*a == 45)
+        {
+
+          if((signed int)*(1l + a) == 0)
+            break;
+
+        }
+
+
+        if(208 + (signed int)(unsigned char)(signed int)*a <= 9)
+        {
+
+          argv[(signed long int)i]=xasprintf("-w%s", a);
+        }
+
+      }
+
+      i = i + 1;
+    }
+  }
+  while((_Bool)0);
+  getopt32(argv, "bsw:", &w_opt);
+  width=xatou_range(w_opt, (unsigned int)1, (unsigned int)10000);
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)"-";
+  }
+
+  signed int return_value_adjust_column$2;
+  _Bool tmp_statement_expression$3;
+  do
+  {
+    struct _IO_FILE *istream;
+
+    istream=fopen_or_warn_stdin(*argv);
+    signed int c;
+    unsigned int column = (unsigned int)0;
+    unsigned int offset_out = (unsigned int)0;
+    if(istream == ((struct _IO_FILE *)NULL))
+      exitcode = (signed char)1;
+
+    else
+    {
+      do
+      {
+        c=getc(istream);
+        if(c == -1)
+          break;
+
+        if((4095u & offset_out) == 0u)
+        {
+          void *return_value_xrealloc$1;
+          return_value_xrealloc$1=xrealloc((void *)line_out, (unsigned long int)(offset_out + (unsigned int)4096));
+          line_out = (char *)return_value_xrealloc$1;
+        }
+
+        do
+        {
+
+        rescan:
+          ;
+
+          line_out[(signed long int)offset_out] = (char)c;
+          if(c == 10)
+          {
+            write2stdout((const void *)line_out, offset_out + (unsigned int)1);
+            offset_out = (unsigned int)0;
+            column = offset_out;
+            break;
+          }
+
+          return_value_adjust_column$2=adjust_column(column, (char)c);
+          column = (unsigned int)return_value_adjust_column$2;
+          if(!(width >= column))
+          {
+            if(offset_out == 0u)
+              goto __CPROVER_DUMP_L31;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L31:
+            ;
+            offset_out = offset_out + 1u;
+            break;
+          }
+          if(!((2u & option_mask32) == 0u))
+          {
+            unsigned int fold_main$$1$$2$$2$$4$$i;
+            unsigned int logical_end = offset_out - (unsigned int)1;
+            for( ; (signed int)logical_end >= 0; logical_end = logical_end - 1u)
+            {
+              unsigned char bb__isblank;
+
+              bb__isblank = line_out[(signed long int)logical_end];
+              tmp_statement_expression$3 = (signed int)bb__isblank == 32 || (signed int)bb__isblank == 9;
+              if(!(tmp_statement_expression$3 == (_Bool)0))
+              {
+                logical_end = logical_end + 1u;
+                write2stdout((const void *)line_out, logical_end);
+                putchar(10);
+                memmove((void *)line_out, (const void *)(line_out + (signed long int)logical_end), (unsigned long int)(offset_out - logical_end));
+                offset_out = offset_out - logical_end;
+                fold_main$$1$$2$$2$$4$$i = (unsigned int)0;
+                column = fold_main$$1$$2$$2$$4$$i;
+                for( ; !(fold_main$$1$$2$$2$$4$$i >= offset_out); fold_main$$1$$2$$2$$4$$i = fold_main$$1$$2$$2$$4$$i + 1u)
+                {
+                  signed int return_value_adjust_column$4;
+
+                  return_value_adjust_column$4=adjust_column(column, line_out[(signed long int)fold_main$$1$$2$$2$$4$$i]);
+                  column = (unsigned int)return_value_adjust_column$4;
+                }
+                goto rescan;
+              }
+
+            }
+          }
+
+
+          line_out[(signed long int)offset_out] = (char)10;
+          write2stdout((const void *)line_out, offset_out + (unsigned int)1);
+          offset_out = (unsigned int)0;
+          column = offset_out;
+        }
+        while((_Bool)1);
+      }
+      while((_Bool)1);
+      if(!(offset_out == 0u))
+        write2stdout((const void *)line_out, offset_out);
+
+      signed int return_value_fclose_if_not_stdin$5;
+      return_value_fclose_if_not_stdin$5=fclose_if_not_stdin(istream);
+      if(!(return_value_fclose_if_not_stdin$5 == 0))
+      {
+
+        bb_simple_perror_msg(*argv);
+        exitcode = (signed char)1;
+      }
+
+    }
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  // fflush_stdout_and_exit((signed int)exitcode); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return (signed int)exitcode;
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/unicode.h line 83
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)NULL))
+      s=getenv("LC_CTYPE");
+
+    if(s == ((char *)NULL))
+      s=getenv("LANG");
+
+    reinit_unicode(s);
+  }
+
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)NULL))
+    tmp_if_expr$4 = 1 != 0;
+
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)NULL)))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)NULL ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+
+  unicode_status = (unsigned char)2;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/fold.c line 59
+static void write2stdout(const void *buf, unsigned int size)
+{
+  fwrite(buf, (unsigned long int)1, (unsigned long int)size, stdout);
+}
+
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  va_start(p, format);
+  r=vasprintf(&string_ptr, format, p);
+  va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  return string_ptr;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/fold_false-no-overflow.i
+++ b/c/busybox-1.22.0/fold_false-no-overflow.i
@@ -1,0 +1,3308 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static signed int adjust_column(unsigned int column, char c);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void init_unicode(void);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static void reinit_unicode(const char *LANG);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void write2stdout(const void *buf, unsigned int size);
+static char * xasprintf(const char *format, ...);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static void * xrealloc(void *ptr, unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char unicode_status;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static signed int adjust_column(unsigned int column, char c)
+{
+  if(!((1u & option_mask32) == 0u))
+  {
+    column = column + 1u;
+    return (signed int)column;
+  }
+  if((signed int)c == 9)
+    return (signed int)((column + (unsigned int)8) - column % (unsigned int)8);
+  if((signed int)c == 8)
+  {
+    column = column - 1u;
+    if((signed int)column < 0)
+      column = (unsigned int)0;
+  }
+  else
+    if((signed int)c == 13)
+      column = (unsigned int)0;
+    else
+      if((signed int)unicode_status == 2)
+      {
+        if((192 & (signed int)c) != 128)
+          goto __CPROVER_DUMP_L6;
+      }
+      else
+      {
+      __CPROVER_DUMP_L6:
+        ;
+        column = column + 1u;
+      }
+  return (signed int)column;
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+  return r;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+signed int __main(signed int argc, char **argv)
+{
+  char *line_out = (char *)((void *)0);
+  const char *w_opt = "80";
+  unsigned int width;
+  signed char exitcode = (signed char)0;
+  init_unicode();
+  do
+  {
+    signed int i = 1;
+    while((_Bool)1)
+    {
+      if(argv[(signed long int)i] == ((char *)((void *)0)))
+        break;
+      const char *a = argv[(signed long int)i];
+      if((signed int)*a == 45)
+      {
+        a = a + 1l;
+        if((signed int)*a == 45)
+        {
+          if((signed int)*(1l + a) == 0)
+            break;
+        }
+        if(208 + (signed int)(unsigned char)(signed int)*a <= 9)
+        {
+          argv[(signed long int)i]=xasprintf("-w%s", a);
+        }
+      }
+      i = i + 1;
+    }
+  }
+  while((_Bool)0);
+  getopt32(argv, "bsw:", &w_opt);
+  width=xatou_range(w_opt, (unsigned int)1, (unsigned int)10000);
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)"-";
+  }
+  signed int return_value_adjust_column$2;
+  _Bool tmp_statement_expression$3;
+  do
+  {
+    struct _IO_FILE *istream;
+    istream=fopen_or_warn_stdin(*argv);
+    signed int c;
+    unsigned int column = (unsigned int)0;
+    unsigned int offset_out = (unsigned int)0;
+    if(istream == ((struct _IO_FILE *)((void *)0)))
+      exitcode = (signed char)1;
+    else
+    {
+      do
+      {
+        c=_IO_getc (istream);
+        if(c == -1)
+          break;
+        if((4095u & offset_out) == 0u)
+        {
+          void *return_value_xrealloc$1;
+          return_value_xrealloc$1=xrealloc((void *)line_out, (unsigned long int)(offset_out + (unsigned int)4096));
+          line_out = (char *)return_value_xrealloc$1;
+        }
+        do
+        {
+        rescan:
+          ;
+          line_out[(signed long int)offset_out] = (char)c;
+          if(c == 10)
+          {
+            write2stdout((const void *)line_out, offset_out + (unsigned int)1);
+            offset_out = (unsigned int)0;
+            column = offset_out;
+            break;
+          }
+          return_value_adjust_column$2=adjust_column(column, (char)c);
+          column = (unsigned int)return_value_adjust_column$2;
+          if(!(width >= column))
+          {
+            if(offset_out == 0u)
+              goto __CPROVER_DUMP_L31;
+          }
+          else
+          {
+          __CPROVER_DUMP_L31:
+            ;
+            offset_out = offset_out + 1u;
+            break;
+          }
+          if(!((2u & option_mask32) == 0u))
+          {
+            unsigned int fold_main$$1$$2$$2$$4$$i;
+            unsigned int logical_end = offset_out - (unsigned int)1;
+            for( ; (signed int)logical_end >= 0; logical_end = logical_end - 1u)
+            {
+              unsigned char bb__isblank;
+              bb__isblank = line_out[(signed long int)logical_end];
+              tmp_statement_expression$3 = (signed int)bb__isblank == 32 || (signed int)bb__isblank == 9;
+              if(!(tmp_statement_expression$3 == (_Bool)0))
+              {
+                logical_end = logical_end + 1u;
+                write2stdout((const void *)line_out, logical_end);
+                putchar(10);
+                memmove((void *)line_out, (const void *)(line_out + (signed long int)logical_end), (unsigned long int)(offset_out - logical_end));
+                offset_out = offset_out - logical_end;
+                fold_main$$1$$2$$2$$4$$i = (unsigned int)0;
+                column = fold_main$$1$$2$$2$$4$$i;
+                for( ; !(fold_main$$1$$2$$2$$4$$i >= offset_out); fold_main$$1$$2$$2$$4$$i = fold_main$$1$$2$$2$$4$$i + 1u)
+                {
+                  signed int return_value_adjust_column$4;
+                  return_value_adjust_column$4=adjust_column(column, line_out[(signed long int)fold_main$$1$$2$$2$$4$$i]);
+                  column = (unsigned int)return_value_adjust_column$4;
+                }
+                goto rescan;
+              }
+            }
+          }
+          line_out[(signed long int)offset_out] = (char)10;
+          write2stdout((const void *)line_out, offset_out + (unsigned int)1);
+          offset_out = (unsigned int)0;
+          column = offset_out;
+        }
+        while((_Bool)1);
+      }
+      while((_Bool)1);
+      if(!(offset_out == 0u))
+        write2stdout((const void *)line_out, offset_out);
+      signed int return_value_fclose_if_not_stdin$5;
+      return_value_fclose_if_not_stdin$5=fclose_if_not_stdin(istream);
+      if(!(return_value_fclose_if_not_stdin$5 == 0))
+      {
+        bb_simple_perror_msg(*argv);
+        exitcode = (signed char)1;
+      }
+    }
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  fflush(stdout);
+  return (signed int)exitcode;
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LC_CTYPE");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LANG");
+    reinit_unicode(s);
+  }
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)((void *)0)))
+    tmp_if_expr$4 = 1 != 0;
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)((void *)0))))
+      tmp_if_expr$3 = 1 != 0;
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)((void *)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+  unicode_status = (unsigned char)2;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void write2stdout(const void *buf, unsigned int size)
+{
+  fwrite(buf, (unsigned long int)1, (unsigned long int)size, stdout);
+}
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  __builtin_va_start(p,format);
+  r=vasprintf(&string_ptr, format, p);
+  __builtin_va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+  return string_ptr;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.c
@@ -297,7 +297,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.i
@@ -2311,7 +2311,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/head_false-no-overflow.c
+++ b/c/busybox-1.22.0/head_false-no-overflow.c
@@ -1,0 +1,959 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/xfuncs_printf.c line 269
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn);
+// file libbb/xfuncs_printf.c line 278
+static void die_if_ferror_stdout(void);
+// file coreutils/head.c line 133
+static unsigned long int eat_num(_Bool *negative_N, const char *p);
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file coreutils/head.c line 61
+static void print_except_N_last_bytes(struct _IO_FILE *fp, unsigned int count);
+// file coreutils/head.c line 90
+static void print_except_N_last_lines(struct _IO_FILE *fp, unsigned int count);
+// file coreutils/head.c line 44
+static void print_first_N(struct _IO_FILE *fp, unsigned long int count, _Bool count_bytes);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx);
+// file libbb/xatonum_template.c line 110
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/get_line_from_file.c line 46
+static char * xmalloc_fgets(struct _IO_FILE *file);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/xatonum.c line 72
+static struct suffix_mult bkm_suffixes[4l] = { { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 }, 
+    { .suffix={ (char)107, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 }, 
+    { .suffix={ (char)109, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(1024 * 1024) }, 
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file coreutils/head.c line 144
+static const char head_opts[7l] = { (const char)110, (const char)58, (const char)99, (const char)58, (const char)113, (const char)118, (const char)0 };
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)NULL;
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=getc(file);
+    if(ch == -1)
+      break;
+
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+
+    if(!(end == ((signed int *)NULL)))
+    {
+      if(ch == 10)
+        break;
+
+    }
+
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)NULL)))
+    *end = (signed int)idx;
+
+  if(!(linebuf == ((char *)NULL)))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+
+  return linebuf;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/xfuncs_printf.c line 269
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn)
+{
+  signed int return_value_ferror$1;
+  return_value_ferror$1=ferror(fp);
+  if(!(return_value_ferror$1 == 0))
+    bb_error_msg_and_die("%s: I/O error", fn);
+
+}
+
+// file libbb/xfuncs_printf.c line 278
+static void die_if_ferror_stdout(void)
+{
+  die_if_ferror(stdout, bb_msg_standard_output);
+}
+
+// file coreutils/head.c line 133
+static unsigned long int eat_num(_Bool *negative_N, const char *p)
+{
+
+  if((signed int)*p == 45)
+  {
+
+    *negative_N = 1 != 0;
+    p = p + 1l;
+  }
+
+  unsigned long int return_value_xatoul_sfx$1;
+  return_value_xatoul_sfx$1=xatoul_sfx(p, bkm_suffixes);
+  return return_value_xatoul_sfx$1;
+}
+
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+
+  return r;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/head.c line 154
+signed int __main(signed int argc, char **argv)
+{
+  unsigned long int count = (unsigned long int)10;
+  signed int header_threshhold = 1;
+  _Bool count_bytes = 0 != 0;
+  _Bool negative_N = 0 != 0;
+  struct _IO_FILE *fp;
+  const char *fmt;
+  char *p;
+  signed int opt;
+  signed int retval = 0;
+
+  if(!(*(1l + argv) == ((char *)NULL)))
+  {
+
+    if(!((signed int)*(*(1l + argv)) == 45))
+      goto __CPROVER_DUMP_L9;
+
+
+    if(!(208 + (signed int)(unsigned char)(signed int)*(1l + *(1l + argv)) <= 9))
+      goto __CPROVER_DUMP_L9;
+
+    argc = argc - 1;
+    argv = argv + 1l;
+
+    p = argv[(signed long int)0] + (signed long int)1;
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L9:
+    ;
+    opt=getopt(argc, argv, head_opts);
+    if(!(opt > 0))
+      goto __CPROVER_DUMP_L17;
+
+    if(!(opt == 113))
+    {
+      if(opt == 118)
+        goto __CPROVER_DUMP_L11;
+
+      if(opt == 99)
+        goto __CPROVER_DUMP_L12;
+
+      if(opt == 110)
+        goto __CPROVER_DUMP_L13;
+
+      goto __CPROVER_DUMP_L15;
+    }
+
+    header_threshhold = 2147483647;
+    goto __CPROVER_DUMP_L16;
+
+  __CPROVER_DUMP_L11:
+    ;
+    header_threshhold = -1;
+    goto __CPROVER_DUMP_L16;
+
+  __CPROVER_DUMP_L12:
+    ;
+    count_bytes = 1 != 0;
+
+  __CPROVER_DUMP_L13:
+    ;
+    p = optarg;
+  }
+
+  if(p!=NULL)
+  {
+GET_COUNT:
+  ;
+  count=eat_num(&negative_N, p);
+  goto __CPROVER_DUMP_L16;
+  }
+
+__CPROVER_DUMP_L15:
+  ;
+  bb_show_usage();
+
+__CPROVER_DUMP_L16:
+  ;
+  goto __CPROVER_DUMP_L9;
+
+__CPROVER_DUMP_L17:
+  ;
+  argc = argc - optind;
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)"-";
+  }
+
+  fmt = "\n==> %s <==\n" + (signed long int)1;
+  if(header_threshhold >= argc)
+    header_threshhold = 0;
+
+  if(!((signed int)negative_N == 0))
+  {
+    if(count >= 268435455ul)
+      bb_error_msg("count is too big: %lu", count);
+
+  }
+
+  while((_Bool)1)
+  {
+
+    fp=fopen_or_warn_stdin(*argv);
+    if(!(fp == ((struct _IO_FILE *)NULL)))
+    {
+      if(fp == stdin)
+      {
+
+        *argv = (char *)bb_msg_standard_input;
+      }
+
+      if(!(header_threshhold == 0))
+      {
+
+        printf(fmt, *argv);
+      }
+
+      if(!((signed int)negative_N == 0))
+      {
+        if(!((signed int)count_bytes == 0))
+          print_except_N_last_bytes(fp, (unsigned int)count);
+
+        else
+          print_except_N_last_lines(fp, (unsigned int)count);
+      }
+
+      else
+        print_first_N(fp, count, count_bytes);
+      die_if_ferror_stdout();
+      signed int return_value_fclose_if_not_stdin$1;
+      return_value_fclose_if_not_stdin$1=fclose_if_not_stdin(fp);
+      if(!(return_value_fclose_if_not_stdin$1 == 0))
+      {
+
+        bb_simple_perror_msg(*argv);
+        retval = 1;
+      }
+
+    }
+
+    else
+      retval = 1;
+    fmt = "\n==> %s <==\n";
+    argv = argv + 1l;
+
+    if(*argv == ((char *)NULL))
+      break;
+
+  }
+  // fflush_stdout_and_exit(retval); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return retval;
+}
+
+// file coreutils/head.c line 61
+static void print_except_N_last_bytes(struct _IO_FILE *fp, unsigned int count)
+{
+  unsigned char *circle;
+  count = count + 1u;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)count);
+  circle = (unsigned char *)return_value_xmalloc$1;
+  unsigned int head = (unsigned int)0;
+  unsigned int tmp_post$2;
+  do
+  {
+    signed int c;
+    c=getc(fp);
+    if(c == -1)
+      goto ret;
+
+    tmp_post$2 = head;
+    head = head + 1u;
+
+    circle[(signed long int)tmp_post$2] = (unsigned char)c;
+    if(head == count)
+      break;
+
+  }
+  while((_Bool)1);
+  do
+  {
+    signed int print_except_N_last_bytes$$1$$2$$1$$c;
+    if(head == count)
+      head = (unsigned int)0;
+
+
+    putchar((signed int)circle[(signed long int)head]);
+    print_except_N_last_bytes$$1$$2$$1$$c=getc(fp);
+    if(print_except_N_last_bytes$$1$$2$$1$$c == -1)
+      break;
+
+
+    circle[(signed long int)head] = (unsigned char)print_except_N_last_bytes$$1$$2$$1$$c;
+    head = head + 1u;
+  }
+  while((_Bool)1);
+
+ret:
+  ;
+  free((void *)circle);
+}
+
+// file coreutils/head.c line 90
+static void print_except_N_last_lines(struct _IO_FILE *fp, unsigned int count)
+{
+  char **circle;
+  count = count + 1u;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc((unsigned long int)count * sizeof(char *) /*8ul*/ );
+  circle = (char **)return_value_xzalloc$1;
+  unsigned int head = (unsigned int)0;
+  unsigned int tmp_post$2;
+  do
+  {
+    char *c;
+    c=xmalloc_fgets(fp);
+    if(c == ((char *)NULL))
+      goto ret;
+
+    tmp_post$2 = head;
+    head = head + 1u;
+
+    circle[(signed long int)tmp_post$2] = c;
+    if(head == count)
+      break;
+
+  }
+  while((_Bool)1);
+  unsigned int tmp_post$3;
+  do
+  {
+    char *print_except_N_last_lines$$1$$2$$1$$c;
+    if(head == count)
+      head = (unsigned int)0;
+
+
+    fputs(circle[(signed long int)head], stdout);
+    print_except_N_last_lines$$1$$2$$1$$c=xmalloc_fgets(fp);
+    if(print_except_N_last_lines$$1$$2$$1$$c == ((char *)NULL))
+      break;
+
+
+    free((void *)circle[(signed long int)head]);
+    tmp_post$3 = head;
+    head = head + 1u;
+
+    circle[(signed long int)tmp_post$3] = print_except_N_last_lines$$1$$2$$1$$c;
+  }
+  while((_Bool)1);
+
+ret:
+  ;
+  head = (unsigned int)0;
+  unsigned int tmp_post$4;
+  do
+  {
+    tmp_post$4 = head;
+    head = head + 1u;
+
+    free((void *)circle[(signed long int)tmp_post$4]);
+    if(head == count)
+      break;
+
+  }
+  while((_Bool)1);
+  free((void *)circle);
+}
+
+// file coreutils/head.c line 44
+static void print_first_N(struct _IO_FILE *fp, unsigned long int count, _Bool count_bytes)
+{
+  while(!(count == 0ul))
+  {
+    signed int c;
+    c=getc(fp);
+    if(c == -1)
+      break;
+
+    if((signed int)count_bytes == 0)
+    {
+      if(c == 10)
+        goto __CPROVER_DUMP_L3;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L3:
+      ;
+      count = count - 1ul;
+    }
+    putchar(c);
+  }
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_sfx$1;
+  return_value_xatoull_sfx$1=xatoull_sfx(str, sfx);
+  return return_value_xatoull_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 110
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/get_line_from_file.c line 46
+static char * xmalloc_fgets(struct _IO_FILE *file)
+{
+  signed int i;
+  char *return_value_bb_get_chunk_from_file$1;
+  return_value_bb_get_chunk_from_file$1=bb_get_chunk_from_file(file, &i);
+  return return_value_bb_get_chunk_from_file$1;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/head_false-no-overflow.i
+++ b/c/busybox-1.22.0/head_false-no-overflow.i
@@ -1,0 +1,2954 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct suffix_mult;
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn);
+static void die_if_ferror_stdout(void);
+static unsigned long int eat_num(_Bool *negative_N, const char *p);
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static void print_except_N_last_bytes(struct _IO_FILE *fp, unsigned int count);
+static void print_except_N_last_lines(struct _IO_FILE *fp, unsigned int count);
+static void print_first_N(struct _IO_FILE *fp, unsigned long int count, _Bool count_bytes);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx);
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_fgets(struct _IO_FILE *file);
+static void * xrealloc(void *ptr, unsigned long int size);
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct suffix_mult bkm_suffixes[4l] = { { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 },
+    { .suffix={ (char)107, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 },
+    { .suffix={ (char)109, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(1024 * 1024) },
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static const char head_opts[7l] = { (const char)110, (const char)58, (const char)99, (const char)58, (const char)113, (const char)118, (const char)0 };
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)((void *)0);
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=_IO_getc (file);
+    if(ch == -1)
+      break;
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+    if(!(end == ((signed int *)((void *)0))))
+    {
+      if(ch == 10)
+        break;
+    }
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)((void *)0))))
+    *end = (signed int)idx;
+  if(!(linebuf == ((char *)((void *)0))))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+  return linebuf;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn)
+{
+  signed int return_value_ferror$1;
+  return_value_ferror$1=ferror(fp);
+  if(!(return_value_ferror$1 == 0))
+    bb_error_msg_and_die("%s: I/O error", fn);
+}
+static void die_if_ferror_stdout(void)
+{
+  die_if_ferror(stdout, bb_msg_standard_output);
+}
+static unsigned long int eat_num(_Bool *negative_N, const char *p)
+{
+  if((signed int)*p == 45)
+  {
+    *negative_N = 1 != 0;
+    p = p + 1l;
+  }
+  unsigned long int return_value_xatoul_sfx$1;
+  return_value_xatoul_sfx$1=xatoul_sfx(p, bkm_suffixes);
+  return return_value_xatoul_sfx$1;
+}
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+  return r;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+signed int __main(signed int argc, char **argv)
+{
+  unsigned long int count = (unsigned long int)10;
+  signed int header_threshhold = 1;
+  _Bool count_bytes = 0 != 0;
+  _Bool negative_N = 0 != 0;
+  struct _IO_FILE *fp;
+  const char *fmt;
+  char *p;
+  signed int opt;
+  signed int retval = 0;
+  if(!(*(1l + argv) == ((char *)((void *)0))))
+  {
+    if(!((signed int)*(*(1l + argv)) == 45))
+      goto __CPROVER_DUMP_L9;
+    if(!(208 + (signed int)(unsigned char)(signed int)*(1l + *(1l + argv)) <= 9))
+      goto __CPROVER_DUMP_L9;
+    argc = argc - 1;
+    argv = argv + 1l;
+    p = argv[(signed long int)0] + (signed long int)1;
+  }
+  else
+  {
+  __CPROVER_DUMP_L9:
+    ;
+    opt=getopt(argc, argv, head_opts);
+    if(!(opt > 0))
+      goto __CPROVER_DUMP_L17;
+    if(!(opt == 113))
+    {
+      if(opt == 118)
+        goto __CPROVER_DUMP_L11;
+      if(opt == 99)
+        goto __CPROVER_DUMP_L12;
+      if(opt == 110)
+        goto __CPROVER_DUMP_L13;
+      goto __CPROVER_DUMP_L15;
+    }
+    header_threshhold = 2147483647;
+    goto __CPROVER_DUMP_L16;
+  __CPROVER_DUMP_L11:
+    ;
+    header_threshhold = -1;
+    goto __CPROVER_DUMP_L16;
+  __CPROVER_DUMP_L12:
+    ;
+    count_bytes = 1 != 0;
+  __CPROVER_DUMP_L13:
+    ;
+    p = optarg;
+  }
+  if(p!=((void *)0))
+  {
+GET_COUNT:
+  ;
+  count=eat_num(&negative_N, p);
+  goto __CPROVER_DUMP_L16;
+  }
+__CPROVER_DUMP_L15:
+  ;
+  bb_show_usage();
+__CPROVER_DUMP_L16:
+  ;
+  goto __CPROVER_DUMP_L9;
+__CPROVER_DUMP_L17:
+  ;
+  argc = argc - optind;
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)"-";
+  }
+  fmt = "\n==> %s <==\n" + (signed long int)1;
+  if(header_threshhold >= argc)
+    header_threshhold = 0;
+  if(!((signed int)negative_N == 0))
+  {
+    if(count >= 268435455ul)
+      bb_error_msg("count is too big: %lu", count);
+  }
+  while((_Bool)1)
+  {
+    fp=fopen_or_warn_stdin(*argv);
+    if(!(fp == ((struct _IO_FILE *)((void *)0))))
+    {
+      if(fp == stdin)
+      {
+        *argv = (char *)bb_msg_standard_input;
+      }
+      if(!(header_threshhold == 0))
+      {
+        printf(fmt, *argv);
+      }
+      if(!((signed int)negative_N == 0))
+      {
+        if(!((signed int)count_bytes == 0))
+          print_except_N_last_bytes(fp, (unsigned int)count);
+        else
+          print_except_N_last_lines(fp, (unsigned int)count);
+      }
+      else
+        print_first_N(fp, count, count_bytes);
+      die_if_ferror_stdout();
+      signed int return_value_fclose_if_not_stdin$1;
+      return_value_fclose_if_not_stdin$1=fclose_if_not_stdin(fp);
+      if(!(return_value_fclose_if_not_stdin$1 == 0))
+      {
+        bb_simple_perror_msg(*argv);
+        retval = 1;
+      }
+    }
+    else
+      retval = 1;
+    fmt = "\n==> %s <==\n";
+    argv = argv + 1l;
+    if(*argv == ((char *)((void *)0)))
+      break;
+  }
+  fflush(stdout);
+  return retval;
+}
+static void print_except_N_last_bytes(struct _IO_FILE *fp, unsigned int count)
+{
+  unsigned char *circle;
+  count = count + 1u;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)count);
+  circle = (unsigned char *)return_value_xmalloc$1;
+  unsigned int head = (unsigned int)0;
+  unsigned int tmp_post$2;
+  do
+  {
+    signed int c;
+    c=_IO_getc (fp);
+    if(c == -1)
+      goto ret;
+    tmp_post$2 = head;
+    head = head + 1u;
+    circle[(signed long int)tmp_post$2] = (unsigned char)c;
+    if(head == count)
+      break;
+  }
+  while((_Bool)1);
+  do
+  {
+    signed int print_except_N_last_bytes$$1$$2$$1$$c;
+    if(head == count)
+      head = (unsigned int)0;
+    putchar((signed int)circle[(signed long int)head]);
+    print_except_N_last_bytes$$1$$2$$1$$c=_IO_getc (fp);
+    if(print_except_N_last_bytes$$1$$2$$1$$c == -1)
+      break;
+    circle[(signed long int)head] = (unsigned char)print_except_N_last_bytes$$1$$2$$1$$c;
+    head = head + 1u;
+  }
+  while((_Bool)1);
+ret:
+  ;
+  free((void *)circle);
+}
+static void print_except_N_last_lines(struct _IO_FILE *fp, unsigned int count)
+{
+  char **circle;
+  count = count + 1u;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc((unsigned long int)count * sizeof(char *) );
+  circle = (char **)return_value_xzalloc$1;
+  unsigned int head = (unsigned int)0;
+  unsigned int tmp_post$2;
+  do
+  {
+    char *c;
+    c=xmalloc_fgets(fp);
+    if(c == ((char *)((void *)0)))
+      goto ret;
+    tmp_post$2 = head;
+    head = head + 1u;
+    circle[(signed long int)tmp_post$2] = c;
+    if(head == count)
+      break;
+  }
+  while((_Bool)1);
+  unsigned int tmp_post$3;
+  do
+  {
+    char *print_except_N_last_lines$$1$$2$$1$$c;
+    if(head == count)
+      head = (unsigned int)0;
+    fputs(circle[(signed long int)head], stdout);
+    print_except_N_last_lines$$1$$2$$1$$c=xmalloc_fgets(fp);
+    if(print_except_N_last_lines$$1$$2$$1$$c == ((char *)((void *)0)))
+      break;
+    free((void *)circle[(signed long int)head]);
+    tmp_post$3 = head;
+    head = head + 1u;
+    circle[(signed long int)tmp_post$3] = print_except_N_last_lines$$1$$2$$1$$c;
+  }
+  while((_Bool)1);
+ret:
+  ;
+  head = (unsigned int)0;
+  unsigned int tmp_post$4;
+  do
+  {
+    tmp_post$4 = head;
+    head = head + 1u;
+    free((void *)circle[(signed long int)tmp_post$4]);
+    if(head == count)
+      break;
+  }
+  while((_Bool)1);
+  free((void *)circle);
+}
+static void print_first_N(struct _IO_FILE *fp, unsigned long int count, _Bool count_bytes)
+{
+  while(!(count == 0ul))
+  {
+    signed int c;
+    c=_IO_getc (fp);
+    if(c == -1)
+      break;
+    if((signed int)count_bytes == 0)
+    {
+      if(c == 10)
+        goto __CPROVER_DUMP_L3;
+    }
+    else
+    {
+    __CPROVER_DUMP_L3:
+      ;
+      count = count - 1ul;
+    }
+    putchar(c);
+  }
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_sfx$1;
+  return_value_xatoull_sfx$1=xatoull_sfx(str, sfx);
+  return return_value_xatoull_sfx$1;
+}
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_fgets(struct _IO_FILE *file)
+{
+  signed int i;
+  char *return_value_bb_get_chunk_from_file$1;
+  return_value_bb_get_chunk_from_file$1=bb_get_chunk_from_file(file, &i);
+  return return_value_bb_get_chunk_from_file$1;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/head_false-valid-deref.c
+++ b/c/busybox-1.22.0/head_false-valid-deref.c
@@ -263,7 +263,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/head_false-valid-deref.i
+++ b/c/busybox-1.22.0/head_false-valid-deref.i
@@ -2298,7 +2298,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/head_true-no-overflow_true-valid-deref.c
+++ b/c/busybox-1.22.0/head_true-no-overflow_true-valid-deref.c
@@ -263,7 +263,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/head_true-no-overflow_true-valid-deref.i
+++ b/c/busybox-1.22.0/head_true-no-overflow_true-valid-deref.i
@@ -2298,7 +2298,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/logname_false-no-overflow.c
+++ b/c/busybox-1.22.0/logname_false-no-overflow.c
@@ -1,0 +1,271 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/logname.c line 37
+signed int __main(signed int argc, char **argv)
+{
+  char buf[64l];
+
+  if(!(*(1l + argv) == ((char *)NULL)))
+    bb_show_usage();
+
+  signed int return_value_getlogin_r$2;
+  return_value_getlogin_r$2=getlogin_r(buf, sizeof(char [64l]) /*64ul*/ );
+  if(return_value_getlogin_r$2 == 0)
+  {
+    puts(buf);
+    signed int return_value_fflush_all$1;
+    return_value_fflush_all$1=fflush_all();
+    return return_value_fflush_all$1;
+  }
+
+  bb_perror_msg_and_die("getlogin");
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/logname_false-no-overflow.i
+++ b/c/busybox-1.22.0/logname_false-no-overflow.i
@@ -1,0 +1,2499 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void xfunc_die(void);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+signed int __main(signed int argc, char **argv)
+{
+  char buf[64l];
+  if(!(*(1l + argv) == ((char *)((void *)0))))
+    bb_show_usage();
+  signed int return_value_getlogin_r$2;
+  return_value_getlogin_r$2=getlogin_r(buf, sizeof(char [64l]) );
+  if(return_value_getlogin_r$2 == 0)
+  {
+    puts(buf);
+    signed int return_value_fflush_all$1;
+    return_value_fflush_all$1=fflush_all();
+    return return_value_fflush_all$1;
+  }
+  bb_perror_msg_and_die("getlogin");
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.c
@@ -102,7 +102,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.i
@@ -2249,7 +2249,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/ls-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/ls-incomplete_false-no-overflow.c
@@ -1,0 +1,3514 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <dirent.h>
+#include <getopt.h>
+#include <grp.h>
+#include <libio.h>
+#include <pwd.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/procps.c line 20
+struct cache_t;
+
+// file coreutils/ls.c line 307
+struct dnode;
+
+// file libbb/ptr_to_globals.c line 10
+struct globals;
+
+// file libbb/procps.c line 15
+struct id_to_name_map_t;
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+// file include/libbb.h line 671
+struct uni_stat_t;
+
+// file /usr/include/x86_64-linux-gnu/bits/ioctl-types.h line 27
+struct winsize;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file coreutils/ls.c line 427
+static char append_char(unsigned int mode);
+// file include/libbb.h line 386
+static const char * bb_basename(const char *name);
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/grp_.h line 71
+struct group * bb_internal_getgrgid(unsigned int);
+// file include/pwd_.h line 70
+struct passwd * bb_internal_getpwuid(unsigned int);
+// file libbb/mode_string.c line 94
+static const char * bb_mode_string(unsigned int mode);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/unicode.h line 112
+static signed int bb_wcwidth(unsigned int ucs);
+// file coreutils/ls.c line 418
+static char bold(unsigned int mode);
+// file coreutils/ls.c line 441
+static unsigned int calc_name_len(const char *name);
+// file coreutils/ls.c line 1003
+static signed long int calculate_blocks(struct dnode **dn);
+// file libbb/concat_path_file.c line 19
+static char * concat_path_file(const char *path, const char *filename);
+// file coreutils/ls.c line 767
+static unsigned int count_dirs(struct dnode **dn, signed int which);
+// file coreutils/ls.c line 805
+static void dfree(struct dnode **dnp);
+// file coreutils/ls.c line 652
+static void display_files(struct dnode **dn, unsigned int nfiles);
+// file coreutils/ls.c line 501
+static unsigned int display_single(struct dnode *dn);
+// file coreutils/ls.c line 795
+static struct dnode ** dnalloc(unsigned int num);
+// file coreutils/ls.c line 917
+static void dnsort(struct dnode **dn, signed int size);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file coreutils/ls.c line 412
+static char fgcolor(unsigned int mode);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file libbb/procps.c line 55
+static char * get_cached(struct cache_t *cp, unsigned int id, char * (*x2x_utoa)(unsigned int));
+// 
+char * x2x_utoa$object(unsigned int);
+// file libbb/procps.c line 73
+static const char * get_cached_groupname(unsigned int gid);
+// file libbb/procps.c line 69
+static const char * get_cached_username(unsigned int uid);
+// file include/libbb.h line 1348
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file libbb/bb_pwd.c line 69
+static char * gid2group(unsigned int gid);
+// file libbb/bb_pwd.c line 81
+static char * gid2group_utoa(unsigned int gid);
+// file libbb/compare_string_array.c line 54
+static signed int index_in_substrings(const char *strings, const char *key);
+// file include/unicode.h line 83
+static void init_unicode(void);
+// file include/libbb.h line 388
+static char * last_char_is(const char *s, signed int c);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/human_readable.c line 33
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit);
+// file libbb/unicode.c line 175
+static const char * mbstowc_internal(signed int *res, const char *src);
+// file coreutils/ls.c line 711
+static struct dnode * my_stat(const char *fullname, const char *name, signed int force_follow);
+// file coreutils/ls.c line 470
+static unsigned int print_name(const char *name);
+// file include/libbb.h line 678
+static const char * printable_string(struct uni_stat_t *stats, const char *str);
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG);
+// file include/libbb.h line 651
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file coreutils/ls.c line 1021
+static void scan_and_display_dirs_recur(struct dnode **dn, signed int first);
+// file coreutils/ls.c line 933
+static struct dnode ** scan_one_dir(const char *path, unsigned int *nfiles_p);
+// file coreutils/ls.c line 922
+static void sort_and_display_files(struct dnode **dn, unsigned int nfiles);
+// file coreutils/ls.c line 864
+static signed int sortcmp(const void *a, const void *b);
+// file coreutils/ls.c line 825
+static struct dnode ** splitdnarray(struct dnode **dn, signed int which);
+// file libbb/bb_pwd.c line 63
+static char * uid2uname(unsigned int uid);
+// file libbb/bb_pwd.c line 75
+static char * uid2uname_utoa(unsigned int uid);
+// file include/unicode.h line 63
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src);
+// file libbb/unicode.c line 1003
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags);
+// file include/libbb.h line 815
+static char * utoa(unsigned int n);
+// file include/libbb.h line 818
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen);
+// file libbb/xfuncs_printf.c line 396
+static struct __dirstream * warn_opendir(const char *path);
+// file libbb/unicode.c line 88
+static unsigned long int wcrtomb_internal(char *s, signed int wc);
+// file libbb/xfuncs.c line 237
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err);
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file include/libbb.h line 402
+static char * xmalloc_readlink(const char *path);
+// file include/libbb.h line 403
+static char * xmalloc_readlink_or_warn(const char *path);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file include/libbb.h line 707
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx);
+// file include/libbb.h line 649
+static char * xstrndup(const char *s, signed int n);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct cache_t
+{
+  // cache
+  struct id_to_name_map_t *cache;
+  // size
+  signed int size;
+};
+
+struct dnode
+{
+  // name
+  const char *name;
+  // fullname
+  const char *fullname;
+  // dn_next
+  struct dnode *dn_next;
+  // fname_allocated
+  signed char fname_allocated;
+  // dn_mode_lstat
+  unsigned int dn_mode_lstat;
+  // dn_mode_stat
+  unsigned int dn_mode_stat;
+  // dn_mode
+  unsigned int dn_mode;
+  // dn_size
+  signed long int dn_size;
+  // dn_atime
+  signed long int dn_atime;
+  // dn_mtime
+  signed long int dn_mtime;
+  // dn_ctime
+  signed long int dn_ctime;
+  // dn_ino
+  unsigned long int dn_ino;
+  // dn_blocks
+  signed long int dn_blocks;
+  // dn_nlink
+  unsigned long int dn_nlink;
+  // dn_uid
+  unsigned int dn_uid;
+  // dn_gid
+  unsigned int dn_gid;
+  // dn_rdev_maj
+  signed int dn_rdev_maj;
+  // dn_rdev_min
+  signed int dn_rdev_min;
+};
+
+struct globals
+{
+  // show_color
+  signed char show_color;
+  // exit_code
+  signed char exit_code;
+  // all_fmt
+  unsigned int all_fmt;
+  // terminal_width
+  unsigned int terminal_width;
+  // current_time_t
+  signed long int current_time_t;
+};
+
+struct id_to_name_map_t
+{
+  // id
+  unsigned int id;
+  // name
+  char name[28l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+struct uni_stat_t
+{
+  // byte_count
+  unsigned int byte_count;
+  // unicode_count
+  unsigned int unicode_count;
+  // unicode_width
+  unsigned int unicode_width;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/messages.c line 66
+static char bb_common_bufsiz1[8193l];
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/procps.c line 25
+static struct cache_t groupname;
+// file libbb/xfuncs.c line 114
+static char local_buf[(signed long int)(sizeof(signed int) * 3) /*12l*/ ];
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file coreutils/ls.c line 194
+static const char ls_options[32l] = { (const char)67, (const char)97, (const char)100, (const char)105, (const char)108, (const char)49, (const char)103, (const char)110, (const char)115, (const char)120, (const char)81, (const char)65, (const char)107, (const char)99, (const char)101, (const char)116, (const char)117, (const char)83, (const char)88, (const char)114, (const char)118, (const char)70, (const char)112, (const char)82, (const char)76, (const char)72, (const char)104, (const char)84, (const char)58, (const char)119, (const char)58, (const char)0 };
+// file libbb/mode_string.c line 92
+static const char mode_chars[7l] = { (const char)114, (const char)119, (const char)120, (const char)83, (const char)84, (const char)115, (const char)116 };
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file coreutils/ls.c line 262
+static const unsigned int opt_flags[25l] = { (const unsigned int)524288, (const unsigned int)(16384 | 32768), (const unsigned int)65536, (const unsigned int)1, (const unsigned int)(1436 | 1048576), (const unsigned int)1572864, (const unsigned int)(1436 | 1048576), (const unsigned int)(32 | 1436 | 1048576), 
+    (const unsigned int)2, (const unsigned int)(262144 | 524288), (const unsigned int)0, (const unsigned int)16384, (const unsigned int)(0 * (64 | 1572864)), 
+    (const unsigned int)(2097152 | 1 * 50331648), 
+    (const unsigned int)512, (const unsigned int)(1 * 67108864), (const unsigned int)(4194304 | 1 * 33554432), 
+    (const unsigned int)16777216, (const unsigned int)100663296, (const unsigned int)8388608, (const unsigned int)83886080, (const unsigned int)(2048 | 4096), (const unsigned int)2048, (const unsigned int)131072, 1u << 31 };
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/mode_string.c line 90
+static const char type_chars[16l] = { (const char)63, (const char)112, (const char)99, (const char)63, (const char)100, (const char)63, (const char)98, (const char)63, (const char)45, (const char)63, (const char)108, (const char)63, (const char)115, (const char)63, (const char)63, (const char)63 };
+// file libbb/unicode.c line 14
+static unsigned char unicode_status;
+// file libbb/procps.c line 25
+static struct cache_t username;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file coreutils/ls.c line 427
+static char append_char(unsigned int mode)
+{
+  if((2048u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+    return (char)0;
+
+  if((61440u & mode) == 16384u)
+    return (char)47;
+
+  if((4096u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+    return (char)0;
+
+  if((61440u & mode) == 32768u)
+  {
+    if(!((73u & mode) == 0u))
+      return (char)42;
+
+  }
+
+  if((signed long int)(15u & mode >> 12) < 17l)
+    (void)0;
+
+  else
+    /* assertion (signed long int)(15u & mode >> 12) < 17l */
+    __VERIFIER_error();
+  return ""[(signed long int)(mode >> 12 & (unsigned int)15)];
+}
+
+// file include/libbb.h line 386
+static const char * bb_basename(const char *name)
+{
+  const char *cp;
+  cp=strrchr(name, 47);
+  if(!(cp == ((const char *)NULL)))
+    return cp + (signed long int)1;
+
+  return name;
+}
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/mode_string.c line 94
+static const char * bb_mode_string(unsigned int mode)
+{
+  static char buf[12l];
+  char *p = buf;
+  signed int i;
+  signed int j;
+  signed int k;
+  signed int m;
+  *p = type_chars[(signed long int)(mode >> 12 & (unsigned int)15)];
+  i = 0;
+  m = 256;
+  do
+  {
+    k = 0;
+    j = k;
+    do
+    {
+      p = p + 1l;
+      *p = (char)45;
+      if(!((mode & (unsigned int)m) == 0u))
+      {
+        *p = mode_chars[(signed long int)j];
+        k = j;
+      }
+
+      m = m >> 1;
+      j = j + 1;
+    }
+    while(j < 3);
+    i = i + 1;
+    if(!((mode & (unsigned int)(4096 >> i)) == 0u))
+      *p = mode_chars[(signed long int)(3 + (k & 2) + (signed int)(i == 3))];
+
+  }
+  while(i < 3);
+  (void)0;
+  return buf;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/unicode.h line 112
+static signed int bb_wcwidth(unsigned int ucs)
+{
+  if(ucs == 0u)
+    return 0;
+
+  if(!((4294967167u & ucs) < 32u))
+  {
+    if(ucs == 127u)
+      goto __CPROVER_DUMP_L2;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L2:
+    ;
+    return -1;
+  }
+  if(ucs > 767u)
+    return -1;
+
+  return 1;
+}
+
+// file coreutils/ls.c line 418
+static char bold(unsigned int mode)
+{
+  if((61440u & mode) == 32768u)
+  {
+    if(!((73u & mode) == 0u))
+      return "\001"[(signed long int)(61440 >> 12 & 15)];
+
+  }
+
+  if((signed long int)(15u & mode >> 12) < 17l)
+    (void)0;
+
+  else
+    /* assertion (signed long int)(15u & mode >> 12) < 17l */
+    __VERIFIER_error();
+  return "\001"[(signed long int)(mode >> 12 & (unsigned int)15)];
+}
+
+// file coreutils/ls.c line 441
+static unsigned int calc_name_len(const char *name)
+{
+  unsigned int len;
+  struct uni_stat_t uni_stat;
+  name=printable_string(&uni_stat, name);
+  if((1024u & option_mask32) == 0u)
+    return uni_stat.unicode_width;
+
+  len = (unsigned int)2 + uni_stat.unicode_width;
+  _Bool tmp_if_expr$1;
+  while((_Bool)1)
+  {
+
+    if((signed int)*name == 0)
+      break;
+
+    if((signed int)*name == 34)
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+    {
+
+      tmp_if_expr$1 = ((signed int)*name == 92 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      len = len + 1u;
+
+    name = name + 1l;
+  }
+  return len;
+}
+
+// file coreutils/ls.c line 1003
+static signed long int calculate_blocks(struct dnode **dn)
+{
+  unsigned long int blocks = (unsigned long int)1;
+  if(!(dn == ((struct dnode **)NULL)))
+    while((_Bool)1)
+    {
+
+      if(*dn == ((struct dnode *)NULL))
+        break;
+
+
+      blocks = blocks + (unsigned long int)(*dn)->dn_blocks;
+      dn = dn + 1l;
+    }
+
+  return (signed long int)(blocks >> 1);
+}
+
+// file libbb/concat_path_file.c line 19
+static char * concat_path_file(const char *path, const char *filename)
+{
+  char *lc;
+  if(path == ((const char *)NULL))
+    path = "";
+
+  lc=last_char_is(path, 47);
+  for( ; (signed int)*filename == 47; filename = filename + 1l)
+    ;
+  char *return_value_xasprintf$1;
+  return_value_xasprintf$1=xasprintf("%s%s%s", path, lc == (char *)NULL ? "/" : "", filename);
+  return return_value_xasprintf$1;
+}
+
+// file coreutils/ls.c line 767
+static unsigned int count_dirs(struct dnode **dn, signed int which)
+{
+  unsigned int dirs;
+  unsigned int all;
+  if(dn == ((struct dnode **)NULL))
+    return (unsigned int)0;
+
+  all = (unsigned int)0;
+  dirs = all;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$2;
+  while((_Bool)1)
+  {
+
+    if(*dn == ((struct dnode *)NULL))
+      break;
+
+    const char *name;
+    all = all + 1u;
+
+    if((61440u & (*dn)->dn_mode) == 16384u)
+    {
+
+
+      name = (*dn)->name;
+      if(!(which == 2))
+        tmp_if_expr$1 = 1 != 0;
+
+      else
+      {
+
+        tmp_if_expr$1 = ((signed int)name[(signed long int)0] != 46 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$1 == (_Bool)0))
+        tmp_if_expr$4 = 1 != 0;
+
+      else
+      {
+
+        if(!((signed int)*(1l + name) == 0))
+        {
+          if(!((signed int)*(1l + name) == 46))
+            tmp_if_expr$2 = 1 != 0;
+
+          else
+          {
+
+            tmp_if_expr$2 = ((signed int)name[(signed long int)2] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          tmp_if_expr$3 = (tmp_if_expr$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$3 = 0 != 0;
+        tmp_if_expr$4 = (tmp_if_expr$3 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$4 == (_Bool)0))
+        dirs = dirs + 1u;
+
+    }
+
+    dn = dn + 1l;
+  }
+  return which != 0 ? dirs : all - dirs;
+}
+
+// file coreutils/ls.c line 805
+static void dfree(struct dnode **dnp)
+{
+  unsigned int i;
+  if(dnp == ((struct dnode **)NULL))
+    return;
+
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+
+    if(dnp[(signed long int)i] == ((struct dnode *)NULL))
+      break;
+
+    struct dnode *cur = dnp[(signed long int)i];
+
+    if(!((signed int)cur->fname_allocated == 0))
+      free((void *)(char *)cur->fullname);
+
+    free((void *)cur);
+    i = i + 1u;
+  }
+  free((void *)dnp);
+}
+
+// file coreutils/ls.c line 652
+static void display_files(struct dnode **dn, unsigned int nfiles)
+{
+  unsigned int i;
+  unsigned int ncols;
+  unsigned int nrows;
+  unsigned int row;
+  unsigned int nc;
+  unsigned int column;
+  unsigned int nexttab;
+  unsigned int column_width = (unsigned int)0;
+  if(!((1048576u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ncols = (unsigned int)1;
+
+  else
+  {
+    i = (unsigned int)0;
+    while((_Bool)1)
+    {
+
+      if(dn[(signed long int)i] == ((struct dnode *)NULL))
+        break;
+
+      signed int len;
+      unsigned int return_value_calc_name_len$1;
+
+      return_value_calc_name_len$1=calc_name_len(dn[(signed long int)i]->name);
+      len = (signed int)return_value_calc_name_len$1;
+      if(!(column_width >= (unsigned int)len))
+        column_width = (unsigned int)len;
+
+      i = i + 1u;
+    }
+    column_width = column_width + (unsigned int)(1 + ((((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)1) != 0u ? 8 : 0) + ((((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)2) != 0u ? 5 : 0));
+    if(!(column_width == 0u))
+      (void)0;
+
+    else
+      /* assertion column_width != 0u */
+      __VERIFIER_error();
+    ncols = (unsigned int)((struct globals *)&bb_common_bufsiz1)->terminal_width / column_width;
+  }
+  if(ncols > 1u)
+  {
+    if(!(ncols == 0u))
+      (void)0;
+
+    else
+      /* assertion ncols != 0u */
+      __VERIFIER_error();
+    nrows = nfiles / ncols;
+    if(!(ncols * nrows >= nfiles))
+      nrows = nrows + 1u;
+
+  }
+
+  else
+  {
+    nrows = nfiles;
+    ncols = (unsigned int)1;
+  }
+  column = (unsigned int)0;
+  nexttab = (unsigned int)0;
+  row = (unsigned int)0;
+  for( ; !(row >= nrows); row = row + 1u)
+  {
+    nc = (unsigned int)0;
+    for( ; !(nc >= ncols); nc = nc + 1u)
+    {
+      if(!((262144u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+        i = row * ncols + nc;
+
+      else
+        i = nc * nrows + row;
+      if(!(i >= nfiles))
+      {
+        if(column > 0u)
+        {
+          nexttab = nexttab - column;
+          printf("%*s ", nexttab, "");
+          column = column + nexttab + (unsigned int)1;
+        }
+
+        nexttab = column + column_width;
+        unsigned int return_value_display_single$2;
+
+        return_value_display_single$2=display_single(dn[(signed long int)i]);
+        column = column + return_value_display_single$2;
+      }
+
+    }
+    putchar(10);
+    column = (unsigned int)0;
+  }
+}
+
+// file coreutils/ls.c line 501
+static unsigned int display_single(struct dnode *dn)
+{
+  unsigned int column = (unsigned int)0;
+  char *lpath;
+  struct stat statbuf;
+  char append;
+
+  append=append_char(dn->dn_mode);
+  lpath = (char *)NULL;
+  if(!((1024u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+
+    if((61440u & dn->dn_mode) == 40960u)
+      lpath=xmalloc_readlink_or_warn(dn->fullname);
+
+  }
+
+  signed int return_value_printf$1;
+  if(!((1u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+
+    return_value_printf$1 = printf("%7llu ", (signed long long int)dn->dn_ino);
+    column = column + (unsigned int)return_value_printf$1;
+  }
+
+  signed int return_value_printf$2;
+  if(!((2u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+
+    return_value_printf$2 = printf("%6lu ", (signed long int)(dn->dn_blocks >> 1));
+    column = column + (unsigned int)return_value_printf$2;
+  }
+
+  const char *return_value_bb_mode_string$3;
+  signed int return_value_printf$4;
+  if(!((4u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+
+    return_value_bb_mode_string$3=bb_mode_string(dn->dn_mode);
+    return_value_printf$4 = printf("%-10s ", (char *)return_value_bb_mode_string$3);
+    column = column + (unsigned int)return_value_printf$4;
+  }
+
+  signed int return_value_printf$5;
+  if(!((8u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+
+    return_value_printf$5 = printf("%4lu ", (signed long int)dn->dn_nlink);
+    column = column + (unsigned int)return_value_printf$5;
+  }
+
+  signed int return_value_printf$6;
+  signed int return_value_printf$7;
+  if(!((32u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    if(!((64u & option_mask32) == 0u))
+    {
+
+      return_value_printf$6 = printf("%-8u ", (signed int)dn->dn_gid);
+      column = column + (unsigned int)return_value_printf$6;
+    }
+
+    else
+    {
+
+      return_value_printf$7 = printf("%-8u %-8u ", (signed int)dn->dn_uid, (signed int)dn->dn_gid);
+      column = column + (unsigned int)return_value_printf$7;
+    }
+  }
+
+  else
+    if(!((16u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      if(!((64u & option_mask32) == 0u))
+      {
+        const char *return_value_get_cached_groupname$8;
+
+        return_value_get_cached_groupname$8=get_cached_groupname(dn->dn_gid);
+        signed int return_value_printf$9 = printf("%-8.8s ", return_value_get_cached_groupname$8);
+        column = column + (unsigned int)return_value_printf$9;
+      }
+
+      else
+      {
+        const char *return_value_get_cached_username$10;
+
+        return_value_get_cached_username$10=get_cached_username(dn->dn_uid);
+        const char *return_value_get_cached_groupname$11;
+
+        return_value_get_cached_groupname$11=get_cached_groupname(dn->dn_gid);
+        signed int return_value_printf$12 = printf("%-8.8s %-8.8s ", return_value_get_cached_username$10, return_value_get_cached_groupname$11);
+        column = column + (unsigned int)return_value_printf$12;
+      }
+    }
+
+  _Bool tmp_if_expr$17;
+  if(!((128u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+
+    if((61440u & dn->dn_mode) == 24576u)
+      tmp_if_expr$17 = 1 != 0;
+
+    else
+    {
+
+      tmp_if_expr$17 = ((dn->dn_mode & (unsigned int)61440) == (unsigned int)8192 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$17 == (_Bool)0))
+    {
+      signed int return_value_printf$13;
+
+      return_value_printf$13 = printf("%4u, %3u ", dn->dn_rdev_maj, dn->dn_rdev_min);
+      column = column + (unsigned int)return_value_printf$13;
+    }
+
+    else
+      if(!((67108864u & option_mask32) == 0u))
+      {
+        const char *return_value_make_human_readable_str$14;
+
+        return_value_make_human_readable_str$14=make_human_readable_str((unsigned long long int)dn->dn_size, (unsigned long int)1, (unsigned long int)0);
+        signed int return_value_printf$15 = printf("%7s ", return_value_make_human_readable_str$14);
+        column = column + (unsigned int)return_value_printf$15;
+      }
+
+      else
+      {
+        signed int return_value_printf$16;
+
+        return_value_printf$16 = printf("%9lu ", dn->dn_size);
+        column = column + (unsigned int)return_value_printf$16;
+      }
+  }
+
+  if(!((768u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    char *filetime;
+    signed long int ttime;
+
+    ttime = dn->dn_mtime;
+    if(!((4194304u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+      ttime = dn->dn_atime;
+
+    if(!((2097152u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+
+      ttime = dn->dn_ctime;
+    }
+
+    filetime=ctime(&ttime);
+    if(!((512u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      signed int return_value_printf$18 = printf("%.24s ", filetime);
+      column = column + (unsigned int)return_value_printf$18;
+    }
+
+    else
+    {
+      signed long int age = ((struct globals *)&bb_common_bufsiz1)->current_time_t - ttime;
+      printf("%.6s ", filetime + (signed long int)4);
+      if(age < 15768000l)
+      {
+        if(!(age > -900l))
+          goto __CPROVER_DUMP_L55;
+
+        printf("%.5s ", filetime + (signed long int)11);
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L55:
+        ;
+        printf(" %.4s ", filetime + (signed long int)20);
+      }
+      column = column + (unsigned int)13;
+    }
+  }
+
+  signed int return_value_lstat$19;
+  if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+  {
+    unsigned int mode;
+
+    mode = dn->dn_mode_lstat;
+    if(mode == 0u)
+    {
+      return_value_lstat$19=lstat(dn->fullname, &statbuf);
+      if(return_value_lstat$19 == 0)
+        mode = statbuf.st_mode;
+
+    }
+
+    char return_value_bold$20;
+    return_value_bold$20=bold(mode);
+    char return_value_fgcolor$21;
+    return_value_fgcolor$21=fgcolor(mode);
+    printf("\033[%u;%um", return_value_bold$20, return_value_fgcolor$21);
+  }
+
+  unsigned int return_value_print_name$22;
+
+  return_value_print_name$22=print_name(dn->name);
+  column = column + return_value_print_name$22;
+  if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+    printf("\033[0m");
+
+  _Bool tmp_if_expr$26;
+  signed int return_value_stat$23;
+  if(!(lpath == ((char *)NULL)))
+  {
+    printf(" -> ");
+    if(!((2048u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+      tmp_if_expr$26 = 1 != 0;
+
+    else
+      tmp_if_expr$26 = ((signed int)((struct globals *)&bb_common_bufsiz1)->show_color != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$26 == (_Bool)0))
+    {
+      unsigned int display_single$$1$$7$$1$$mode;
+
+      display_single$$1$$7$$1$$mode = dn->dn_mode_stat;
+      if(display_single$$1$$7$$1$$mode == 0u)
+      {
+        return_value_stat$23=stat(dn->fullname, &statbuf);
+        if(return_value_stat$23 == 0)
+          display_single$$1$$7$$1$$mode = statbuf.st_mode;
+
+      }
+
+      append=append_char(display_single$$1$$7$$1$$mode);
+      if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+      {
+        char return_value_bold$24;
+        return_value_bold$24=bold(display_single$$1$$7$$1$$mode);
+        char return_value_fgcolor$25;
+        return_value_fgcolor$25=fgcolor(display_single$$1$$7$$1$$mode);
+        printf("\033[%u;%um", return_value_bold$24, return_value_fgcolor$25);
+      }
+
+    }
+
+    unsigned int return_value_print_name$27;
+    return_value_print_name$27=print_name(lpath);
+    column = column + return_value_print_name$27 + (unsigned int)4;
+    free((void *)lpath);
+    if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+      printf("\033[0m");
+
+  }
+
+  if(!((2048u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    if(!((signed int)append == 0))
+    {
+      putchar((signed int)append);
+      column = column + 1u;
+    }
+
+  }
+
+  return column;
+}
+
+// file coreutils/ls.c line 795
+static struct dnode ** dnalloc(unsigned int num)
+{
+  if(num < 1u)
+    return (struct dnode **)NULL;
+
+  num = num + 1u;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc((unsigned long int)num * sizeof(struct dnode *) /*8ul*/ );
+  return (struct dnode **)return_value_xzalloc$1;
+}
+
+// file coreutils/ls.c line 917
+static void dnsort(struct dnode **dn, signed int size)
+{
+  qsort((void *)dn, (unsigned long int)size, sizeof(struct dnode *) /*8ul*/ , sortcmp);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file coreutils/ls.c line 412
+static char fgcolor(unsigned int mode)
+{
+  if((61440u & mode) == 32768u)
+  {
+    if(!((73u & mode) == 0u))
+      return "\037##%\"%##"[(signed long int)(61440 >> 12 & 15)];
+
+  }
+
+  if((signed long int)(15u & mode >> 12) < 17l)
+    (void)0;
+
+  else
+    /* assertion (signed long int)(15u & mode >> 12) < 17l */
+    __VERIFIER_error();
+  return "\037##%\"%##"[(signed long int)(mode >> 12 & (unsigned int)15)];
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file libbb/procps.c line 55
+static char * get_cached(struct cache_t *cp, unsigned int id, char * (*x2x_utoa)(unsigned int))
+{
+  signed int i = 0;
+  for( ; !(i >= cp->size); i = i + 1)
+    if((cp->cache + (signed long int)i)->id == id)
+      return (cp->cache + (signed long int)i)->name;
+
+  signed int tmp_post$1 = cp->size;
+  cp->size = cp->size + 1;
+  i = tmp_post$1;
+  void *return_value_xrealloc_vector_helper$2;
+  return_value_xrealloc_vector_helper$2=xrealloc_vector_helper((void *)cp->cache, (unsigned int)((sizeof(struct id_to_name_map_t) /*32ul*/  << 8) + (unsigned long int)2), i);
+  cp->cache = (struct id_to_name_map_t *)return_value_xrealloc_vector_helper$2;
+  (cp->cache + (signed long int)i)->id = id;
+  char *return_value;
+  return_value=x2x_utoa(id);
+  safe_strncpy((cp->cache + (signed long int)i)->name, return_value, sizeof(char [28l]) /*28ul*/ );
+  return (cp->cache + (signed long int)i)->name;
+}
+
+// file libbb/procps.c line 73
+static const char * get_cached_groupname(unsigned int gid)
+{
+  char *return_value_get_cached$1;
+  return_value_get_cached$1=get_cached(&groupname, gid, gid2group_utoa);
+  return return_value_get_cached$1;
+}
+
+// file libbb/procps.c line 69
+static const char * get_cached_username(unsigned int uid)
+{
+  char *return_value_get_cached$1;
+  return_value_get_cached$1=get_cached(&username, uid, uid2uname_utoa);
+  return return_value_get_cached$1;
+}
+
+// file include/libbb.h line 1348
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height)
+{
+  struct winsize win;
+  signed int err;
+  win.ws_row = (unsigned short int)0;
+  win.ws_col = (unsigned short int)0;
+  signed int return_value_ioctl$1;
+  return_value_ioctl$1=ioctl(fd, (unsigned long int)21523, &win);
+  err = (signed int)(return_value_ioctl$1 != 0 ? (signed int)(1 != 0) : ((signed int)win.ws_row == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)));
+  signed int return_value_wh_helper$2;
+  if(!(height == ((unsigned int *)NULL)))
+  {
+    return_value_wh_helper$2=wh_helper((signed int)win.ws_row, 24, "LINES", &err);
+    *height = (unsigned int)return_value_wh_helper$2;
+  }
+
+  signed int return_value_wh_helper$3;
+  if(!(width == ((unsigned int *)NULL)))
+  {
+    return_value_wh_helper$3=wh_helper((signed int)win.ws_col, 80, "COLUMNS", &err);
+    *width = (unsigned int)return_value_wh_helper$3;
+  }
+
+  return err;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file libbb/bb_pwd.c line 69
+static char * gid2group(unsigned int gid)
+{
+  struct group *gr;
+  gr=bb_internal_getgrgid(gid);
+  char *tmp_if_expr$1;
+  if(!(gr == ((struct group *)NULL)))
+    tmp_if_expr$1 = gr->gr_name;
+
+  else
+    tmp_if_expr$1 = (char *)NULL;
+  return tmp_if_expr$1;
+}
+
+// file libbb/bb_pwd.c line 81
+static char * gid2group_utoa(unsigned int gid)
+{
+  char *name;
+  name=gid2group(gid);
+  char *tmp_if_expr$2;
+  char *return_value_utoa$1;
+  if(!(name == ((char *)NULL)))
+    tmp_if_expr$2 = name;
+
+  else
+  {
+    return_value_utoa$1=utoa(gid);
+    tmp_if_expr$2 = return_value_utoa$1;
+  }
+  return tmp_if_expr$2;
+}
+
+// file libbb/compare_string_array.c line 54
+static signed int index_in_substrings(const char *strings, const char *key)
+{
+  signed int matched_idx = -1;
+  signed int len;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(key);
+  len = (const signed int)return_value_strlen$1;
+  if(!(len == 0))
+  {
+    signed int idx = 0;
+    while(!((signed int)*strings == 0))
+    {
+      signed int return_value_strncmp$2;
+      return_value_strncmp$2=strncmp(strings, key, (unsigned long int)len);
+      if(return_value_strncmp$2 == 0)
+      {
+        if((signed int)strings[(signed long int)len] == 0)
+          return idx;
+
+        if(matched_idx >= 0)
+          return -1;
+
+        matched_idx = idx;
+      }
+
+      unsigned long int return_value_strlen$3;
+      return_value_strlen$3=strlen(strings);
+      strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+      idx = idx + 1;
+    }
+  }
+
+  return matched_idx;
+}
+
+// file include/unicode.h line 83
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)NULL))
+      s=getenv("LC_CTYPE");
+
+    if(s == ((char *)NULL))
+      s=getenv("LANG");
+
+    reinit_unicode(s);
+  }
+
+}
+
+// file include/libbb.h line 388
+static char * last_char_is(const char *s, signed int c)
+{
+  if(!(s == ((const char *)NULL)))
+  {
+    if(!((signed int)*s == 0))
+    {
+      unsigned long int sz;
+      unsigned long int return_value_strlen$1;
+      return_value_strlen$1=strlen(s);
+      sz = return_value_strlen$1 - (unsigned long int)1;
+      s = s + (signed long int)sz;
+      if((signed int)*s == c)
+        return (char *)s;
+
+    }
+
+  }
+
+  return (char *)NULL;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file coreutils/ls.c line 1064
+signed int __main(signed int argc, char **argv)
+{
+  struct dnode **dnd;
+  struct dnode **dnf;
+  struct dnode **dnp;
+  struct dnode *dn;
+  struct dnode *cur;
+  unsigned int opt;
+  unsigned int nfiles;
+  unsigned int dnfiles;
+  unsigned int dndirs;
+  unsigned int i;
+  static const char color_str[34l] = { (const char)97, (const char)108, (const char)119, (const char)97, (const char)121, (const char)115, (const char)0, (const char)121, (const char)101, (const char)115, (const char)0, (const char)102, (const char)111, (const char)114, (const char)99, (const char)101, (const char)0, (const char)97, (const char)117, (const char)116, (const char)111, (const char)0, (const char)116, (const char)116, (const char)121, (const char)0, (const char)105, (const char)102, (const char)45, (const char)116, (const char)116, (const char)121, (const char)0, (const char)0 };
+  const char *color_opt = color_str;
+  do
+  {
+    memset((void *)&(*((struct globals *)&bb_common_bufsiz1)), 0, sizeof(struct globals) /*24ul*/ );
+    ((struct globals *)&bb_common_bufsiz1)->terminal_width = (unsigned int)80;
+    time(&((struct globals *)&bb_common_bufsiz1)->current_time_t);
+  }
+  while((_Bool)0);
+  init_unicode();
+  ((struct globals *)&bb_common_bufsiz1)->all_fmt = (unsigned int)0;
+  get_terminal_width_height(0, &((struct globals *)&bb_common_bufsiz1)->terminal_width, (unsigned int *)NULL);
+  ((struct globals *)&bb_common_bufsiz1)->terminal_width = ((struct globals *)&bb_common_bufsiz1)->terminal_width - 1u;
+  static const char ls_longopts[9l] = { (const char)99, (const char)111, (const char)108, (const char)111, (const char)114, (const char)0, (const char)2, (const char)255, (const char)0 };
+  applet_long_options = ls_longopts;
+  opt_complementary = "el:t-S:S-t:H-L:L-H:C-xl:x-Cl:l-xC:C-1:1-C:x-1:1-x:c-u:u-c:w+";
+  opt=getopt32(argv, ls_options, NULL, &((struct globals *)&bb_common_bufsiz1)->terminal_width, &color_opt);
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+    if((signed long int)i < 25l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)i < 25l */
+      __VERIFIER_error();
+    if(opt_flags[(signed long int)i] == 2147483648u)
+      break;
+
+    if(!((opt & (unsigned int)(1 << i)) == 0u))
+    {
+      unsigned int flags = opt_flags[(signed long int)i];
+      if(!((1572864u & flags) == 0u))
+        ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~1572864;
+
+      if(!((117440512u & flags) == 0u))
+        ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~117440512;
+
+      if(!((6291456u & flags) == 0u))
+        ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~6291456;
+
+      ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt | flags;
+    }
+
+    i = i + 1u;
+  }
+  signed int return_value_isatty$8;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$6;
+  signed int tmp_statement_expression$1;
+  _Bool tmp_if_expr$2;
+  signed int tmp_if_expr$5;
+  signed int tmp_statement_expression$3;
+  signed int return_value___builtin_strcmp$4;
+  if((_Bool)0)
+  {
+    return_value_isatty$8=isatty(1);
+    if(!(return_value_isatty$8 == 0))
+    {
+      char *p;
+      p=getenv("LS_COLORS");
+      if(p == ((char *)NULL))
+        tmp_if_expr$7 = 1 != 0;
+
+      else
+      {
+
+        if(!((signed int)*p == 0))
+        {
+          unsigned long int __s1_len;
+          unsigned long int __s2_len;
+          if((_Bool)1)
+          {
+            if(!((unsigned long int)("none" + 1l) + -((unsigned long int)"none") == 1ul))
+              goto __CPROVER_DUMP_L13;
+
+            __s2_len=strlen("none");
+            tmp_if_expr$2 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L13:
+            ;
+            tmp_if_expr$2 = 0 != 0;
+          }
+          if(!(tmp_if_expr$2 == (_Bool)0))
+          {
+            const char *__s2 = (const char *)p;
+            signed int __result;
+
+            __result = (signed int)((const char *)"none")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+            if(__s2_len > 0ul)
+            {
+              if(__result == 0)
+              {
+
+
+                __result = (signed int)((const char *)"none")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+                if(__s2_len > 1ul)
+                {
+                  if(__result == 0)
+                  {
+
+
+                    __result = (signed int)((const char *)"none")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                    if(__s2_len > 2ul)
+                    {
+                      if(__result == 0)
+                      {
+
+
+                        __result = (signed int)((const char *)"none")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                      }
+
+                    }
+
+                  }
+
+                }
+
+              }
+
+            }
+
+            tmp_statement_expression$3 = __result;
+            tmp_if_expr$5 = -tmp_statement_expression$3;
+          }
+
+          else
+          {
+            return_value___builtin_strcmp$4=strcmp(p, "none");
+            tmp_if_expr$5 = return_value___builtin_strcmp$4;
+          }
+          tmp_statement_expression$1 = tmp_if_expr$5;
+          tmp_if_expr$6 = (tmp_statement_expression$1 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$6 = 0 != 0;
+        tmp_if_expr$7 = (tmp_if_expr$6 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$7 == (_Bool)0))
+        ((struct globals *)&bb_common_bufsiz1)->show_color = (signed char)1;
+
+    }
+
+  }
+
+  signed int return_value_index_in_substrings$9;
+  signed int return_value_isatty$10;
+  if(!((536870912u & opt) == 0u))
+  {
+
+    if((signed int)*color_opt == 110)
+      ((struct globals *)&bb_common_bufsiz1)->show_color = (signed char)0;
+
+    else
+    {
+      return_value_index_in_substrings$9=index_in_substrings(color_str, color_opt);
+      if(!(return_value_index_in_substrings$9 == 0))
+      {
+        if(!(return_value_index_in_substrings$9 == 1))
+        {
+          if(!(return_value_index_in_substrings$9 == 2))
+          {
+            if(!(return_value_index_in_substrings$9 == 3) && !(return_value_index_in_substrings$9 == 4) && !(return_value_index_in_substrings$9 == 5))
+              goto __CPROVER_DUMP_L42;
+
+            return_value_isatty$10=isatty(1);
+            if(return_value_isatty$10 == 0)
+              goto __CPROVER_DUMP_L41;
+
+          }
+
+        }
+
+      }
+
+      ((struct globals *)&bb_common_bufsiz1)->show_color = (signed char)1;
+    }
+  }
+
+__CPROVER_DUMP_L41:
+  ;
+
+__CPROVER_DUMP_L42:
+  ;
+  if(!((65536u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~131072;
+
+  if(!((2097152u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~117440512 | (unsigned int)50331648;
+
+  if(!((4194304u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~117440512 | (unsigned int)33554432;
+
+  if(!((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 1048576u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~(32 | 16 | 512);
+
+  signed int return_value_isatty$11;
+  if((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+  {
+    return_value_isatty$11=isatty(1);
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt | (unsigned int)(return_value_isatty$11 != 0 ? 524288 : 1572864);
+  }
+
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)".";
+  }
+
+
+  if(!(*(1l + argv) == ((char *)NULL)))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt | (unsigned int)8192;
+
+  dn = (struct dnode *)NULL;
+  nfiles = (unsigned int)0;
+  _Bool tmp_if_expr$12;
+  while((_Bool)1)
+  {
+    if((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 1048576u)
+      tmp_if_expr$12 = 1 != 0;
+
+    else
+      tmp_if_expr$12 = ((((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)2) != 0u ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    cur=my_stat(*argv, *argv, (signed int)(!((tmp_if_expr$12 != (_Bool)0 ? (signed int)(1 != 0) : ((option_mask32 & (unsigned int)2097152) != 0u ? (signed int)(1 != 0) : (signed int)(0 != 0))) != 0) ? (signed int)(1 != 0) : ((option_mask32 & (unsigned int)33554432) != 0u ? (signed int)(1 != 0) : (signed int)(0 != 0))));
+    argv = argv + 1l;
+    if(!(cur == ((struct dnode *)NULL)))
+    {
+
+      cur->dn_next = dn;
+      dn = cur;
+      nfiles = nfiles + 1u;
+    }
+
+
+    if(*argv == ((char *)NULL))
+      break;
+
+  }
+  if(nfiles == 0u)
+    return (signed int)((struct globals *)&bb_common_bufsiz1)->exit_code;
+
+  dnp=dnalloc(nfiles);
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+
+    dnp[(signed long int)i] = dn;
+
+    dn = dn->dn_next;
+    if(dn == ((struct dnode *)NULL))
+      break;
+
+    i = i + 1u;
+  }
+  if(!((65536u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    sort_and_display_files(dnp, nfiles);
+
+  else
+  {
+    dnd=splitdnarray(dnp, 1);
+    dnf=splitdnarray(dnp, 0);
+    dndirs=count_dirs(dnp, 1);
+    dnfiles = nfiles - dndirs;
+    if(dnfiles > 0u)
+      sort_and_display_files(dnf, dnfiles);
+
+    if(dndirs > 0u)
+    {
+      dnsort(dnd, (signed int)dndirs);
+      scan_and_display_dirs_recur(dnd, (signed int)(dnfiles == (unsigned int)0));
+    }
+
+  }
+  return (signed int)((struct globals *)&bb_common_bufsiz1)->exit_code;
+}
+
+// file libbb/human_readable.c line 33
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit)
+{
+  unsigned int frac;
+  const char *u;
+  const char *fmt;
+  if(val == 0ul)
+    return "0";
+
+  fmt = "%llu";
+  if(block_size > 1ul)
+    val = val * block_size;
+
+  frac = (unsigned int)0;
+  static const char unit_chars[9l] = { (const char)0, (const char)75, (const char)77, (const char)71, (const char)84, (const char)80, (const char)69, (const char)90, (const char)89 };
+  u = unit_chars;
+  if(!(display_unit == 0ul))
+  {
+    val = val + display_unit / (unsigned long int)2;
+    val = val / display_unit;
+  }
+
+  else
+  {
+    for( ; val >= 1024ul; val = val / (unsigned long long int)1024)
+    {
+      fmt = "%llu.%u%c";
+      u = u + 1l;
+      frac = (((unsigned int)val % (unsigned int)1024) * (unsigned int)10 + (unsigned int)(1024 / 2)) / (unsigned int)1024;
+    }
+    if(frac >= 10u)
+    {
+      val = val + 1ull;
+      frac = (unsigned int)0;
+    }
+
+    if(block_size == 0ul)
+    {
+      if(frac >= 5u)
+        val = val + 1ull;
+
+      fmt = "%llu%*c";
+      frac = (unsigned int)1;
+    }
+
+  }
+  static char *str;
+  if(str == ((char *)NULL))
+  {
+    void *return_value_xmalloc$1;
+    return_value_xmalloc$1=xmalloc(sizeof(unsigned long long int) /*8ul*/  * (unsigned long int)3 + (unsigned long int)2 + (unsigned long int)3);
+    str = (char *)return_value_xmalloc$1;
+  }
+
+  sprintf(str, fmt, val, frac, *u);
+  return str;
+}
+
+// file libbb/unicode.c line 175
+static const char * mbstowc_internal(signed int *res, const char *src)
+{
+  signed int bytes;
+  unsigned int c;
+  const char *tmp_post$1 = src;
+  src = src + 1l;
+  c = (unsigned int)(unsigned char)*tmp_post$1;
+  if(c <= 127u)
+  {
+    *res = (signed int)c;
+    return src;
+  }
+
+  bytes = 0;
+  do
+  {
+    c = c << 1;
+    bytes = bytes + 1;
+  }
+  while(bytes < 6 && (128u & c) != 0u);
+  if(bytes == 1)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+
+  c = (unsigned int)((signed int)(unsigned char)c >> bytes);
+  do
+  {
+    bytes = bytes - 1;
+    if(bytes == 0)
+      break;
+
+    unsigned int ch = (unsigned int)(unsigned char)*src;
+    if(!((192u & ch) == 128u))
+    {
+      *res = ~((signed int)0);
+      return src;
+    }
+
+    c = (c << 6) + (ch & (unsigned int)63);
+    src = src + 1l;
+  }
+  while((_Bool)1);
+  if(c <= 127u)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+
+  *res = (signed int)c;
+  return src;
+}
+
+// file coreutils/ls.c line 711
+static struct dnode * my_stat(const char *fullname, const char *name, signed int force_follow)
+{
+  struct stat statbuf;
+  struct dnode *cur;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct dnode) /*112ul*/ );
+  cur = (struct dnode *)return_value_xzalloc$1;
+
+  cur->fullname = fullname;
+
+  cur->name = name;
+  if((16777216u & option_mask32) == 0u)
+  {
+    if(force_follow != 0)
+      goto __CPROVER_DUMP_L5;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L5:
+    ;
+    signed int return_value_stat$2;
+    return_value_stat$2=stat(fullname, &statbuf);
+    if(!(return_value_stat$2 == 0))
+    {
+      bb_simple_perror_msg(fullname);
+      ((struct globals *)&bb_common_bufsiz1)->exit_code = (signed char)1;
+      free((void *)cur);
+      return (struct dnode *)NULL;
+    }
+
+
+    cur->dn_mode_stat = statbuf.st_mode;
+    goto __CPROVER_DUMP_L13;
+  }
+  signed int return_value_lstat$3;
+  return_value_lstat$3=lstat(fullname, &statbuf);
+  if(!(return_value_lstat$3 == 0))
+  {
+    bb_simple_perror_msg(fullname);
+    ((struct globals *)&bb_common_bufsiz1)->exit_code = (signed char)1;
+    free((void *)cur);
+    return (struct dnode *)NULL;
+  }
+
+
+  cur->dn_mode_lstat = statbuf.st_mode;
+
+__CPROVER_DUMP_L13:
+  ;
+
+  cur->dn_mode = statbuf.st_mode;
+
+  cur->dn_size = statbuf.st_size;
+
+  cur->dn_atime = statbuf.st_atim.tv_sec;
+
+  cur->dn_mtime = statbuf.st_mtim.tv_sec;
+
+  cur->dn_ctime = statbuf.st_ctim.tv_sec;
+
+  cur->dn_ino = statbuf.st_ino;
+
+  cur->dn_blocks = statbuf.st_blocks;
+
+  cur->dn_nlink = statbuf.st_nlink;
+
+  cur->dn_uid = statbuf.st_uid;
+
+  cur->dn_gid = statbuf.st_gid;
+  unsigned int return_value_gnu_dev_major$4;
+  return_value_gnu_dev_major$4=gnu_dev_major(statbuf.st_rdev);
+
+  cur->dn_rdev_maj = (signed int)return_value_gnu_dev_major$4;
+  unsigned int return_value_gnu_dev_minor$5;
+  return_value_gnu_dev_minor$5=gnu_dev_minor(statbuf.st_rdev);
+
+  cur->dn_rdev_min = (signed int)return_value_gnu_dev_minor$5;
+  return cur;
+}
+
+// file coreutils/ls.c line 470
+static unsigned int print_name(const char *name)
+{
+  unsigned int len;
+  struct uni_stat_t uni_stat;
+  name=printable_string(&uni_stat, name);
+  if((1024u & option_mask32) == 0u)
+  {
+    fputs(name, stdout);
+    return uni_stat.unicode_width;
+  }
+
+  len = (unsigned int)2 + uni_stat.unicode_width;
+  putchar(34);
+  _Bool tmp_if_expr$1;
+  while((_Bool)1)
+  {
+
+    if((signed int)*name == 0)
+      break;
+
+    if((signed int)*name == 34)
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+    {
+
+      tmp_if_expr$1 = ((signed int)*name == 92 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+    {
+      putchar(92);
+      len = len + 1u;
+    }
+
+
+    putchar((signed int)*name);
+    name = name + 1l;
+  }
+  putchar(34);
+  return len;
+}
+
+// file include/libbb.h line 678
+static const char * printable_string(struct uni_stat_t *stats, const char *str)
+{
+  char *dst;
+  const char *s = str;
+  while((_Bool)1)
+  {
+    unsigned char c = *s;
+    if((signed int)c == 0)
+    {
+      if(!(stats == ((struct uni_stat_t *)NULL)))
+      {
+        stats->byte_count = (unsigned int)(s - str);
+        stats->unicode_count = (unsigned int)(s - str);
+        stats->unicode_width = (unsigned int)(s - str);
+      }
+
+      return str;
+    }
+
+    if((signed int)c < 32)
+      break;
+
+    if((signed int)c >= 127)
+      break;
+
+    s = s + 1l;
+  }
+  dst=unicode_conv_to_printable(stats, str);
+  static unsigned int cur_saved;
+  static char *saved[4l];
+  free((void *)saved[(signed long int)cur_saved]);
+  saved[(signed long int)cur_saved] = dst;
+  cur_saved = cur_saved + (unsigned int)1 & (unsigned int)(sizeof(char *[4l]) /*32ul*/  / sizeof(char *) /*8ul*/ ) - (unsigned int)1;
+  return dst;
+}
+
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)NULL))
+    tmp_if_expr$4 = 1 != 0;
+
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)NULL)))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)NULL ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+
+  unicode_status = (unsigned char)2;
+}
+
+// file include/libbb.h line 651
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size)
+{
+  if(size == 0ul)
+    return dst;
+
+  size = size - 1ul;
+  dst[(signed long int)size] = (char)0;
+  char *return_value_strncpy$1;
+  return_value_strncpy$1=strncpy(dst, src, size);
+  return return_value_strncpy$1;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/ls.c line 1021
+static void scan_and_display_dirs_recur(struct dnode **dn, signed int first)
+{
+  unsigned int nfiles;
+  struct dnode **subdnp;
+  signed long int return_value_calculate_blocks$1;
+  while((_Bool)1)
+  {
+
+    if(*dn == ((struct dnode *)NULL))
+      break;
+
+    if(!((139264u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      if(first == 0)
+        bb_putchar(10);
+
+      first = 0;
+
+
+      printf("%s:\n", (*dn)->fullname);
+    }
+
+
+
+    subdnp=scan_one_dir((*dn)->fullname, &nfiles);
+    if((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 1048576u)
+    {
+      return_value_calculate_blocks$1=calculate_blocks(subdnp);
+      printf("total %lu\n", return_value_calculate_blocks$1);
+    }
+
+    if(nfiles > 0u)
+    {
+      sort_and_display_files(subdnp, nfiles);
+      if(!((131072u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+      {
+        struct dnode **dnd;
+        unsigned int dndirs;
+        dnd=splitdnarray(subdnp, 2);
+        dndirs=count_dirs(subdnp, 2);
+        if(dndirs > 0u)
+        {
+          dnsort(dnd, (signed int)dndirs);
+          scan_and_display_dirs_recur(dnd, 0);
+          free((void *)dnd);
+        }
+
+      }
+
+      dfree(subdnp);
+    }
+
+    dn = dn + 1l;
+  }
+}
+
+// file coreutils/ls.c line 933
+static struct dnode ** scan_one_dir(const char *path, unsigned int *nfiles_p)
+{
+  struct dnode *dn;
+  struct dnode *cur;
+  struct dnode **dnp;
+  struct dirent *entry;
+  struct __dirstream *dir;
+  unsigned int i;
+  unsigned int nfiles;
+
+  *nfiles_p = (unsigned int)0;
+  dir=warn_opendir(path);
+  if(dir == ((struct __dirstream *)NULL))
+  {
+    ((struct globals *)&bb_common_bufsiz1)->exit_code = (signed char)1;
+    return (struct dnode **)NULL;
+  }
+
+  dn = (struct dnode *)NULL;
+  nfiles = (unsigned int)0;
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    entry=readdir(dir);
+    if(entry == ((struct dirent *)NULL))
+      break;
+
+    char *fullname;
+
+    if((signed int)entry->d_name[0l] == 46)
+    {
+      if((signed int)entry->d_name[1l] == 0)
+        tmp_if_expr$2 = 1 != 0;
+
+      else
+      {
+
+        if((signed int)entry->d_name[1l] == 46)
+          tmp_if_expr$1 = (!((signed int)entry->d_name[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+        else
+          tmp_if_expr$1 = 0 != 0;
+        tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+      {
+        if((32768u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+          continue;
+
+      }
+
+      if((16384u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) != 0u)
+        goto __CPROVER_DUMP_L14;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L14:
+      ;
+      fullname=concat_path_file(path, entry->d_name);
+      const char *return_value_bb_basename$3;
+      return_value_bb_basename$3=bb_basename(fullname);
+      cur=my_stat(fullname, return_value_bb_basename$3, 0);
+      if(cur == ((struct dnode *)NULL))
+        free((void *)fullname);
+
+      else
+      {
+
+        cur->fname_allocated = (signed char)1;
+
+        cur->dn_next = dn;
+        dn = cur;
+        nfiles = nfiles + 1u;
+      }
+    }
+  }
+  while((_Bool)1);
+  closedir(dir);
+  if(dn == ((struct dnode *)NULL))
+    return (struct dnode **)NULL;
+
+
+  *nfiles_p = nfiles;
+  dnp=dnalloc(nfiles);
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+
+    dnp[(signed long int)i] = dn;
+
+    dn = dn->dn_next;
+    if(dn == ((struct dnode *)NULL))
+      break;
+
+    i = i + 1u;
+  }
+  return dnp;
+}
+
+// file coreutils/ls.c line 922
+static void sort_and_display_files(struct dnode **dn, unsigned int nfiles)
+{
+  dnsort(dn, (signed int)nfiles);
+  display_files(dn, nfiles);
+}
+
+// file coreutils/ls.c line 864
+static signed int sortcmp(const void *a, const void *b)
+{
+  struct dnode *d1;
+  if(!(a == NULL))
+    (void)0;
+
+  else
+    /* assertion !(a == ((void*)0)) */
+    __VERIFIER_error();
+  d1 = *((struct dnode **)a);
+  struct dnode *d2;
+  if(!(b == NULL))
+    (void)0;
+
+  else
+    /* assertion !(b == ((void*)0)) */
+    __VERIFIER_error();
+  d2 = *((struct dnode **)b);
+  unsigned int sort_opts = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)117440512;
+  signed long int dif = (signed long int)0;
+  signed long int tmp_statement_expression$2;
+  if(sort_opts == 16777216u)
+  {
+
+
+    dif = d2->dn_size - d1->dn_size;
+  }
+
+  else
+    if(sort_opts == 33554432u)
+    {
+
+
+      dif = d2->dn_atime - d1->dn_atime;
+    }
+
+    else
+      if(sort_opts == 50331648u)
+      {
+
+
+        dif = d2->dn_ctime - d1->dn_ctime;
+      }
+
+      else
+        if(sort_opts == 67108864u)
+        {
+
+
+          dif = d2->dn_mtime - d1->dn_mtime;
+        }
+
+        else
+          if(sort_opts == 117440512u)
+          {
+
+
+            dif = (signed long int)((signed int)((d2->dn_mode & (unsigned int)61440) == (unsigned int)16384) - (signed int)((d1->dn_mode & (unsigned int)61440) == (unsigned int)16384));
+          }
+
+          else
+            if(sort_opts == 83886080u)
+            {
+              signed int return_value_strverscmp$1;
+
+
+              return_value_strverscmp$1=strverscmp(d1->name, d2->name);
+              dif = (signed long int)return_value_strverscmp$1;
+            }
+
+            else
+              if(sort_opts == 100663296u)
+              {
+                unsigned long int __s1_len;
+                unsigned long int __s2_len;
+                char *return_value_strchrnul$3;
+
+                return_value_strchrnul$3=strchrnul(d1->name, 46);
+                char *return_value_strchrnul$4;
+
+                return_value_strchrnul$4=strchrnul(d2->name, 46);
+                signed int return_value___builtin_strcmp$5;
+                return_value___builtin_strcmp$5=strcmp(return_value_strchrnul$3, return_value_strchrnul$4);
+                tmp_statement_expression$2 = (signed long int)return_value___builtin_strcmp$5;
+                dif = tmp_statement_expression$2;
+              }
+
+  signed int return_value_strcoll$6;
+  signed long int tmp_statement_expression$7;
+  if(dif == 0l)
+    do
+    {
+      unsigned long int sortcmp$$1$$8$$1$$__s1_len;
+      unsigned long int sortcmp$$1$$8$$1$$__s2_len;
+      signed int return_value___builtin_strcmp$8;
+
+
+      return_value___builtin_strcmp$8=strcmp(d1->name, d2->name);
+      tmp_statement_expression$7 = (signed long int)return_value___builtin_strcmp$8;
+      dif = tmp_statement_expression$7;
+    }
+    while((_Bool)0);
+
+  if(!(dif == 0l))
+    dif = (signed long int)(1 | (signed int)((unsigned long int)dif >> (signed int)(sizeof(signed long int) /*8ul*/  * (unsigned long int)4)));
+
+  return (((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)8388608) != 0u ? -((signed int)dif) : (signed int)dif;
+}
+
+// file coreutils/ls.c line 825
+static struct dnode ** splitdnarray(struct dnode **dn, signed int which)
+{
+  unsigned int dncnt;
+  unsigned int d;
+  struct dnode **dnp;
+  if(dn == ((struct dnode **)NULL))
+    return (struct dnode **)NULL;
+
+  dncnt=count_dirs(dn, which);
+  dnp=dnalloc(dncnt);
+  d = (unsigned int)0;
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$5;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$3;
+  unsigned int tmp_post$1;
+  unsigned int tmp_post$6;
+  while((_Bool)1)
+  {
+
+    if(*dn == ((struct dnode *)NULL))
+      break;
+
+
+    if((61440u & (*dn)->dn_mode) == 16384u)
+    {
+      const char *name;
+      if(which == 0)
+        goto __CPROVER_DUMP_L35;
+
+
+
+      name = (*dn)->name;
+      if(!((1 & which) == 0))
+        tmp_if_expr$2 = 1 != 0;
+
+      else
+      {
+
+        tmp_if_expr$2 = ((signed int)name[(signed long int)0] != 46 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        tmp_if_expr$5 = 1 != 0;
+
+      else
+      {
+
+        if(!((signed int)*(1l + name) == 0))
+        {
+          if(!((signed int)*(1l + name) == 46))
+            tmp_if_expr$3 = 1 != 0;
+
+          else
+          {
+
+            tmp_if_expr$3 = ((signed int)name[(signed long int)2] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          tmp_if_expr$4 = (tmp_if_expr$3 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$4 = 0 != 0;
+        tmp_if_expr$5 = (tmp_if_expr$4 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$5 == (_Bool)0))
+      {
+        tmp_post$1 = d;
+        d = d + 1u;
+
+
+        dnp[(signed long int)tmp_post$1] = *dn;
+      }
+
+    }
+
+    else
+      if(which == 0)
+      {
+        tmp_post$6 = d;
+        d = d + 1u;
+
+
+        dnp[(signed long int)tmp_post$6] = *dn;
+      }
+
+  __CPROVER_DUMP_L35:
+    ;
+    dn = dn + 1l;
+  }
+  return dnp;
+}
+
+// file libbb/bb_pwd.c line 63
+static char * uid2uname(unsigned int uid)
+{
+  struct passwd *pw;
+  pw=bb_internal_getpwuid(uid);
+  char *tmp_if_expr$1;
+  if(!(pw == ((struct passwd *)NULL)))
+    tmp_if_expr$1 = pw->pw_name;
+
+  else
+    tmp_if_expr$1 = (char *)NULL;
+  return tmp_if_expr$1;
+}
+
+// file libbb/bb_pwd.c line 75
+static char * uid2uname_utoa(unsigned int uid)
+{
+  char *name;
+  name=uid2uname(uid);
+  char *tmp_if_expr$2;
+  char *return_value_utoa$1;
+  if(!(name == ((char *)NULL)))
+    tmp_if_expr$2 = name;
+
+  else
+  {
+    return_value_utoa$1=utoa(uid);
+    tmp_if_expr$2 = return_value_utoa$1;
+  }
+  return tmp_if_expr$2;
+}
+
+// file include/unicode.h line 63
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src)
+{
+  char *return_value_unicode_conv_to_printable2$1;
+  return_value_unicode_conv_to_printable2$1=unicode_conv_to_printable2(stats, src, (unsigned int)2147483647, 0);
+  return return_value_unicode_conv_to_printable2$1;
+}
+
+// file libbb/unicode.c line 1003
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags)
+{
+  char *dst;
+  unsigned int dst_len;
+  unsigned int uni_count;
+  unsigned int uni_width;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  if(!((signed int)unicode_status == 2))
+  {
+    char *d;
+    if(!((1 & flags) == 0))
+    {
+      void *return_value_xmalloc$1;
+      return_value_xmalloc$1=xmalloc((unsigned long int)(width + (unsigned int)1));
+      dst = (char *)return_value_xmalloc$1;
+      d = dst;
+      do
+      {
+        width = width - 1u;
+        if(!((signed int)width >= 0))
+          break;
+
+        unsigned char unicode_conv_to_printable2$$1$$1$$1$$1$$c = *src;
+        if((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c == 0)
+        {
+          do
+          {
+            tmp_post$2 = d;
+            d = d + 1l;
+            *tmp_post$2 = (char)32;
+            width = width - 1u;
+          }
+          while((signed int)width >= 0);
+          break;
+        }
+
+        tmp_post$3 = d;
+        d = d + 1l;
+        *tmp_post$3 = (char)((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c >= 32 && (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c < 127 ? (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c : 63);
+        src = src + 1l;
+      }
+      while((_Bool)1);
+      *d = (char)0;
+    }
+
+    else
+    {
+      dst=xstrndup(src, (signed int)width);
+      d = dst;
+      while(!((signed int)*d == 0))
+      {
+        unsigned char c = *d;
+        if(!((signed int)c < 32))
+        {
+          if((signed int)c >= 127)
+            goto __CPROVER_DUMP_L7;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L7:
+          ;
+          *d = (char)63;
+        }
+        d = d + 1l;
+      }
+    }
+    if(!(stats == ((struct uni_stat_t *)NULL)))
+    {
+      stats->byte_count = (unsigned int)(d - dst);
+      stats->unicode_count = (unsigned int)(d - dst);
+      stats->unicode_width = (unsigned int)(d - dst);
+    }
+
+    return dst;
+  }
+
+  dst = (char *)NULL;
+  uni_width = (unsigned int)0;
+  uni_count = uni_width;
+  dst_len = (unsigned int)0;
+  while((_Bool)1)
+  {
+    signed int w;
+    signed int wc;
+    src=mbstowc_internal(&wc, src);
+    if(!(wc == -1))
+    {
+      if(wc == 0)
+        break;
+
+      if(wc > 767)
+        goto subst;
+
+      w=bb_wcwidth((unsigned int)wc);
+      if(w <= 0)
+        goto subst;
+
+      if(w > 1)
+        goto subst;
+
+    }
+
+    else
+    {
+
+    subst:
+      ;
+      wc = 63;
+      w = 1;
+    }
+    width = width - (unsigned int)w;
+    if((signed int)width < 0)
+    {
+      width = width + (unsigned int)w;
+      break;
+    }
+
+    uni_count = uni_count + 1u;
+    uni_width = uni_width + (unsigned int)w;
+    void *return_value_xrealloc$4;
+    return_value_xrealloc$4=xrealloc((void *)dst, (unsigned long int)(dst_len + (unsigned int)6));
+    dst = (char *)return_value_xrealloc$4;
+    unsigned long int return_value_wcrtomb_internal$5;
+    return_value_wcrtomb_internal$5=wcrtomb_internal(&dst[(signed long int)dst_len], wc);
+    dst_len = dst_len + (unsigned int)return_value_wcrtomb_internal$5;
+  }
+  unsigned int tmp_post$7;
+  if(!((1 & flags) == 0))
+  {
+    void *return_value_xrealloc$6;
+    return_value_xrealloc$6=xrealloc((void *)dst, (unsigned long int)(dst_len + width + (unsigned int)1));
+    dst = (char *)return_value_xrealloc$6;
+    uni_count = uni_count + width;
+    uni_width = uni_width + width;
+    do
+    {
+      width = width - 1u;
+      if(!((signed int)width >= 0))
+        break;
+
+      tmp_post$7 = dst_len;
+      dst_len = dst_len + 1u;
+      dst[(signed long int)tmp_post$7] = (char)32;
+    }
+    while((_Bool)1);
+  }
+
+  dst[(signed long int)dst_len] = (char)0;
+  if(!(stats == ((struct uni_stat_t *)NULL)))
+  {
+    stats->byte_count = dst_len;
+    stats->unicode_count = uni_count;
+    stats->unicode_width = uni_width;
+  }
+
+  return dst;
+}
+
+// file include/libbb.h line 815
+static char * utoa(unsigned int n)
+{
+  char *return_value_utoa_to_buf$1;
+  return_value_utoa_to_buf$1=utoa_to_buf(n, local_buf, (unsigned int)(sizeof(char [12l]) /*12ul*/  - (unsigned long int)1));
+  *return_value_utoa_to_buf$1 = (char)0;
+  return local_buf;
+}
+
+// file include/libbb.h line 818
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen)
+{
+  unsigned int i;
+  unsigned int out;
+  unsigned int res;
+  char *tmp_post$1;
+  if(!(buflen == 0u))
+  {
+    out = (unsigned int)0;
+    i = (unsigned int)1000000000;
+    for( ; !(i == 0u); i = i / (unsigned int)10)
+    {
+      res = n / i;
+      n = n % i;
+      if(res == 0u)
+      {
+        if(out != 0u)
+          goto __CPROVER_DUMP_L2;
+
+        if(i == 1u)
+          goto __CPROVER_DUMP_L2;
+
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L2:
+        ;
+        buflen = buflen - 1u;
+        if(buflen == 0u)
+          break;
+
+        out = out + 1u;
+        tmp_post$1 = buf;
+        buf = buf + 1l;
+        *tmp_post$1 = (char)((unsigned int)48 + res);
+      }
+    }
+  }
+
+  return buf;
+}
+
+// file libbb/xfuncs_printf.c line 396
+static struct __dirstream * warn_opendir(const char *path)
+{
+  struct __dirstream *dp;
+  dp=opendir(path);
+  if(dp == ((struct __dirstream *)NULL))
+    bb_perror_msg("can't open '%s'", path);
+
+  return dp;
+}
+
+// file libbb/unicode.c line 88
+static unsigned long int wcrtomb_internal(char *s, signed int wc)
+{
+  signed int n;
+  signed int i;
+  unsigned int v = (unsigned int)wc;
+  if(v <= 127u)
+  {
+    *s = (char)v;
+    return (unsigned long int)1;
+  }
+
+  n = 2;
+  for( ; v >= 2048u; n = n + 1)
+  {
+    if(!(n < 6))
+      break;
+
+    v = v >> 5;
+  }
+  i = n;
+  do
+  {
+    i = i - 1;
+    if(i == 0)
+      break;
+
+    s[(signed long int)i] = (char)(wc & 63 | 128);
+    wc = wc >> 6;
+  }
+  while((_Bool)1);
+  s[(signed long int)0] = (char)(wc | (signed int)(unsigned char)(16128 >> n));
+  return (unsigned long int)n;
+}
+
+// file libbb/xfuncs.c line 237
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err)
+{
+  if(value == 0)
+  {
+    char *s;
+    s=getenv(env_name);
+    if(!(s == ((char *)NULL)))
+    {
+      value=atoi(s);
+      *err = 0;
+    }
+
+  }
+
+  if(!(value <= 1))
+  {
+    if(value >= 30000)
+      goto __CPROVER_DUMP_L3;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L3:
+    ;
+    value = def_val;
+  }
+  return value;
+}
+
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  va_start(p, format);
+  r=vasprintf(&string_ptr, format, p);
+  va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  return string_ptr;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 402
+static char * xmalloc_readlink(const char *path)
+{
+  char *buf = (char *)NULL;
+  signed int bufsize = 0;
+  signed int readsize = 0;
+  do
+  {
+    bufsize = bufsize + 80;
+    void *return_value_xrealloc$1;
+    return_value_xrealloc$1=xrealloc((void *)buf, (unsigned long int)bufsize);
+    buf = (char *)return_value_xrealloc$1;
+    signed long int return_value_readlink$2;
+    return_value_readlink$2=readlink(path, buf, (unsigned long int)bufsize);
+    readsize = (signed int)return_value_readlink$2;
+    if(readsize == -1)
+    {
+      free((void *)buf);
+      return (char *)NULL;
+    }
+
+  }
+  while(!(bufsize >= 1 + readsize));
+  buf[(signed long int)readsize] = (char)0;
+  return buf;
+}
+
+// file include/libbb.h line 403
+static char * xmalloc_readlink_or_warn(const char *path)
+{
+  char *buf;
+  buf=xmalloc_readlink(path);
+  if(buf == ((char *)NULL))
+  {
+    const char *errmsg = "not a symlink";
+    signed int err = *bb_errno;
+    if(!(err == 22))
+      errmsg=strerror(err);
+
+    bb_error_msg("%s: cannot read link: %s", path, errmsg);
+  }
+
+  return buf;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 707
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx)
+{
+  signed int mask = 1 << (signed int)(unsigned char)sizeof_and_shift;
+  if((-1 + mask & idx) == 0)
+  {
+    sizeof_and_shift = sizeof_and_shift >> 8;
+    vector=xrealloc(vector, (unsigned long int)(sizeof_and_shift * (unsigned int)(idx + mask + 1)));
+    memset((void *)((char *)vector + (signed long int)(sizeof_and_shift * (unsigned int)idx)), 0, (unsigned long int)(sizeof_and_shift * (unsigned int)(mask + 1)));
+  }
+
+  return vector;
+}
+
+// file include/libbb.h line 649
+static char * xstrndup(const char *s, signed int n)
+{
+  signed int m;
+  char *t;
+  m = n;
+  t = (char *)s;
+  for( ; !(m == 0); t = t + 1l)
+  {
+    if((signed int)*t == 0)
+      break;
+
+    m = m - 1;
+  }
+  n = n - m;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)(n + 1));
+  t = (char *)return_value_xmalloc$1;
+  t[(signed long int)n] = (char)0;
+  void *return_value_memcpy$2;
+  return_value_memcpy$2=memcpy((void *)t, (const void *)s, (unsigned long int)n);
+  return (char *)return_value_memcpy$2;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp-getgrgid.h"
+#include "busybox_sv_comp-getpwnam.h"
+#include "busybox_sv_comp-readlink.h"
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
@@ -1,0 +1,5386 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+struct dirent
+  {
+    __ino_t d_ino;
+    __off_t d_off;
+    unsigned short int d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+  };
+struct dirent64
+  {
+    __ino64_t d_ino;
+    __off64_t d_off;
+    unsigned short int d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+  };
+enum
+  {
+    DT_UNKNOWN = 0,
+    DT_FIFO = 1,
+    DT_CHR = 2,
+    DT_DIR = 4,
+    DT_BLK = 6,
+    DT_REG = 8,
+    DT_LNK = 10,
+    DT_SOCK = 12,
+    DT_WHT = 14
+  };
+typedef struct __dirstream DIR;
+extern DIR *opendir (const char *__name) __attribute__ ((__nonnull__ (1)));
+extern DIR *fdopendir (int __fd);
+extern int closedir (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern struct dirent *readdir (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern struct dirent64 *readdir64 (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern int readdir_r (DIR *__restrict __dirp,
+        struct dirent *__restrict __entry,
+        struct dirent **__restrict __result)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int readdir64_r (DIR *__restrict __dirp,
+   struct dirent64 *__restrict __entry,
+   struct dirent64 **__restrict __result)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern void rewinddir (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void seekdir (DIR *__dirp, long int __pos) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int telldir (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int dirfd (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+typedef long unsigned int size_t;
+extern int scandir (const char *__restrict __dir,
+      struct dirent ***__restrict __namelist,
+      int (*__selector) (const struct dirent *),
+      int (*__cmp) (const struct dirent **,
+      const struct dirent **))
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int scandir64 (const char *__restrict __dir,
+        struct dirent64 ***__restrict __namelist,
+        int (*__selector) (const struct dirent64 *),
+        int (*__cmp) (const struct dirent64 **,
+        const struct dirent64 **))
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int scandirat (int __dfd, const char *__restrict __dir,
+        struct dirent ***__restrict __namelist,
+        int (*__selector) (const struct dirent *),
+        int (*__cmp) (const struct dirent **,
+        const struct dirent **))
+     __attribute__ ((__nonnull__ (2, 3)));
+extern int scandirat64 (int __dfd, const char *__restrict __dir,
+   struct dirent64 ***__restrict __namelist,
+   int (*__selector) (const struct dirent64 *),
+   int (*__cmp) (const struct dirent64 **,
+          const struct dirent64 **))
+     __attribute__ ((__nonnull__ (2, 3)));
+extern int alphasort (const struct dirent **__e1,
+        const struct dirent **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int alphasort64 (const struct dirent64 **__e1,
+   const struct dirent64 **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern __ssize_t getdirentries (int __fd, char *__restrict __buf,
+    size_t __nbytes,
+    __off_t *__restrict __basep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern __ssize_t getdirentries64 (int __fd, char *__restrict __buf,
+      size_t __nbytes,
+      __off64_t *__restrict __basep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int versionsort (const struct dirent **__e1,
+   const struct dirent **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int versionsort64 (const struct dirent64 **__e1,
+     const struct dirent64 **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+
+typedef __gid_t gid_t;
+struct group
+  {
+    char *gr_name;
+    char *gr_passwd;
+    __gid_t gr_gid;
+    char **gr_mem;
+  };
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+extern void setgrent (void);
+extern void endgrent (void);
+extern struct group *getgrent (void);
+extern struct group *fgetgrent (FILE *__stream);
+extern int putgrent (const struct group *__restrict __p,
+       FILE *__restrict __f);
+extern struct group *getgrgid (__gid_t __gid);
+extern struct group *getgrnam (const char *__name);
+extern int getgrent_r (struct group *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct group **__restrict __result);
+extern int getgrgid_r (__gid_t __gid, struct group *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct group **__restrict __result);
+extern int getgrnam_r (const char *__restrict __name,
+         struct group *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct group **__restrict __result);
+extern int fgetgrent_r (FILE *__restrict __stream,
+   struct group *__restrict __resultbuf,
+   char *__restrict __buffer, size_t __buflen,
+   struct group **__restrict __result);
+extern int setgroups (size_t __n, const __gid_t *__groups) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgrouplist (const char *__user, __gid_t __group,
+    __gid_t *__groups, int *__ngroups);
+extern int initgroups (const char *__user, __gid_t __group);
+
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef __uid_t uid_t;
+struct passwd
+{
+  char *pw_name;
+  char *pw_passwd;
+  __uid_t pw_uid;
+  __gid_t pw_gid;
+  char *pw_gecos;
+  char *pw_dir;
+  char *pw_shell;
+};
+extern void setpwent (void);
+extern void endpwent (void);
+extern struct passwd *getpwent (void);
+extern struct passwd *fgetpwent (FILE *__stream);
+extern int putpwent (const struct passwd *__restrict __p,
+       FILE *__restrict __f);
+extern struct passwd *getpwuid (__uid_t __uid);
+extern struct passwd *getpwnam (const char *__name);
+extern int getpwent_r (struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int getpwuid_r (__uid_t __uid,
+         struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int getpwnam_r (const char *__restrict __name,
+         struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int fgetpwent_r (FILE *__restrict __stream,
+   struct passwd *__restrict __resultbuf,
+   char *__restrict __buffer, size_t __buflen,
+   struct passwd **__restrict __result);
+extern int getpw (__uid_t __uid, char *__buffer);
+
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __dev_t dev_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct winsize
+  {
+    unsigned short int ws_row;
+    unsigned short int ws_col;
+    unsigned short int ws_xpixel;
+    unsigned short int ws_ypixel;
+  };
+struct termio
+  {
+    unsigned short int c_iflag;
+    unsigned short int c_oflag;
+    unsigned short int c_cflag;
+    unsigned short int c_lflag;
+    unsigned char c_line;
+    unsigned char c_cc[8];
+};
+extern int ioctl (int __fd, unsigned long int __request, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct cache_t;
+struct dnode;
+struct globals;
+struct id_to_name_map_t;
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+struct uni_stat_t;
+struct winsize;
+static char append_char(unsigned int mode);
+static const char * bb_basename(const char *name);
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+struct group * bb_internal_getgrgid(unsigned int);
+struct passwd * bb_internal_getpwuid(unsigned int);
+static const char * bb_mode_string(unsigned int mode);
+static void bb_perror_msg(const char *s, ...);
+static signed int bb_putchar(signed int ch);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int bb_wcwidth(unsigned int ucs);
+static char bold(unsigned int mode);
+static unsigned int calc_name_len(const char *name);
+static signed long int calculate_blocks(struct dnode **dn);
+static char * concat_path_file(const char *path, const char *filename);
+static unsigned int count_dirs(struct dnode **dn, signed int which);
+static void dfree(struct dnode **dnp);
+static void display_files(struct dnode **dn, unsigned int nfiles);
+static unsigned int display_single(struct dnode *dn);
+static struct dnode ** dnalloc(unsigned int num);
+static void dnsort(struct dnode **dn, signed int size);
+static signed int fflush_all(void);
+static char fgcolor(unsigned int mode);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static char * get_cached(struct cache_t *cp, unsigned int id, char * (*x2x_utoa)(unsigned int));
+char * x2x_utoa$object(unsigned int);
+static const char * get_cached_groupname(unsigned int gid);
+static const char * get_cached_username(unsigned int uid);
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static char * gid2group(unsigned int gid);
+static char * gid2group_utoa(unsigned int gid);
+static signed int index_in_substrings(const char *strings, const char *key);
+static void init_unicode(void);
+static char * last_char_is(const char *s, signed int c);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit);
+static const char * mbstowc_internal(signed int *res, const char *src);
+static struct dnode * my_stat(const char *fullname, const char *name, signed int force_follow);
+static unsigned int print_name(const char *name);
+static const char * printable_string(struct uni_stat_t *stats, const char *str);
+static void reinit_unicode(const char *LANG);
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void scan_and_display_dirs_recur(struct dnode **dn, signed int first);
+static struct dnode ** scan_one_dir(const char *path, unsigned int *nfiles_p);
+static void sort_and_display_files(struct dnode **dn, unsigned int nfiles);
+static signed int sortcmp(const void *a, const void *b);
+static struct dnode ** splitdnarray(struct dnode **dn, signed int which);
+static char * uid2uname(unsigned int uid);
+static char * uid2uname_utoa(unsigned int uid);
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src);
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags);
+static char * utoa(unsigned int n);
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen);
+static struct __dirstream * warn_opendir(const char *path);
+static unsigned long int wcrtomb_internal(char *s, signed int wc);
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err);
+static char * xasprintf(const char *format, ...);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_readlink(const char *path);
+static char * xmalloc_readlink_or_warn(const char *path);
+static void * xrealloc(void *ptr, unsigned long int size);
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx);
+static char * xstrndup(const char *s, signed int n);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct cache_t
+{
+  struct id_to_name_map_t *cache;
+  signed int size;
+};
+struct dnode
+{
+  const char *name;
+  const char *fullname;
+  struct dnode *dn_next;
+  signed char fname_allocated;
+  unsigned int dn_mode_lstat;
+  unsigned int dn_mode_stat;
+  unsigned int dn_mode;
+  signed long int dn_size;
+  signed long int dn_atime;
+  signed long int dn_mtime;
+  signed long int dn_ctime;
+  unsigned long int dn_ino;
+  signed long int dn_blocks;
+  unsigned long int dn_nlink;
+  unsigned int dn_uid;
+  unsigned int dn_gid;
+  signed int dn_rdev_maj;
+  signed int dn_rdev_min;
+};
+struct globals
+{
+  signed char show_color;
+  signed char exit_code;
+  unsigned int all_fmt;
+  unsigned int terminal_width;
+  signed long int current_time_t;
+};
+struct id_to_name_map_t
+{
+  unsigned int id;
+  char name[28l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+struct uni_stat_t
+{
+  unsigned int byte_count;
+  unsigned int unicode_count;
+  unsigned int unicode_width;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static char bb_common_bufsiz1[8193l];
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static struct cache_t groupname;
+static char local_buf[(signed long int)(sizeof(signed int) * 3) ];
+static signed char logmode = (signed char)1;
+static const char ls_options[32l] = { (const char)67, (const char)97, (const char)100, (const char)105, (const char)108, (const char)49, (const char)103, (const char)110, (const char)115, (const char)120, (const char)81, (const char)65, (const char)107, (const char)99, (const char)101, (const char)116, (const char)117, (const char)83, (const char)88, (const char)114, (const char)118, (const char)70, (const char)112, (const char)82, (const char)76, (const char)72, (const char)104, (const char)84, (const char)58, (const char)119, (const char)58, (const char)0 };
+static const char mode_chars[7l] = { (const char)114, (const char)119, (const char)120, (const char)83, (const char)84, (const char)115, (const char)116 };
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static const unsigned int opt_flags[25l] = { (const unsigned int)524288, (const unsigned int)(16384 | 32768), (const unsigned int)65536, (const unsigned int)1, (const unsigned int)(1436 | 1048576), (const unsigned int)1572864, (const unsigned int)(1436 | 1048576), (const unsigned int)(32 | 1436 | 1048576),
+    (const unsigned int)2, (const unsigned int)(262144 | 524288), (const unsigned int)0, (const unsigned int)16384, (const unsigned int)(0 * (64 | 1572864)),
+    (const unsigned int)(2097152 | 1 * 50331648),
+    (const unsigned int)512, (const unsigned int)(1 * 67108864), (const unsigned int)(4194304 | 1 * 33554432),
+    (const unsigned int)16777216, (const unsigned int)100663296, (const unsigned int)8388608, (const unsigned int)83886080, (const unsigned int)(2048 | 4096), (const unsigned int)2048, (const unsigned int)131072, 1u << 31 };
+static unsigned int option_mask32;
+static const char type_chars[16l] = { (const char)63, (const char)112, (const char)99, (const char)63, (const char)100, (const char)63, (const char)98, (const char)63, (const char)45, (const char)63, (const char)108, (const char)63, (const char)115, (const char)63, (const char)63, (const char)63 };
+static unsigned char unicode_status;
+static struct cache_t username;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static char append_char(unsigned int mode)
+{
+  if((2048u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+    return (char)0;
+  if((61440u & mode) == 16384u)
+    return (char)47;
+  if((4096u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+    return (char)0;
+  if((61440u & mode) == 32768u)
+  {
+    if(!((73u & mode) == 0u))
+      return (char)42;
+  }
+  if((signed long int)(15u & mode >> 12) < 17l)
+    (void)0;
+  else
+    __VERIFIER_error();
+  return ""[(signed long int)(mode >> 12 & (unsigned int)15)];
+}
+static const char * bb_basename(const char *name)
+{
+  const char *cp;
+  cp=strrchr(name, 47);
+  if(!(cp == ((const char *)((void *)0))))
+    return cp + (signed long int)1;
+  return name;
+}
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static const char * bb_mode_string(unsigned int mode)
+{
+  static char buf[12l];
+  char *p = buf;
+  signed int i;
+  signed int j;
+  signed int k;
+  signed int m;
+  *p = type_chars[(signed long int)(mode >> 12 & (unsigned int)15)];
+  i = 0;
+  m = 256;
+  do
+  {
+    k = 0;
+    j = k;
+    do
+    {
+      p = p + 1l;
+      *p = (char)45;
+      if(!((mode & (unsigned int)m) == 0u))
+      {
+        *p = mode_chars[(signed long int)j];
+        k = j;
+      }
+      m = m >> 1;
+      j = j + 1;
+    }
+    while(j < 3);
+    i = i + 1;
+    if(!((mode & (unsigned int)(4096 >> i)) == 0u))
+      *p = mode_chars[(signed long int)(3 + (k & 2) + (signed int)(i == 3))];
+  }
+  while(i < 3);
+  (void)0;
+  return buf;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int bb_wcwidth(unsigned int ucs)
+{
+  if(ucs == 0u)
+    return 0;
+  if(!((4294967167u & ucs) < 32u))
+  {
+    if(ucs == 127u)
+      goto __CPROVER_DUMP_L2;
+  }
+  else
+  {
+  __CPROVER_DUMP_L2:
+    ;
+    return -1;
+  }
+  if(ucs > 767u)
+    return -1;
+  return 1;
+}
+static char bold(unsigned int mode)
+{
+  if((61440u & mode) == 32768u)
+  {
+    if(!((73u & mode) == 0u))
+      return "\001"[(signed long int)(61440 >> 12 & 15)];
+  }
+  if((signed long int)(15u & mode >> 12) < 17l)
+    (void)0;
+  else
+    __VERIFIER_error();
+  return "\001"[(signed long int)(mode >> 12 & (unsigned int)15)];
+}
+static unsigned int calc_name_len(const char *name)
+{
+  unsigned int len;
+  struct uni_stat_t uni_stat;
+  name=printable_string(&uni_stat, name);
+  if((1024u & option_mask32) == 0u)
+    return uni_stat.unicode_width;
+  len = (unsigned int)2 + uni_stat.unicode_width;
+  _Bool tmp_if_expr$1;
+  while((_Bool)1)
+  {
+    if((signed int)*name == 0)
+      break;
+    if((signed int)*name == 34)
+      tmp_if_expr$1 = 1 != 0;
+    else
+    {
+      tmp_if_expr$1 = ((signed int)*name == 92 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      len = len + 1u;
+    name = name + 1l;
+  }
+  return len;
+}
+static signed long int calculate_blocks(struct dnode **dn)
+{
+  unsigned long int blocks = (unsigned long int)1;
+  if(!(dn == ((struct dnode **)((void *)0))))
+    while((_Bool)1)
+    {
+      if(*dn == ((struct dnode *)((void *)0)))
+        break;
+      blocks = blocks + (unsigned long int)(*dn)->dn_blocks;
+      dn = dn + 1l;
+    }
+  return (signed long int)(blocks >> 1);
+}
+static char * concat_path_file(const char *path, const char *filename)
+{
+  char *lc;
+  if(path == ((const char *)((void *)0)))
+    path = "";
+  lc=last_char_is(path, 47);
+  for( ; (signed int)*filename == 47; filename = filename + 1l)
+    ;
+  char *return_value_xasprintf$1;
+  return_value_xasprintf$1=xasprintf("%s%s%s", path, lc == (char *)((void *)0) ? "/" : "", filename);
+  return return_value_xasprintf$1;
+}
+static unsigned int count_dirs(struct dnode **dn, signed int which)
+{
+  unsigned int dirs;
+  unsigned int all;
+  if(dn == ((struct dnode **)((void *)0)))
+    return (unsigned int)0;
+  all = (unsigned int)0;
+  dirs = all;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$2;
+  while((_Bool)1)
+  {
+    if(*dn == ((struct dnode *)((void *)0)))
+      break;
+    const char *name;
+    all = all + 1u;
+    if((61440u & (*dn)->dn_mode) == 16384u)
+    {
+      name = (*dn)->name;
+      if(!(which == 2))
+        tmp_if_expr$1 = 1 != 0;
+      else
+      {
+        tmp_if_expr$1 = ((signed int)name[(signed long int)0] != 46 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$1 == (_Bool)0))
+        tmp_if_expr$4 = 1 != 0;
+      else
+      {
+        if(!((signed int)*(1l + name) == 0))
+        {
+          if(!((signed int)*(1l + name) == 46))
+            tmp_if_expr$2 = 1 != 0;
+          else
+          {
+            tmp_if_expr$2 = ((signed int)name[(signed long int)2] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          tmp_if_expr$3 = (tmp_if_expr$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$3 = 0 != 0;
+        tmp_if_expr$4 = (tmp_if_expr$3 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$4 == (_Bool)0))
+        dirs = dirs + 1u;
+    }
+    dn = dn + 1l;
+  }
+  return which != 0 ? dirs : all - dirs;
+}
+static void dfree(struct dnode **dnp)
+{
+  unsigned int i;
+  if(dnp == ((struct dnode **)((void *)0)))
+    return;
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+    if(dnp[(signed long int)i] == ((struct dnode *)((void *)0)))
+      break;
+    struct dnode *cur = dnp[(signed long int)i];
+    if(!((signed int)cur->fname_allocated == 0))
+      free((void *)(char *)cur->fullname);
+    free((void *)cur);
+    i = i + 1u;
+  }
+  free((void *)dnp);
+}
+static void display_files(struct dnode **dn, unsigned int nfiles)
+{
+  unsigned int i;
+  unsigned int ncols;
+  unsigned int nrows;
+  unsigned int row;
+  unsigned int nc;
+  unsigned int column;
+  unsigned int nexttab;
+  unsigned int column_width = (unsigned int)0;
+  if(!((1048576u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ncols = (unsigned int)1;
+  else
+  {
+    i = (unsigned int)0;
+    while((_Bool)1)
+    {
+      if(dn[(signed long int)i] == ((struct dnode *)((void *)0)))
+        break;
+      signed int len;
+      unsigned int return_value_calc_name_len$1;
+      return_value_calc_name_len$1=calc_name_len(dn[(signed long int)i]->name);
+      len = (signed int)return_value_calc_name_len$1;
+      if(!(column_width >= (unsigned int)len))
+        column_width = (unsigned int)len;
+      i = i + 1u;
+    }
+    column_width = column_width + (unsigned int)(1 + ((((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)1) != 0u ? 8 : 0) + ((((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)2) != 0u ? 5 : 0));
+    if(!(column_width == 0u))
+      (void)0;
+    else
+      __VERIFIER_error();
+    ncols = (unsigned int)((struct globals *)&bb_common_bufsiz1)->terminal_width / column_width;
+  }
+  if(ncols > 1u)
+  {
+    if(!(ncols == 0u))
+      (void)0;
+    else
+      __VERIFIER_error();
+    nrows = nfiles / ncols;
+    if(!(ncols * nrows >= nfiles))
+      nrows = nrows + 1u;
+  }
+  else
+  {
+    nrows = nfiles;
+    ncols = (unsigned int)1;
+  }
+  column = (unsigned int)0;
+  nexttab = (unsigned int)0;
+  row = (unsigned int)0;
+  for( ; !(row >= nrows); row = row + 1u)
+  {
+    nc = (unsigned int)0;
+    for( ; !(nc >= ncols); nc = nc + 1u)
+    {
+      if(!((262144u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+        i = row * ncols + nc;
+      else
+        i = nc * nrows + row;
+      if(!(i >= nfiles))
+      {
+        if(column > 0u)
+        {
+          nexttab = nexttab - column;
+          printf("%*s ", nexttab, "");
+          column = column + nexttab + (unsigned int)1;
+        }
+        nexttab = column + column_width;
+        unsigned int return_value_display_single$2;
+        return_value_display_single$2=display_single(dn[(signed long int)i]);
+        column = column + return_value_display_single$2;
+      }
+    }
+    putchar(10);
+    column = (unsigned int)0;
+  }
+}
+static unsigned int display_single(struct dnode *dn)
+{
+  unsigned int column = (unsigned int)0;
+  char *lpath;
+  struct stat statbuf;
+  char append;
+  append=append_char(dn->dn_mode);
+  lpath = (char *)((void *)0);
+  if(!((1024u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    if((61440u & dn->dn_mode) == 40960u)
+      lpath=xmalloc_readlink_or_warn(dn->fullname);
+  }
+  signed int return_value_printf$1;
+  if(!((1u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    return_value_printf$1 = printf("%7llu ", (signed long long int)dn->dn_ino);
+    column = column + (unsigned int)return_value_printf$1;
+  }
+  signed int return_value_printf$2;
+  if(!((2u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    return_value_printf$2 = printf("%6lu ", (signed long int)(dn->dn_blocks >> 1));
+    column = column + (unsigned int)return_value_printf$2;
+  }
+  const char *return_value_bb_mode_string$3;
+  signed int return_value_printf$4;
+  if(!((4u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    return_value_bb_mode_string$3=bb_mode_string(dn->dn_mode);
+    return_value_printf$4 = printf("%-10s ", (char *)return_value_bb_mode_string$3);
+    column = column + (unsigned int)return_value_printf$4;
+  }
+  signed int return_value_printf$5;
+  if(!((8u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    return_value_printf$5 = printf("%4lu ", (signed long int)dn->dn_nlink);
+    column = column + (unsigned int)return_value_printf$5;
+  }
+  signed int return_value_printf$6;
+  signed int return_value_printf$7;
+  if(!((32u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    if(!((64u & option_mask32) == 0u))
+    {
+      return_value_printf$6 = printf("%-8u ", (signed int)dn->dn_gid);
+      column = column + (unsigned int)return_value_printf$6;
+    }
+    else
+    {
+      return_value_printf$7 = printf("%-8u %-8u ", (signed int)dn->dn_uid, (signed int)dn->dn_gid);
+      column = column + (unsigned int)return_value_printf$7;
+    }
+  }
+  else
+    if(!((16u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      if(!((64u & option_mask32) == 0u))
+      {
+        const char *return_value_get_cached_groupname$8;
+        return_value_get_cached_groupname$8=get_cached_groupname(dn->dn_gid);
+        signed int return_value_printf$9 = printf("%-8.8s ", return_value_get_cached_groupname$8);
+        column = column + (unsigned int)return_value_printf$9;
+      }
+      else
+      {
+        const char *return_value_get_cached_username$10;
+        return_value_get_cached_username$10=get_cached_username(dn->dn_uid);
+        const char *return_value_get_cached_groupname$11;
+        return_value_get_cached_groupname$11=get_cached_groupname(dn->dn_gid);
+        signed int return_value_printf$12 = printf("%-8.8s %-8.8s ", return_value_get_cached_username$10, return_value_get_cached_groupname$11);
+        column = column + (unsigned int)return_value_printf$12;
+      }
+    }
+  _Bool tmp_if_expr$17;
+  if(!((128u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    if((61440u & dn->dn_mode) == 24576u)
+      tmp_if_expr$17 = 1 != 0;
+    else
+    {
+      tmp_if_expr$17 = ((dn->dn_mode & (unsigned int)61440) == (unsigned int)8192 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$17 == (_Bool)0))
+    {
+      signed int return_value_printf$13;
+      return_value_printf$13 = printf("%4u, %3u ", dn->dn_rdev_maj, dn->dn_rdev_min);
+      column = column + (unsigned int)return_value_printf$13;
+    }
+    else
+      if(!((67108864u & option_mask32) == 0u))
+      {
+        const char *return_value_make_human_readable_str$14;
+        return_value_make_human_readable_str$14=make_human_readable_str((unsigned long long int)dn->dn_size, (unsigned long int)1, (unsigned long int)0);
+        signed int return_value_printf$15 = printf("%7s ", return_value_make_human_readable_str$14);
+        column = column + (unsigned int)return_value_printf$15;
+      }
+      else
+      {
+        signed int return_value_printf$16;
+        return_value_printf$16 = printf("%9lu ", dn->dn_size);
+        column = column + (unsigned int)return_value_printf$16;
+      }
+  }
+  if(!((768u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    char *filetime;
+    signed long int ttime;
+    ttime = dn->dn_mtime;
+    if(!((4194304u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+      ttime = dn->dn_atime;
+    if(!((2097152u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      ttime = dn->dn_ctime;
+    }
+    filetime=ctime(&ttime);
+    if(!((512u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      signed int return_value_printf$18 = printf("%.24s ", filetime);
+      column = column + (unsigned int)return_value_printf$18;
+    }
+    else
+    {
+      signed long int age = ((struct globals *)&bb_common_bufsiz1)->current_time_t - ttime;
+      printf("%.6s ", filetime + (signed long int)4);
+      if(age < 15768000l)
+      {
+        if(!(age > -900l))
+          goto __CPROVER_DUMP_L55;
+        printf("%.5s ", filetime + (signed long int)11);
+      }
+      else
+      {
+      __CPROVER_DUMP_L55:
+        ;
+        printf(" %.4s ", filetime + (signed long int)20);
+      }
+      column = column + (unsigned int)13;
+    }
+  }
+  signed int return_value_lstat$19;
+  if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+  {
+    unsigned int mode;
+    mode = dn->dn_mode_lstat;
+    if(mode == 0u)
+    {
+      return_value_lstat$19=lstat(dn->fullname, &statbuf);
+      if(return_value_lstat$19 == 0)
+        mode = statbuf.st_mode;
+    }
+    char return_value_bold$20;
+    return_value_bold$20=bold(mode);
+    char return_value_fgcolor$21;
+    return_value_fgcolor$21=fgcolor(mode);
+    printf("\033[%u;%um", return_value_bold$20, return_value_fgcolor$21);
+  }
+  unsigned int return_value_print_name$22;
+  return_value_print_name$22=print_name(dn->name);
+  column = column + return_value_print_name$22;
+  if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+    printf("\033[0m");
+  _Bool tmp_if_expr$26;
+  signed int return_value_stat$23;
+  if(!(lpath == ((char *)((void *)0))))
+  {
+    printf(" -> ");
+    if(!((2048u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+      tmp_if_expr$26 = 1 != 0;
+    else
+      tmp_if_expr$26 = ((signed int)((struct globals *)&bb_common_bufsiz1)->show_color != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$26 == (_Bool)0))
+    {
+      unsigned int display_single$$1$$7$$1$$mode;
+      display_single$$1$$7$$1$$mode = dn->dn_mode_stat;
+      if(display_single$$1$$7$$1$$mode == 0u)
+      {
+        return_value_stat$23=stat(dn->fullname, &statbuf);
+        if(return_value_stat$23 == 0)
+          display_single$$1$$7$$1$$mode = statbuf.st_mode;
+      }
+      append=append_char(display_single$$1$$7$$1$$mode);
+      if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+      {
+        char return_value_bold$24;
+        return_value_bold$24=bold(display_single$$1$$7$$1$$mode);
+        char return_value_fgcolor$25;
+        return_value_fgcolor$25=fgcolor(display_single$$1$$7$$1$$mode);
+        printf("\033[%u;%um", return_value_bold$24, return_value_fgcolor$25);
+      }
+    }
+    unsigned int return_value_print_name$27;
+    return_value_print_name$27=print_name(lpath);
+    column = column + return_value_print_name$27 + (unsigned int)4;
+    free((void *)lpath);
+    if(!((signed int)((struct globals *)&bb_common_bufsiz1)->show_color == 0))
+      printf("\033[0m");
+  }
+  if(!((2048u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+  {
+    if(!((signed int)append == 0))
+    {
+      putchar((signed int)append);
+      column = column + 1u;
+    }
+  }
+  return column;
+}
+static struct dnode ** dnalloc(unsigned int num)
+{
+  if(num < 1u)
+    return (struct dnode **)((void *)0);
+  num = num + 1u;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc((unsigned long int)num * sizeof(struct dnode *) );
+  return (struct dnode **)return_value_xzalloc$1;
+}
+static void dnsort(struct dnode **dn, signed int size)
+{
+  qsort((void *)dn, (unsigned long int)size, sizeof(struct dnode *) , sortcmp);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static char fgcolor(unsigned int mode)
+{
+  if((61440u & mode) == 32768u)
+  {
+    if(!((73u & mode) == 0u))
+      return "\037##%\"%##"[(signed long int)(61440 >> 12 & 15)];
+  }
+  if((signed long int)(15u & mode >> 12) < 17l)
+    (void)0;
+  else
+    __VERIFIER_error();
+  return "\037##%\"%##"[(signed long int)(mode >> 12 & (unsigned int)15)];
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static char * get_cached(struct cache_t *cp, unsigned int id, char * (*x2x_utoa)(unsigned int))
+{
+  signed int i = 0;
+  for( ; !(i >= cp->size); i = i + 1)
+    if((cp->cache + (signed long int)i)->id == id)
+      return (cp->cache + (signed long int)i)->name;
+  signed int tmp_post$1 = cp->size;
+  cp->size = cp->size + 1;
+  i = tmp_post$1;
+  void *return_value_xrealloc_vector_helper$2;
+  return_value_xrealloc_vector_helper$2=xrealloc_vector_helper((void *)cp->cache, (unsigned int)((sizeof(struct id_to_name_map_t) << 8) + (unsigned long int)2), i);
+  cp->cache = (struct id_to_name_map_t *)return_value_xrealloc_vector_helper$2;
+  (cp->cache + (signed long int)i)->id = id;
+  char *return_value;
+  return_value=x2x_utoa(id);
+  safe_strncpy((cp->cache + (signed long int)i)->name, return_value, sizeof(char [28l]) );
+  return (cp->cache + (signed long int)i)->name;
+}
+static const char * get_cached_groupname(unsigned int gid)
+{
+  char *return_value_get_cached$1;
+  return_value_get_cached$1=get_cached(&groupname, gid, gid2group_utoa);
+  return return_value_get_cached$1;
+}
+static const char * get_cached_username(unsigned int uid)
+{
+  char *return_value_get_cached$1;
+  return_value_get_cached$1=get_cached(&username, uid, uid2uname_utoa);
+  return return_value_get_cached$1;
+}
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height)
+{
+  struct winsize win;
+  signed int err;
+  win.ws_row = (unsigned short int)0;
+  win.ws_col = (unsigned short int)0;
+  signed int return_value_ioctl$1;
+  return_value_ioctl$1=ioctl(fd, (unsigned long int)21523, &win);
+  err = (signed int)(return_value_ioctl$1 != 0 ? (signed int)(1 != 0) : ((signed int)win.ws_row == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)));
+  signed int return_value_wh_helper$2;
+  if(!(height == ((unsigned int *)((void *)0))))
+  {
+    return_value_wh_helper$2=wh_helper((signed int)win.ws_row, 24, "LINES", &err);
+    *height = (unsigned int)return_value_wh_helper$2;
+  }
+  signed int return_value_wh_helper$3;
+  if(!(width == ((unsigned int *)((void *)0))))
+  {
+    return_value_wh_helper$3=wh_helper((signed int)win.ws_col, 80, "COLUMNS", &err);
+    *width = (unsigned int)return_value_wh_helper$3;
+  }
+  return err;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static char * gid2group(unsigned int gid)
+{
+  struct group *gr;
+  gr=bb_internal_getgrgid(gid);
+  char *tmp_if_expr$1;
+  if(!(gr == ((struct group *)((void *)0))))
+    tmp_if_expr$1 = gr->gr_name;
+  else
+    tmp_if_expr$1 = (char *)((void *)0);
+  return tmp_if_expr$1;
+}
+static char * gid2group_utoa(unsigned int gid)
+{
+  char *name;
+  name=gid2group(gid);
+  char *tmp_if_expr$2;
+  char *return_value_utoa$1;
+  if(!(name == ((char *)((void *)0))))
+    tmp_if_expr$2 = name;
+  else
+  {
+    return_value_utoa$1=utoa(gid);
+    tmp_if_expr$2 = return_value_utoa$1;
+  }
+  return tmp_if_expr$2;
+}
+static signed int index_in_substrings(const char *strings, const char *key)
+{
+  signed int matched_idx = -1;
+  signed int len;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(key);
+  len = (const signed int)return_value_strlen$1;
+  if(!(len == 0))
+  {
+    signed int idx = 0;
+    while(!((signed int)*strings == 0))
+    {
+      signed int return_value_strncmp$2;
+      return_value_strncmp$2=strncmp(strings, key, (unsigned long int)len);
+      if(return_value_strncmp$2 == 0)
+      {
+        if((signed int)strings[(signed long int)len] == 0)
+          return idx;
+        if(matched_idx >= 0)
+          return -1;
+        matched_idx = idx;
+      }
+      unsigned long int return_value_strlen$3;
+      return_value_strlen$3=strlen(strings);
+      strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+      idx = idx + 1;
+    }
+  }
+  return matched_idx;
+}
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LC_CTYPE");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LANG");
+    reinit_unicode(s);
+  }
+}
+static char * last_char_is(const char *s, signed int c)
+{
+  if(!(s == ((const char *)((void *)0))))
+  {
+    if(!((signed int)*s == 0))
+    {
+      unsigned long int sz;
+      unsigned long int return_value_strlen$1;
+      return_value_strlen$1=strlen(s);
+      sz = return_value_strlen$1 - (unsigned long int)1;
+      s = s + (signed long int)sz;
+      if((signed int)*s == c)
+        return (char *)s;
+    }
+  }
+  return (char *)((void *)0);
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct dnode **dnd;
+  struct dnode **dnf;
+  struct dnode **dnp;
+  struct dnode *dn;
+  struct dnode *cur;
+  unsigned int opt;
+  unsigned int nfiles;
+  unsigned int dnfiles;
+  unsigned int dndirs;
+  unsigned int i;
+  static const char color_str[34l] = { (const char)97, (const char)108, (const char)119, (const char)97, (const char)121, (const char)115, (const char)0, (const char)121, (const char)101, (const char)115, (const char)0, (const char)102, (const char)111, (const char)114, (const char)99, (const char)101, (const char)0, (const char)97, (const char)117, (const char)116, (const char)111, (const char)0, (const char)116, (const char)116, (const char)121, (const char)0, (const char)105, (const char)102, (const char)45, (const char)116, (const char)116, (const char)121, (const char)0, (const char)0 };
+  const char *color_opt = color_str;
+  do
+  {
+    memset((void *)&(*((struct globals *)&bb_common_bufsiz1)), 0, sizeof(struct globals) );
+    ((struct globals *)&bb_common_bufsiz1)->terminal_width = (unsigned int)80;
+    time(&((struct globals *)&bb_common_bufsiz1)->current_time_t);
+  }
+  while((_Bool)0);
+  init_unicode();
+  ((struct globals *)&bb_common_bufsiz1)->all_fmt = (unsigned int)0;
+  get_terminal_width_height(0, &((struct globals *)&bb_common_bufsiz1)->terminal_width, (unsigned int *)((void *)0));
+  ((struct globals *)&bb_common_bufsiz1)->terminal_width = ((struct globals *)&bb_common_bufsiz1)->terminal_width - 1u;
+  static const char ls_longopts[9l] = { (const char)99, (const char)111, (const char)108, (const char)111, (const char)114, (const char)0, (const char)2, (const char)255, (const char)0 };
+  applet_long_options = ls_longopts;
+  opt_complementary = "el:t-S:S-t:H-L:L-H:C-xl:x-Cl:l-xC:C-1:1-C:x-1:1-x:c-u:u-c:w+";
+  opt=getopt32(argv, ls_options, ((void *)0), &((struct globals *)&bb_common_bufsiz1)->terminal_width, &color_opt);
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+    if((signed long int)i < 25l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(opt_flags[(signed long int)i] == 2147483648u)
+      break;
+    if(!((opt & (unsigned int)(1 << i)) == 0u))
+    {
+      unsigned int flags = opt_flags[(signed long int)i];
+      if(!((1572864u & flags) == 0u))
+        ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~1572864;
+      if(!((117440512u & flags) == 0u))
+        ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~117440512;
+      if(!((6291456u & flags) == 0u))
+        ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~6291456;
+      ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt | flags;
+    }
+    i = i + 1u;
+  }
+  signed int return_value_isatty$8;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$6;
+  signed int tmp_statement_expression$1;
+  _Bool tmp_if_expr$2;
+  signed int tmp_if_expr$5;
+  signed int tmp_statement_expression$3;
+  signed int return_value___builtin_strcmp$4;
+  if((_Bool)0)
+  {
+    return_value_isatty$8=isatty(1);
+    if(!(return_value_isatty$8 == 0))
+    {
+      char *p;
+      p=getenv("LS_COLORS");
+      if(p == ((char *)((void *)0)))
+        tmp_if_expr$7 = 1 != 0;
+      else
+      {
+        if(!((signed int)*p == 0))
+        {
+          unsigned long int __s1_len;
+          unsigned long int __s2_len;
+          if((_Bool)1)
+          {
+            if(!((unsigned long int)("none" + 1l) + -((unsigned long int)"none") == 1ul))
+              goto __CPROVER_DUMP_L13;
+            __s2_len=strlen("none");
+            tmp_if_expr$2 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          else
+          {
+          __CPROVER_DUMP_L13:
+            ;
+            tmp_if_expr$2 = 0 != 0;
+          }
+          if(!(tmp_if_expr$2 == (_Bool)0))
+          {
+            const char *__s2 = (const char *)p;
+            signed int __result;
+            __result = (signed int)((const char *)"none")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+            if(__s2_len > 0ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"none")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+                if(__s2_len > 1ul)
+                {
+                  if(__result == 0)
+                  {
+                    __result = (signed int)((const char *)"none")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                    if(__s2_len > 2ul)
+                    {
+                      if(__result == 0)
+                      {
+                        __result = (signed int)((const char *)"none")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            tmp_statement_expression$3 = __result;
+            tmp_if_expr$5 = -tmp_statement_expression$3;
+          }
+          else
+          {
+            return_value___builtin_strcmp$4=strcmp(p, "none");
+            tmp_if_expr$5 = return_value___builtin_strcmp$4;
+          }
+          tmp_statement_expression$1 = tmp_if_expr$5;
+          tmp_if_expr$6 = (tmp_statement_expression$1 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$6 = 0 != 0;
+        tmp_if_expr$7 = (tmp_if_expr$6 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$7 == (_Bool)0))
+        ((struct globals *)&bb_common_bufsiz1)->show_color = (signed char)1;
+    }
+  }
+  signed int return_value_index_in_substrings$9;
+  signed int return_value_isatty$10;
+  if(!((536870912u & opt) == 0u))
+  {
+    if((signed int)*color_opt == 110)
+      ((struct globals *)&bb_common_bufsiz1)->show_color = (signed char)0;
+    else
+    {
+      return_value_index_in_substrings$9=index_in_substrings(color_str, color_opt);
+      if(!(return_value_index_in_substrings$9 == 0))
+      {
+        if(!(return_value_index_in_substrings$9 == 1))
+        {
+          if(!(return_value_index_in_substrings$9 == 2))
+          {
+            if(!(return_value_index_in_substrings$9 == 3) && !(return_value_index_in_substrings$9 == 4) && !(return_value_index_in_substrings$9 == 5))
+              goto __CPROVER_DUMP_L42;
+            return_value_isatty$10=isatty(1);
+            if(return_value_isatty$10 == 0)
+              goto __CPROVER_DUMP_L41;
+          }
+        }
+      }
+      ((struct globals *)&bb_common_bufsiz1)->show_color = (signed char)1;
+    }
+  }
+__CPROVER_DUMP_L41:
+  ;
+__CPROVER_DUMP_L42:
+  ;
+  if(!((65536u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~131072;
+  if(!((2097152u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~117440512 | (unsigned int)50331648;
+  if(!((4194304u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~117440512 | (unsigned int)33554432;
+  if(!((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 1048576u))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)~(32 | 16 | 512);
+  signed int return_value_isatty$11;
+  if((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+  {
+    return_value_isatty$11=isatty(1);
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt | (unsigned int)(return_value_isatty$11 != 0 ? 524288 : 1572864);
+  }
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)".";
+  }
+  if(!(*(1l + argv) == ((char *)((void *)0))))
+    ((struct globals *)&bb_common_bufsiz1)->all_fmt = ((struct globals *)&bb_common_bufsiz1)->all_fmt | (unsigned int)8192;
+  dn = (struct dnode *)((void *)0);
+  nfiles = (unsigned int)0;
+  _Bool tmp_if_expr$12;
+  while((_Bool)1)
+  {
+    if((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 1048576u)
+      tmp_if_expr$12 = 1 != 0;
+    else
+      tmp_if_expr$12 = ((((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)2) != 0u ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    cur=my_stat(*argv, *argv, (signed int)(!((tmp_if_expr$12 != (_Bool)0 ? (signed int)(1 != 0) : ((option_mask32 & (unsigned int)2097152) != 0u ? (signed int)(1 != 0) : (signed int)(0 != 0))) != 0) ? (signed int)(1 != 0) : ((option_mask32 & (unsigned int)33554432) != 0u ? (signed int)(1 != 0) : (signed int)(0 != 0))));
+    argv = argv + 1l;
+    if(!(cur == ((struct dnode *)((void *)0))))
+    {
+      cur->dn_next = dn;
+      dn = cur;
+      nfiles = nfiles + 1u;
+    }
+    if(*argv == ((char *)((void *)0)))
+      break;
+  }
+  if(nfiles == 0u)
+    return (signed int)((struct globals *)&bb_common_bufsiz1)->exit_code;
+  dnp=dnalloc(nfiles);
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+    dnp[(signed long int)i] = dn;
+    dn = dn->dn_next;
+    if(dn == ((struct dnode *)((void *)0)))
+      break;
+    i = i + 1u;
+  }
+  if(!((65536u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    sort_and_display_files(dnp, nfiles);
+  else
+  {
+    dnd=splitdnarray(dnp, 1);
+    dnf=splitdnarray(dnp, 0);
+    dndirs=count_dirs(dnp, 1);
+    dnfiles = nfiles - dndirs;
+    if(dnfiles > 0u)
+      sort_and_display_files(dnf, dnfiles);
+    if(dndirs > 0u)
+    {
+      dnsort(dnd, (signed int)dndirs);
+      scan_and_display_dirs_recur(dnd, (signed int)(dnfiles == (unsigned int)0));
+    }
+  }
+  return (signed int)((struct globals *)&bb_common_bufsiz1)->exit_code;
+}
+static const char * make_human_readable_str(unsigned long long int val, unsigned long int block_size, unsigned long int display_unit)
+{
+  unsigned int frac;
+  const char *u;
+  const char *fmt;
+  if(val == 0ul)
+    return "0";
+  fmt = "%llu";
+  if(block_size > 1ul)
+    val = val * block_size;
+  frac = (unsigned int)0;
+  static const char unit_chars[9l] = { (const char)0, (const char)75, (const char)77, (const char)71, (const char)84, (const char)80, (const char)69, (const char)90, (const char)89 };
+  u = unit_chars;
+  if(!(display_unit == 0ul))
+  {
+    val = val + display_unit / (unsigned long int)2;
+    val = val / display_unit;
+  }
+  else
+  {
+    for( ; val >= 1024ul; val = val / (unsigned long long int)1024)
+    {
+      fmt = "%llu.%u%c";
+      u = u + 1l;
+      frac = (((unsigned int)val % (unsigned int)1024) * (unsigned int)10 + (unsigned int)(1024 / 2)) / (unsigned int)1024;
+    }
+    if(frac >= 10u)
+    {
+      val = val + 1ull;
+      frac = (unsigned int)0;
+    }
+    if(block_size == 0ul)
+    {
+      if(frac >= 5u)
+        val = val + 1ull;
+      fmt = "%llu%*c";
+      frac = (unsigned int)1;
+    }
+  }
+  static char *str;
+  if(str == ((char *)((void *)0)))
+  {
+    void *return_value_xmalloc$1;
+    return_value_xmalloc$1=xmalloc(sizeof(unsigned long long int) * (unsigned long int)3 + (unsigned long int)2 + (unsigned long int)3);
+    str = (char *)return_value_xmalloc$1;
+  }
+  sprintf(str, fmt, val, frac, *u);
+  return str;
+}
+static const char * mbstowc_internal(signed int *res, const char *src)
+{
+  signed int bytes;
+  unsigned int c;
+  const char *tmp_post$1 = src;
+  src = src + 1l;
+  c = (unsigned int)(unsigned char)*tmp_post$1;
+  if(c <= 127u)
+  {
+    *res = (signed int)c;
+    return src;
+  }
+  bytes = 0;
+  do
+  {
+    c = c << 1;
+    bytes = bytes + 1;
+  }
+  while(bytes < 6 && (128u & c) != 0u);
+  if(bytes == 1)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+  c = (unsigned int)((signed int)(unsigned char)c >> bytes);
+  do
+  {
+    bytes = bytes - 1;
+    if(bytes == 0)
+      break;
+    unsigned int ch = (unsigned int)(unsigned char)*src;
+    if(!((192u & ch) == 128u))
+    {
+      *res = ~((signed int)0);
+      return src;
+    }
+    c = (c << 6) + (ch & (unsigned int)63);
+    src = src + 1l;
+  }
+  while((_Bool)1);
+  if(c <= 127u)
+  {
+    *res = ~((signed int)0);
+    return src;
+  }
+  *res = (signed int)c;
+  return src;
+}
+static struct dnode * my_stat(const char *fullname, const char *name, signed int force_follow)
+{
+  struct stat statbuf;
+  struct dnode *cur;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct dnode) );
+  cur = (struct dnode *)return_value_xzalloc$1;
+  cur->fullname = fullname;
+  cur->name = name;
+  if((16777216u & option_mask32) == 0u)
+  {
+    if(force_follow != 0)
+      goto __CPROVER_DUMP_L5;
+  }
+  else
+  {
+  __CPROVER_DUMP_L5:
+    ;
+    signed int return_value_stat$2;
+    return_value_stat$2=stat(fullname, &statbuf);
+    if(!(return_value_stat$2 == 0))
+    {
+      bb_simple_perror_msg(fullname);
+      ((struct globals *)&bb_common_bufsiz1)->exit_code = (signed char)1;
+      free((void *)cur);
+      return (struct dnode *)((void *)0);
+    }
+    cur->dn_mode_stat = statbuf.st_mode;
+    goto __CPROVER_DUMP_L13;
+  }
+  signed int return_value_lstat$3;
+  return_value_lstat$3=lstat(fullname, &statbuf);
+  if(!(return_value_lstat$3 == 0))
+  {
+    bb_simple_perror_msg(fullname);
+    ((struct globals *)&bb_common_bufsiz1)->exit_code = (signed char)1;
+    free((void *)cur);
+    return (struct dnode *)((void *)0);
+  }
+  cur->dn_mode_lstat = statbuf.st_mode;
+__CPROVER_DUMP_L13:
+  ;
+  cur->dn_mode = statbuf.st_mode;
+  cur->dn_size = statbuf.st_size;
+  cur->dn_atime = statbuf.st_atim.tv_sec;
+  cur->dn_mtime = statbuf.st_mtim.tv_sec;
+  cur->dn_ctime = statbuf.st_ctim.tv_sec;
+  cur->dn_ino = statbuf.st_ino;
+  cur->dn_blocks = statbuf.st_blocks;
+  cur->dn_nlink = statbuf.st_nlink;
+  cur->dn_uid = statbuf.st_uid;
+  cur->dn_gid = statbuf.st_gid;
+  unsigned int return_value_gnu_dev_major$4;
+  return_value_gnu_dev_major$4=gnu_dev_major(statbuf.st_rdev);
+  cur->dn_rdev_maj = (signed int)return_value_gnu_dev_major$4;
+  unsigned int return_value_gnu_dev_minor$5;
+  return_value_gnu_dev_minor$5=gnu_dev_minor(statbuf.st_rdev);
+  cur->dn_rdev_min = (signed int)return_value_gnu_dev_minor$5;
+  return cur;
+}
+static unsigned int print_name(const char *name)
+{
+  unsigned int len;
+  struct uni_stat_t uni_stat;
+  name=printable_string(&uni_stat, name);
+  if((1024u & option_mask32) == 0u)
+  {
+    fputs(name, stdout);
+    return uni_stat.unicode_width;
+  }
+  len = (unsigned int)2 + uni_stat.unicode_width;
+  putchar(34);
+  _Bool tmp_if_expr$1;
+  while((_Bool)1)
+  {
+    if((signed int)*name == 0)
+      break;
+    if((signed int)*name == 34)
+      tmp_if_expr$1 = 1 != 0;
+    else
+    {
+      tmp_if_expr$1 = ((signed int)*name == 92 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+    {
+      putchar(92);
+      len = len + 1u;
+    }
+    putchar((signed int)*name);
+    name = name + 1l;
+  }
+  putchar(34);
+  return len;
+}
+static const char * printable_string(struct uni_stat_t *stats, const char *str)
+{
+  char *dst;
+  const char *s = str;
+  while((_Bool)1)
+  {
+    unsigned char c = *s;
+    if((signed int)c == 0)
+    {
+      if(!(stats == ((struct uni_stat_t *)((void *)0))))
+      {
+        stats->byte_count = (unsigned int)(s - str);
+        stats->unicode_count = (unsigned int)(s - str);
+        stats->unicode_width = (unsigned int)(s - str);
+      }
+      return str;
+    }
+    if((signed int)c < 32)
+      break;
+    if((signed int)c >= 127)
+      break;
+    s = s + 1l;
+  }
+  dst=unicode_conv_to_printable(stats, str);
+  static unsigned int cur_saved;
+  static char *saved[4l];
+  free((void *)saved[(signed long int)cur_saved]);
+  saved[(signed long int)cur_saved] = dst;
+  cur_saved = cur_saved + (unsigned int)1 & (unsigned int)(sizeof(char *[4l]) / sizeof(char *) ) - (unsigned int)1;
+  return dst;
+}
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)((void *)0)))
+    tmp_if_expr$4 = 1 != 0;
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)((void *)0))))
+      tmp_if_expr$3 = 1 != 0;
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)((void *)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+  unicode_status = (unsigned char)2;
+}
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size)
+{
+  if(size == 0ul)
+    return dst;
+  size = size - 1ul;
+  dst[(signed long int)size] = (char)0;
+  char *return_value_strncpy$1;
+  return_value_strncpy$1=strncpy(dst, src, size);
+  return return_value_strncpy$1;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void scan_and_display_dirs_recur(struct dnode **dn, signed int first)
+{
+  unsigned int nfiles;
+  struct dnode **subdnp;
+  signed long int return_value_calculate_blocks$1;
+  while((_Bool)1)
+  {
+    if(*dn == ((struct dnode *)((void *)0)))
+      break;
+    if(!((139264u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+    {
+      if(first == 0)
+        bb_putchar(10);
+      first = 0;
+      printf("%s:\n", (*dn)->fullname);
+    }
+    subdnp=scan_one_dir((*dn)->fullname, &nfiles);
+    if((1572864u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 1048576u)
+    {
+      return_value_calculate_blocks$1=calculate_blocks(subdnp);
+      printf("total %lu\n", return_value_calculate_blocks$1);
+    }
+    if(nfiles > 0u)
+    {
+      sort_and_display_files(subdnp, nfiles);
+      if(!((131072u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u))
+      {
+        struct dnode **dnd;
+        unsigned int dndirs;
+        dnd=splitdnarray(subdnp, 2);
+        dndirs=count_dirs(subdnp, 2);
+        if(dndirs > 0u)
+        {
+          dnsort(dnd, (signed int)dndirs);
+          scan_and_display_dirs_recur(dnd, 0);
+          free((void *)dnd);
+        }
+      }
+      dfree(subdnp);
+    }
+    dn = dn + 1l;
+  }
+}
+static struct dnode ** scan_one_dir(const char *path, unsigned int *nfiles_p)
+{
+  struct dnode *dn;
+  struct dnode *cur;
+  struct dnode **dnp;
+  struct dirent *entry;
+  struct __dirstream *dir;
+  unsigned int i;
+  unsigned int nfiles;
+  *nfiles_p = (unsigned int)0;
+  dir=warn_opendir(path);
+  if(dir == ((struct __dirstream *)((void *)0)))
+  {
+    ((struct globals *)&bb_common_bufsiz1)->exit_code = (signed char)1;
+    return (struct dnode **)((void *)0);
+  }
+  dn = (struct dnode *)((void *)0);
+  nfiles = (unsigned int)0;
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    entry=readdir(dir);
+    if(entry == ((struct dirent *)((void *)0)))
+      break;
+    char *fullname;
+    if((signed int)entry->d_name[0l] == 46)
+    {
+      if((signed int)entry->d_name[1l] == 0)
+        tmp_if_expr$2 = 1 != 0;
+      else
+      {
+        if((signed int)entry->d_name[1l] == 46)
+          tmp_if_expr$1 = (!((signed int)entry->d_name[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        else
+          tmp_if_expr$1 = 0 != 0;
+        tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+      {
+        if((32768u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) == 0u)
+          continue;
+      }
+      if((16384u & ((struct globals *)&bb_common_bufsiz1)->all_fmt) != 0u)
+        goto __CPROVER_DUMP_L14;
+    }
+    else
+    {
+    __CPROVER_DUMP_L14:
+      ;
+      fullname=concat_path_file(path, entry->d_name);
+      const char *return_value_bb_basename$3;
+      return_value_bb_basename$3=bb_basename(fullname);
+      cur=my_stat(fullname, return_value_bb_basename$3, 0);
+      if(cur == ((struct dnode *)((void *)0)))
+        free((void *)fullname);
+      else
+      {
+        cur->fname_allocated = (signed char)1;
+        cur->dn_next = dn;
+        dn = cur;
+        nfiles = nfiles + 1u;
+      }
+    }
+  }
+  while((_Bool)1);
+  closedir(dir);
+  if(dn == ((struct dnode *)((void *)0)))
+    return (struct dnode **)((void *)0);
+  *nfiles_p = nfiles;
+  dnp=dnalloc(nfiles);
+  i = (unsigned int)0;
+  while((_Bool)1)
+  {
+    dnp[(signed long int)i] = dn;
+    dn = dn->dn_next;
+    if(dn == ((struct dnode *)((void *)0)))
+      break;
+    i = i + 1u;
+  }
+  return dnp;
+}
+static void sort_and_display_files(struct dnode **dn, unsigned int nfiles)
+{
+  dnsort(dn, (signed int)nfiles);
+  display_files(dn, nfiles);
+}
+static signed int sortcmp(const void *a, const void *b)
+{
+  struct dnode *d1;
+  if(!(a == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  d1 = *((struct dnode **)a);
+  struct dnode *d2;
+  if(!(b == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  d2 = *((struct dnode **)b);
+  unsigned int sort_opts = ((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)117440512;
+  signed long int dif = (signed long int)0;
+  signed long int tmp_statement_expression$2;
+  if(sort_opts == 16777216u)
+  {
+    dif = d2->dn_size - d1->dn_size;
+  }
+  else
+    if(sort_opts == 33554432u)
+    {
+      dif = d2->dn_atime - d1->dn_atime;
+    }
+    else
+      if(sort_opts == 50331648u)
+      {
+        dif = d2->dn_ctime - d1->dn_ctime;
+      }
+      else
+        if(sort_opts == 67108864u)
+        {
+          dif = d2->dn_mtime - d1->dn_mtime;
+        }
+        else
+          if(sort_opts == 117440512u)
+          {
+            dif = (signed long int)((signed int)((d2->dn_mode & (unsigned int)61440) == (unsigned int)16384) - (signed int)((d1->dn_mode & (unsigned int)61440) == (unsigned int)16384));
+          }
+          else
+            if(sort_opts == 83886080u)
+            {
+              signed int return_value_strverscmp$1;
+              return_value_strverscmp$1=strverscmp(d1->name, d2->name);
+              dif = (signed long int)return_value_strverscmp$1;
+            }
+            else
+              if(sort_opts == 100663296u)
+              {
+                unsigned long int __s1_len;
+                unsigned long int __s2_len;
+                char *return_value_strchrnul$3;
+                return_value_strchrnul$3=strchrnul(d1->name, 46);
+                char *return_value_strchrnul$4;
+                return_value_strchrnul$4=strchrnul(d2->name, 46);
+                signed int return_value___builtin_strcmp$5;
+                return_value___builtin_strcmp$5=strcmp(return_value_strchrnul$3, return_value_strchrnul$4);
+                tmp_statement_expression$2 = (signed long int)return_value___builtin_strcmp$5;
+                dif = tmp_statement_expression$2;
+              }
+  signed int return_value_strcoll$6;
+  signed long int tmp_statement_expression$7;
+  if(dif == 0l)
+    do
+    {
+      unsigned long int sortcmp$$1$$8$$1$$__s1_len;
+      unsigned long int sortcmp$$1$$8$$1$$__s2_len;
+      signed int return_value___builtin_strcmp$8;
+      return_value___builtin_strcmp$8=strcmp(d1->name, d2->name);
+      tmp_statement_expression$7 = (signed long int)return_value___builtin_strcmp$8;
+      dif = tmp_statement_expression$7;
+    }
+    while((_Bool)0);
+  if(!(dif == 0l))
+    dif = (signed long int)(1 | (signed int)((unsigned long int)dif >> (signed int)(sizeof(signed long int) * (unsigned long int)4)));
+  return (((struct globals *)&bb_common_bufsiz1)->all_fmt & (unsigned int)8388608) != 0u ? -((signed int)dif) : (signed int)dif;
+}
+static struct dnode ** splitdnarray(struct dnode **dn, signed int which)
+{
+  unsigned int dncnt;
+  unsigned int d;
+  struct dnode **dnp;
+  if(dn == ((struct dnode **)((void *)0)))
+    return (struct dnode **)((void *)0);
+  dncnt=count_dirs(dn, which);
+  dnp=dnalloc(dncnt);
+  d = (unsigned int)0;
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$5;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$3;
+  unsigned int tmp_post$1;
+  unsigned int tmp_post$6;
+  while((_Bool)1)
+  {
+    if(*dn == ((struct dnode *)((void *)0)))
+      break;
+    if((61440u & (*dn)->dn_mode) == 16384u)
+    {
+      const char *name;
+      if(which == 0)
+        goto __CPROVER_DUMP_L35;
+      name = (*dn)->name;
+      if(!((1 & which) == 0))
+        tmp_if_expr$2 = 1 != 0;
+      else
+      {
+        tmp_if_expr$2 = ((signed int)name[(signed long int)0] != 46 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        tmp_if_expr$5 = 1 != 0;
+      else
+      {
+        if(!((signed int)*(1l + name) == 0))
+        {
+          if(!((signed int)*(1l + name) == 46))
+            tmp_if_expr$3 = 1 != 0;
+          else
+          {
+            tmp_if_expr$3 = ((signed int)name[(signed long int)2] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          tmp_if_expr$4 = (tmp_if_expr$3 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$4 = 0 != 0;
+        tmp_if_expr$5 = (tmp_if_expr$4 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$5 == (_Bool)0))
+      {
+        tmp_post$1 = d;
+        d = d + 1u;
+        dnp[(signed long int)tmp_post$1] = *dn;
+      }
+    }
+    else
+      if(which == 0)
+      {
+        tmp_post$6 = d;
+        d = d + 1u;
+        dnp[(signed long int)tmp_post$6] = *dn;
+      }
+  __CPROVER_DUMP_L35:
+    ;
+    dn = dn + 1l;
+  }
+  return dnp;
+}
+static char * uid2uname(unsigned int uid)
+{
+  struct passwd *pw;
+  pw=bb_internal_getpwuid(uid);
+  char *tmp_if_expr$1;
+  if(!(pw == ((struct passwd *)((void *)0))))
+    tmp_if_expr$1 = pw->pw_name;
+  else
+    tmp_if_expr$1 = (char *)((void *)0);
+  return tmp_if_expr$1;
+}
+static char * uid2uname_utoa(unsigned int uid)
+{
+  char *name;
+  name=uid2uname(uid);
+  char *tmp_if_expr$2;
+  char *return_value_utoa$1;
+  if(!(name == ((char *)((void *)0))))
+    tmp_if_expr$2 = name;
+  else
+  {
+    return_value_utoa$1=utoa(uid);
+    tmp_if_expr$2 = return_value_utoa$1;
+  }
+  return tmp_if_expr$2;
+}
+static char * unicode_conv_to_printable(struct uni_stat_t *stats, const char *src)
+{
+  char *return_value_unicode_conv_to_printable2$1;
+  return_value_unicode_conv_to_printable2$1=unicode_conv_to_printable2(stats, src, (unsigned int)2147483647, 0);
+  return return_value_unicode_conv_to_printable2$1;
+}
+static char * unicode_conv_to_printable2(struct uni_stat_t *stats, const char *src, unsigned int width, signed int flags)
+{
+  char *dst;
+  unsigned int dst_len;
+  unsigned int uni_count;
+  unsigned int uni_width;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  if(!((signed int)unicode_status == 2))
+  {
+    char *d;
+    if(!((1 & flags) == 0))
+    {
+      void *return_value_xmalloc$1;
+      return_value_xmalloc$1=xmalloc((unsigned long int)(width + (unsigned int)1));
+      dst = (char *)return_value_xmalloc$1;
+      d = dst;
+      do
+      {
+        width = width - 1u;
+        if(!((signed int)width >= 0))
+          break;
+        unsigned char unicode_conv_to_printable2$$1$$1$$1$$1$$c = *src;
+        if((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c == 0)
+        {
+          do
+          {
+            tmp_post$2 = d;
+            d = d + 1l;
+            *tmp_post$2 = (char)32;
+            width = width - 1u;
+          }
+          while((signed int)width >= 0);
+          break;
+        }
+        tmp_post$3 = d;
+        d = d + 1l;
+        *tmp_post$3 = (char)((signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c >= 32 && (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c < 127 ? (signed int)unicode_conv_to_printable2$$1$$1$$1$$1$$c : 63);
+        src = src + 1l;
+      }
+      while((_Bool)1);
+      *d = (char)0;
+    }
+    else
+    {
+      dst=xstrndup(src, (signed int)width);
+      d = dst;
+      while(!((signed int)*d == 0))
+      {
+        unsigned char c = *d;
+        if(!((signed int)c < 32))
+        {
+          if((signed int)c >= 127)
+            goto __CPROVER_DUMP_L7;
+        }
+        else
+        {
+        __CPROVER_DUMP_L7:
+          ;
+          *d = (char)63;
+        }
+        d = d + 1l;
+      }
+    }
+    if(!(stats == ((struct uni_stat_t *)((void *)0))))
+    {
+      stats->byte_count = (unsigned int)(d - dst);
+      stats->unicode_count = (unsigned int)(d - dst);
+      stats->unicode_width = (unsigned int)(d - dst);
+    }
+    return dst;
+  }
+  dst = (char *)((void *)0);
+  uni_width = (unsigned int)0;
+  uni_count = uni_width;
+  dst_len = (unsigned int)0;
+  while((_Bool)1)
+  {
+    signed int w;
+    signed int wc;
+    src=mbstowc_internal(&wc, src);
+    if(!(wc == -1))
+    {
+      if(wc == 0)
+        break;
+      if(wc > 767)
+        goto subst;
+      w=bb_wcwidth((unsigned int)wc);
+      if(w <= 0)
+        goto subst;
+      if(w > 1)
+        goto subst;
+    }
+    else
+    {
+    subst:
+      ;
+      wc = 63;
+      w = 1;
+    }
+    width = width - (unsigned int)w;
+    if((signed int)width < 0)
+    {
+      width = width + (unsigned int)w;
+      break;
+    }
+    uni_count = uni_count + 1u;
+    uni_width = uni_width + (unsigned int)w;
+    void *return_value_xrealloc$4;
+    return_value_xrealloc$4=xrealloc((void *)dst, (unsigned long int)(dst_len + (unsigned int)6));
+    dst = (char *)return_value_xrealloc$4;
+    unsigned long int return_value_wcrtomb_internal$5;
+    return_value_wcrtomb_internal$5=wcrtomb_internal(&dst[(signed long int)dst_len], wc);
+    dst_len = dst_len + (unsigned int)return_value_wcrtomb_internal$5;
+  }
+  unsigned int tmp_post$7;
+  if(!((1 & flags) == 0))
+  {
+    void *return_value_xrealloc$6;
+    return_value_xrealloc$6=xrealloc((void *)dst, (unsigned long int)(dst_len + width + (unsigned int)1));
+    dst = (char *)return_value_xrealloc$6;
+    uni_count = uni_count + width;
+    uni_width = uni_width + width;
+    do
+    {
+      width = width - 1u;
+      if(!((signed int)width >= 0))
+        break;
+      tmp_post$7 = dst_len;
+      dst_len = dst_len + 1u;
+      dst[(signed long int)tmp_post$7] = (char)32;
+    }
+    while((_Bool)1);
+  }
+  dst[(signed long int)dst_len] = (char)0;
+  if(!(stats == ((struct uni_stat_t *)((void *)0))))
+  {
+    stats->byte_count = dst_len;
+    stats->unicode_count = uni_count;
+    stats->unicode_width = uni_width;
+  }
+  return dst;
+}
+static char * utoa(unsigned int n)
+{
+  char *return_value_utoa_to_buf$1;
+  return_value_utoa_to_buf$1=utoa_to_buf(n, local_buf, (unsigned int)(sizeof(char [12l]) - (unsigned long int)1));
+  *return_value_utoa_to_buf$1 = (char)0;
+  return local_buf;
+}
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen)
+{
+  unsigned int i;
+  unsigned int out;
+  unsigned int res;
+  char *tmp_post$1;
+  if(!(buflen == 0u))
+  {
+    out = (unsigned int)0;
+    i = (unsigned int)1000000000;
+    for( ; !(i == 0u); i = i / (unsigned int)10)
+    {
+      res = n / i;
+      n = n % i;
+      if(res == 0u)
+      {
+        if(out != 0u)
+          goto __CPROVER_DUMP_L2;
+        if(i == 1u)
+          goto __CPROVER_DUMP_L2;
+      }
+      else
+      {
+      __CPROVER_DUMP_L2:
+        ;
+        buflen = buflen - 1u;
+        if(buflen == 0u)
+          break;
+        out = out + 1u;
+        tmp_post$1 = buf;
+        buf = buf + 1l;
+        *tmp_post$1 = (char)((unsigned int)48 + res);
+      }
+    }
+  }
+  return buf;
+}
+static struct __dirstream * warn_opendir(const char *path)
+{
+  struct __dirstream *dp;
+  dp=opendir(path);
+  if(dp == ((struct __dirstream *)((void *)0)))
+    bb_perror_msg("can't open '%s'", path);
+  return dp;
+}
+static unsigned long int wcrtomb_internal(char *s, signed int wc)
+{
+  signed int n;
+  signed int i;
+  unsigned int v = (unsigned int)wc;
+  if(v <= 127u)
+  {
+    *s = (char)v;
+    return (unsigned long int)1;
+  }
+  n = 2;
+  for( ; v >= 2048u; n = n + 1)
+  {
+    if(!(n < 6))
+      break;
+    v = v >> 5;
+  }
+  i = n;
+  do
+  {
+    i = i - 1;
+    if(i == 0)
+      break;
+    s[(signed long int)i] = (char)(wc & 63 | 128);
+    wc = wc >> 6;
+  }
+  while((_Bool)1);
+  s[(signed long int)0] = (char)(wc | (signed int)(unsigned char)(16128 >> n));
+  return (unsigned long int)n;
+}
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err)
+{
+  if(value == 0)
+  {
+    char *s;
+    s=getenv(env_name);
+    if(!(s == ((char *)((void *)0))))
+    {
+      value=atoi(s);
+      *err = 0;
+    }
+  }
+  if(!(value <= 1))
+  {
+    if(value >= 30000)
+      goto __CPROVER_DUMP_L3;
+  }
+  else
+  {
+  __CPROVER_DUMP_L3:
+    ;
+    value = def_val;
+  }
+  return value;
+}
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  __builtin_va_start(p,format);
+  r=vasprintf(&string_ptr, format, p);
+  __builtin_va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+  return string_ptr;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_readlink(const char *path)
+{
+  char *buf = (char *)((void *)0);
+  signed int bufsize = 0;
+  signed int readsize = 0;
+  do
+  {
+    bufsize = bufsize + 80;
+    void *return_value_xrealloc$1;
+    return_value_xrealloc$1=xrealloc((void *)buf, (unsigned long int)bufsize);
+    buf = (char *)return_value_xrealloc$1;
+    signed long int return_value_readlink$2;
+    return_value_readlink$2=readlink(path, buf, (unsigned long int)bufsize);
+    readsize = (signed int)return_value_readlink$2;
+    if(readsize == -1)
+    {
+      free((void *)buf);
+      return (char *)((void *)0);
+    }
+  }
+  while(!(bufsize >= 1 + readsize));
+  buf[(signed long int)readsize] = (char)0;
+  return buf;
+}
+static char * xmalloc_readlink_or_warn(const char *path)
+{
+  char *buf;
+  buf=xmalloc_readlink(path);
+  if(buf == ((char *)((void *)0)))
+  {
+    const char *errmsg = "not a symlink";
+    signed int err = *bb_errno;
+    if(!(err == 22))
+      errmsg=strerror(err);
+    bb_error_msg("%s: cannot read link: %s", path, errmsg);
+  }
+  return buf;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx)
+{
+  signed int mask = 1 << (signed int)(unsigned char)sizeof_and_shift;
+  if((-1 + mask & idx) == 0)
+  {
+    sizeof_and_shift = sizeof_and_shift >> 8;
+    vector=xrealloc(vector, (unsigned long int)(sizeof_and_shift * (unsigned int)(idx + mask + 1)));
+    memset((void *)((char *)vector + (signed long int)(sizeof_and_shift * (unsigned int)idx)), 0, (unsigned long int)(sizeof_and_shift * (unsigned int)(mask + 1)));
+  }
+  return vector;
+}
+static char * xstrndup(const char *s, signed int n)
+{
+  signed int m;
+  char *t;
+  m = n;
+  t = (char *)s;
+  for( ; !(m == 0); t = t + 1l)
+  {
+    if((signed int)*t == 0)
+      break;
+    m = m - 1;
+  }
+  n = n - m;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)(n + 1));
+  t = (char *)return_value_xmalloc$1;
+  t[(signed long int)n] = (char)0;
+  void *return_value_memcpy$2;
+  return_value_memcpy$2=memcpy((void *)t, (const void *)s, (unsigned long int)n);
+  return (char *)return_value_memcpy$2;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+struct group *bb_internal_getgrgid(gid_t gid)
+{
+  (void)gid;
+  static struct group g;
+  g.gr_name = "";
+  g.gr_passwd = "";
+  g.gr_gid = __VERIFIER_nondet_uint();
+  g.gr_mem = ((void *)0);
+  return &g;
+}
+struct passwd *bb_internal_getpwnam(const char *name)
+{
+  (void)name;
+  static struct passwd p;
+  p.pw_name = "";
+  p.pw_passwd = "";
+  p.pw_uid = __VERIFIER_nondet_uint();
+  p.pw_gid = __VERIFIER_nondet_uint();
+  p.pw_gecos = "";
+  p.pw_dir = "";
+  p.pw_shell = "";
+  return &p;
+}
+struct passwd *bb_internal_getpwuid(uid_t uid)
+{
+  (void)uid;
+  return bb_internal_getpwnam(0);
+}
+ssize_t readlink(const char *path, char *buf, size_t bufsiz)
+{
+  (void)*path;
+  if(__VERIFIER_nondet_int() || bufsiz < 1)
+    return -1;
+  unsigned long len = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(len <= bufsiz);
+  for(size_t i=0; i<len; ++i)
+    buf[i] = __VERIFIER_nondet_char();
+  return len;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -542,7 +542,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2858,7 +2858,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/mkdir_false-no-overflow.c
+++ b/c/busybox-1.22.0/mkdir_false-no-overflow.c
@@ -1,0 +1,1338 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/make_directory.c line 29
+static signed int bb_make_directory(char *path, signed long int mode, signed int flags);
+// file libbb/parse_mode.c line 18
+static signed int bb_parse_mode(const char *s, unsigned int *current_mode);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file coreutils/mkdir.c line 45
+static const char mkdir_longopts[28l] = { (const char)109, (const char)111, (const char)100, (const char)101, (const char)0, (const char)1, (const char)109, (const char)112, (const char)97, (const char)114, (const char)101, (const char)110, (const char)116, (const char)115, (const char)0, (const char)0, (const char)112, (const char)118, (const char)101, (const char)114, (const char)98, (const char)111, (const char)115, (const char)101, (const char)0, (const char)0, (const char)118, (const char)0 };
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/make_directory.c line 29
+static signed int bb_make_directory(char *path, signed long int mode, signed int flags)
+{
+  unsigned int cur_mask;
+  unsigned int org_mask;
+  const char *fail_msg;
+  char *s;
+  char c;
+  struct stat st;
+  if((signed int)*path == 46)
+  {
+    if((signed int)*(1l + path) == 0)
+      return 0;
+
+  }
+
+  cur_mask = (unsigned int)-1l;
+  org_mask = cur_mask;
+  s = path;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$3;
+  signed int return_value_stat$2;
+  signed int return_value_chmod$5;
+  while((_Bool)1)
+  {
+    c = (char)0;
+    if(!((4 & flags) == 0))
+      for( ; !((signed int)*s == 0); s = s + 1l)
+        if((signed int)*s == 47)
+        {
+          do
+            s = s + 1l;
+          while((signed int)*s == 47);
+          c = *s;
+          *s = (char)0;
+          break;
+        }
+
+    if(!((signed int)c == 0))
+    {
+      if(cur_mask == 4294967295u)
+      {
+        unsigned int new_mask;
+        org_mask=umask((unsigned int)0);
+        cur_mask = (unsigned int)0;
+        new_mask = org_mask & ~((unsigned int)192);
+        if(!(new_mask == cur_mask))
+        {
+          cur_mask = new_mask;
+          umask(new_mask);
+        }
+
+      }
+
+    }
+
+    else
+      if(!(org_mask == cur_mask))
+      {
+        cur_mask = org_mask;
+        umask(org_mask);
+      }
+
+    signed int return_value_mkdir$4;
+    return_value_mkdir$4=mkdir(path, (unsigned int)511);
+    if(return_value_mkdir$4 < 0)
+    {
+      if(!(*bb_errno == 17))
+        tmp_if_expr$1 = (*bb_errno != 21 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+      else
+        tmp_if_expr$1 = 0 != 0;
+      if(!((4 & flags) == 0))
+      {
+        if(tmp_if_expr$1 != (_Bool)0)
+          goto __CPROVER_DUMP_L13;
+
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L13:
+        ;
+        tmp_if_expr$3 = 1 != 0;
+        goto __CPROVER_DUMP_L15;
+      }
+      return_value_stat$2=stat(path, &st);
+      tmp_if_expr$3 = ((return_value_stat$2 < 0 ? (signed int)(1 != 0) : (!((st.st_mode & (unsigned int)61440) == (unsigned int)16384) ? (signed int)(1 != 0) : (signed int)(0 != 0))) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    __CPROVER_DUMP_L15:
+      ;
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        fail_msg = "create";
+        break;
+      }
+
+      if((signed int)c == 0)
+        goto ret0;
+
+    }
+
+    if((signed int)c == 0)
+    {
+      if(!(mode == -1l))
+      {
+        return_value_chmod$5=chmod(path, (unsigned int)mode);
+        if(return_value_chmod$5 < 0)
+        {
+          fail_msg = "set permissions of";
+          if(!((2048 & flags) == 0))
+          {
+            flags = 0;
+            goto print_err;
+          }
+
+          break;
+        }
+
+      }
+
+      goto ret0;
+    }
+
+    *s = c;
+  }
+  flags = -1;
+
+print_err:
+  ;
+  bb_perror_msg("can't %s directory '%s'", fail_msg, path);
+  goto ret;
+
+ret0:
+  ;
+  flags = 0;
+
+ret:
+  ;
+  if(!(org_mask == cur_mask))
+    umask(org_mask);
+
+  return flags;
+}
+
+// file libbb/parse_mode.c line 18
+static signed int bb_parse_mode(const char *s, unsigned int *current_mode)
+{
+  const char *p;
+  unsigned int wholist;
+  unsigned int permlist;
+  unsigned int new_mode;
+  char op;
+  _Bool tmp_if_expr$1;
+  if(208 + (signed int)(unsigned char)(signed int)*s < 8)
+  {
+    unsigned long int bb_parse_mode$$1$$1$$tmp;
+    char *e;
+    bb_parse_mode$$1$$1$$tmp=strtoul(s, &e, 8);
+    if(bb_parse_mode$$1$$1$$tmp > 4095ul)
+      tmp_if_expr$1 = (_Bool)1;
+
+    else
+      tmp_if_expr$1 = !((signed int)*e == 0) ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$1)
+      return 0;
+
+    *current_mode = (unsigned int)bb_parse_mode$$1$$1$$tmp;
+    return 1;
+  }
+
+  new_mode = *current_mode;
+  const char *tmp_post$2;
+  _Bool bb_parse_mode$$1$$tmp_if_expr$1;
+  _Bool tmp_if_expr$2;
+  while(!((signed int)*s == 0))
+    if((signed int)*s == 44)
+      s = s + 1l;
+
+    else
+    {
+      wholist = (unsigned int)0;
+      static const unsigned int who_mask[4l] = { (const unsigned int)(2048 | 1024 | 512 | 256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3), 
+    (const unsigned int)(2048 | 256 | 128 | 64), 
+    (const unsigned int)(1024 | (256 | 128 | 64) >> 3), 
+    (const unsigned int)(((256 | 128 | 64) >> 3) >> 3) };
+      static const char who_chars[5l] = { (const char)97, (const char)117, (const char)103, (const char)111, (const char)0 };
+      do
+      {
+
+      WHO_LIST:
+        ;
+        p = who_chars;
+
+      __CPROVER_DUMP_L8:
+        ;
+        if(!(*p == *s))
+          break;
+
+        wholist = wholist | who_mask[(signed long int)(signed int)(p - who_chars)];
+        s = s + 1l;
+        if((signed int)*s == 0)
+          return 0;
+
+      }
+      while((_Bool)1);
+      p = p + 1l;
+      if((signed int)*p != 0)
+        goto __CPROVER_DUMP_L8;
+
+      while((_Bool)1)
+      {
+        if(!((signed int)*s == 43))
+        {
+          if(!((signed int)*s == 45))
+          {
+            if(!((signed int)*s == 61))
+              return 0;
+
+            permlist = (unsigned int)~(2048 | 1024 | 512 | 256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3);
+            if(!(wholist == 0u))
+              permlist = ~wholist;
+
+            new_mode = new_mode & permlist;
+          }
+
+        }
+
+        tmp_post$2 = s;
+        s = s + 1l;
+        op = *tmp_post$2;
+        p = who_chars + (signed long int)1;
+        static const unsigned int perm_mask[6l] = { (const unsigned int)(256 | 256 >> 3 | (256 >> 3) >> 3), 
+    (const unsigned int)(128 | 128 >> 3 | (128 >> 3) >> 3), 
+    (const unsigned int)(64 | 64 >> 3 | (64 >> 3) >> 3), 
+    (const unsigned int)(64 | 64 >> 3 | (64 >> 3) >> 3), 
+    (const unsigned int)(2048 | 1024), (const unsigned int)512 };
+        while((_Bool)1)
+        {
+          if(*p == *s)
+          {
+            signed int i = 0;
+            permlist = who_mask[(signed long int)(signed int)(p - who_chars)] & (unsigned int)(256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3) & new_mode;
+            while((_Bool)1)
+            {
+              if(!((perm_mask[(signed long int)i] & permlist) == 0u))
+                permlist = permlist | perm_mask[(signed long int)i];
+
+              i = i + 1;
+              if(!(i < 3))
+                break;
+
+            }
+            s = s + 1l;
+            goto GOT_ACTION;
+          }
+
+          p = p + 1l;
+          if((signed int)*p == 0)
+            break;
+
+        }
+        permlist = (unsigned int)0;
+        do
+        {
+
+        PERM_LIST:
+          ;
+          static const char perm_chars[7l] = { (const char)114, (const char)119, (const char)120, (const char)88, (const char)115, (const char)116, (const char)0 };
+          p = perm_chars;
+
+        __CPROVER_DUMP_L22:
+          ;
+          if(!(*p == *s))
+            break;
+
+          if(!((16457u & new_mode) == 0u))
+            tmp_if_expr$2 = (_Bool)1;
+
+          else
+            tmp_if_expr$2 = !((signed int)*p == 88) ? (_Bool)1 : (_Bool)0;
+          if(tmp_if_expr$2)
+            permlist = permlist | perm_mask[(signed long int)(signed int)(p - perm_chars)];
+
+          s = s + 1l;
+          if((signed int)*s == 0)
+            goto GOT_ACTION;
+
+        }
+        while((_Bool)1);
+        p = p + 1l;
+        if((signed int)*p != 0)
+          goto __CPROVER_DUMP_L22;
+
+      GOT_ACTION:
+        ;
+        if(!(permlist == 0u))
+        {
+          unsigned int tmp = wholist;
+          if(wholist == 0u)
+          {
+            unsigned int u_mask;
+            u_mask=umask((unsigned int)0);
+            umask(u_mask);
+            tmp = ~u_mask;
+          }
+
+          permlist = permlist & tmp;
+          if((signed int)op == 45)
+            new_mode = new_mode & ~permlist;
+
+          else
+            new_mode = new_mode | permlist;
+        }
+
+        if(!((signed int)*s == 0))
+          bb_parse_mode$$1$$tmp_if_expr$1 = ((signed int)*s != 44 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+        else
+          bb_parse_mode$$1$$tmp_if_expr$1 = 0 != 0;
+        if(bb_parse_mode$$1$$tmp_if_expr$1 == (_Bool)0)
+          break;
+
+      }
+    }
+  *current_mode = new_mode;
+  return 1;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file coreutils/mkdir.c line 56
+signed int __main(signed int argc, char **argv)
+{
+  signed long int mode = (signed long int)-1;
+  signed int status = 0;
+  signed int flags = 0;
+  unsigned int opt;
+  char *smode;
+  applet_long_options = mkdir_longopts;
+  opt=getopt32(argv, "m:pv", &smode);
+  if(!((1u & opt) == 0u))
+  {
+    unsigned int mmode = (unsigned int)511;
+    signed int return_value_bb_parse_mode$1;
+    return_value_bb_parse_mode$1=bb_parse_mode(smode, &mmode);
+    if(return_value_bb_parse_mode$1 == 0)
+      bb_error_msg_and_die("invalid mode '%s'", smode);
+
+    mode = (signed long int)mmode;
+  }
+
+  if(!((2u & opt) == 0u))
+    flags = flags | 4;
+
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+    bb_show_usage();
+
+  do
+  {
+    signed int return_value_bb_make_directory$2;
+
+    return_value_bb_make_directory$2=bb_make_directory(*argv, mode, flags);
+    if(!(return_value_bb_make_directory$2 == 0))
+      status = 1;
+
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  return status;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/mkdir_false-no-overflow.i
+++ b/c/busybox-1.22.0/mkdir_false-no-overflow.i
@@ -1,0 +1,3527 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static signed int bb_make_directory(char *path, signed long int mode, signed int flags);
+static signed int bb_parse_mode(const char *s, unsigned int *current_mode);
+static void bb_perror_msg(const char *s, ...);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char mkdir_longopts[28l] = { (const char)109, (const char)111, (const char)100, (const char)101, (const char)0, (const char)1, (const char)109, (const char)112, (const char)97, (const char)114, (const char)101, (const char)110, (const char)116, (const char)115, (const char)0, (const char)0, (const char)112, (const char)118, (const char)101, (const char)114, (const char)98, (const char)111, (const char)115, (const char)101, (const char)0, (const char)0, (const char)118, (const char)0 };
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static signed int bb_make_directory(char *path, signed long int mode, signed int flags)
+{
+  unsigned int cur_mask;
+  unsigned int org_mask;
+  const char *fail_msg;
+  char *s;
+  char c;
+  struct stat st;
+  if((signed int)*path == 46)
+  {
+    if((signed int)*(1l + path) == 0)
+      return 0;
+  }
+  cur_mask = (unsigned int)-1l;
+  org_mask = cur_mask;
+  s = path;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$3;
+  signed int return_value_stat$2;
+  signed int return_value_chmod$5;
+  while((_Bool)1)
+  {
+    c = (char)0;
+    if(!((4 & flags) == 0))
+      for( ; !((signed int)*s == 0); s = s + 1l)
+        if((signed int)*s == 47)
+        {
+          do
+            s = s + 1l;
+          while((signed int)*s == 47);
+          c = *s;
+          *s = (char)0;
+          break;
+        }
+    if(!((signed int)c == 0))
+    {
+      if(cur_mask == 4294967295u)
+      {
+        unsigned int new_mask;
+        org_mask=umask((unsigned int)0);
+        cur_mask = (unsigned int)0;
+        new_mask = org_mask & ~((unsigned int)192);
+        if(!(new_mask == cur_mask))
+        {
+          cur_mask = new_mask;
+          umask(new_mask);
+        }
+      }
+    }
+    else
+      if(!(org_mask == cur_mask))
+      {
+        cur_mask = org_mask;
+        umask(org_mask);
+      }
+    signed int return_value_mkdir$4;
+    return_value_mkdir$4=mkdir(path, (unsigned int)511);
+    if(return_value_mkdir$4 < 0)
+    {
+      if(!(*bb_errno == 17))
+        tmp_if_expr$1 = (*bb_errno != 21 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      else
+        tmp_if_expr$1 = 0 != 0;
+      if(!((4 & flags) == 0))
+      {
+        if(tmp_if_expr$1 != (_Bool)0)
+          goto __CPROVER_DUMP_L13;
+      }
+      else
+      {
+      __CPROVER_DUMP_L13:
+        ;
+        tmp_if_expr$3 = 1 != 0;
+        goto __CPROVER_DUMP_L15;
+      }
+      return_value_stat$2=stat(path, &st);
+      tmp_if_expr$3 = ((return_value_stat$2 < 0 ? (signed int)(1 != 0) : (!((st.st_mode & (unsigned int)61440) == (unsigned int)16384) ? (signed int)(1 != 0) : (signed int)(0 != 0))) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    __CPROVER_DUMP_L15:
+      ;
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        fail_msg = "create";
+        break;
+      }
+      if((signed int)c == 0)
+        goto ret0;
+    }
+    if((signed int)c == 0)
+    {
+      if(!(mode == -1l))
+      {
+        return_value_chmod$5=chmod(path, (unsigned int)mode);
+        if(return_value_chmod$5 < 0)
+        {
+          fail_msg = "set permissions of";
+          if(!((2048 & flags) == 0))
+          {
+            flags = 0;
+            goto print_err;
+          }
+          break;
+        }
+      }
+      goto ret0;
+    }
+    *s = c;
+  }
+  flags = -1;
+print_err:
+  ;
+  bb_perror_msg("can't %s directory '%s'", fail_msg, path);
+  goto ret;
+ret0:
+  ;
+  flags = 0;
+ret:
+  ;
+  if(!(org_mask == cur_mask))
+    umask(org_mask);
+  return flags;
+}
+static signed int bb_parse_mode(const char *s, unsigned int *current_mode)
+{
+  const char *p;
+  unsigned int wholist;
+  unsigned int permlist;
+  unsigned int new_mode;
+  char op;
+  _Bool tmp_if_expr$1;
+  if(208 + (signed int)(unsigned char)(signed int)*s < 8)
+  {
+    unsigned long int bb_parse_mode$$1$$1$$tmp;
+    char *e;
+    bb_parse_mode$$1$$1$$tmp=strtoul(s, &e, 8);
+    if(bb_parse_mode$$1$$1$$tmp > 4095ul)
+      tmp_if_expr$1 = (_Bool)1;
+    else
+      tmp_if_expr$1 = !((signed int)*e == 0) ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$1)
+      return 0;
+    *current_mode = (unsigned int)bb_parse_mode$$1$$1$$tmp;
+    return 1;
+  }
+  new_mode = *current_mode;
+  const char *tmp_post$2;
+  _Bool bb_parse_mode$$1$$tmp_if_expr$1;
+  _Bool tmp_if_expr$2;
+  while(!((signed int)*s == 0))
+    if((signed int)*s == 44)
+      s = s + 1l;
+    else
+    {
+      wholist = (unsigned int)0;
+      static const unsigned int who_mask[4l] = { (const unsigned int)(2048 | 1024 | 512 | 256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3),
+    (const unsigned int)(2048 | 256 | 128 | 64),
+    (const unsigned int)(1024 | (256 | 128 | 64) >> 3),
+    (const unsigned int)(((256 | 128 | 64) >> 3) >> 3) };
+      static const char who_chars[5l] = { (const char)97, (const char)117, (const char)103, (const char)111, (const char)0 };
+      do
+      {
+      WHO_LIST:
+        ;
+        p = who_chars;
+      __CPROVER_DUMP_L8:
+        ;
+        if(!(*p == *s))
+          break;
+        wholist = wholist | who_mask[(signed long int)(signed int)(p - who_chars)];
+        s = s + 1l;
+        if((signed int)*s == 0)
+          return 0;
+      }
+      while((_Bool)1);
+      p = p + 1l;
+      if((signed int)*p != 0)
+        goto __CPROVER_DUMP_L8;
+      while((_Bool)1)
+      {
+        if(!((signed int)*s == 43))
+        {
+          if(!((signed int)*s == 45))
+          {
+            if(!((signed int)*s == 61))
+              return 0;
+            permlist = (unsigned int)~(2048 | 1024 | 512 | 256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3);
+            if(!(wholist == 0u))
+              permlist = ~wholist;
+            new_mode = new_mode & permlist;
+          }
+        }
+        tmp_post$2 = s;
+        s = s + 1l;
+        op = *tmp_post$2;
+        p = who_chars + (signed long int)1;
+        static const unsigned int perm_mask[6l] = { (const unsigned int)(256 | 256 >> 3 | (256 >> 3) >> 3),
+    (const unsigned int)(128 | 128 >> 3 | (128 >> 3) >> 3),
+    (const unsigned int)(64 | 64 >> 3 | (64 >> 3) >> 3),
+    (const unsigned int)(64 | 64 >> 3 | (64 >> 3) >> 3),
+    (const unsigned int)(2048 | 1024), (const unsigned int)512 };
+        while((_Bool)1)
+        {
+          if(*p == *s)
+          {
+            signed int i = 0;
+            permlist = who_mask[(signed long int)(signed int)(p - who_chars)] & (unsigned int)(256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3) & new_mode;
+            while((_Bool)1)
+            {
+              if(!((perm_mask[(signed long int)i] & permlist) == 0u))
+                permlist = permlist | perm_mask[(signed long int)i];
+              i = i + 1;
+              if(!(i < 3))
+                break;
+            }
+            s = s + 1l;
+            goto GOT_ACTION;
+          }
+          p = p + 1l;
+          if((signed int)*p == 0)
+            break;
+        }
+        permlist = (unsigned int)0;
+        do
+        {
+        PERM_LIST:
+          ;
+          static const char perm_chars[7l] = { (const char)114, (const char)119, (const char)120, (const char)88, (const char)115, (const char)116, (const char)0 };
+          p = perm_chars;
+        __CPROVER_DUMP_L22:
+          ;
+          if(!(*p == *s))
+            break;
+          if(!((16457u & new_mode) == 0u))
+            tmp_if_expr$2 = (_Bool)1;
+          else
+            tmp_if_expr$2 = !((signed int)*p == 88) ? (_Bool)1 : (_Bool)0;
+          if(tmp_if_expr$2)
+            permlist = permlist | perm_mask[(signed long int)(signed int)(p - perm_chars)];
+          s = s + 1l;
+          if((signed int)*s == 0)
+            goto GOT_ACTION;
+        }
+        while((_Bool)1);
+        p = p + 1l;
+        if((signed int)*p != 0)
+          goto __CPROVER_DUMP_L22;
+      GOT_ACTION:
+        ;
+        if(!(permlist == 0u))
+        {
+          unsigned int tmp = wholist;
+          if(wholist == 0u)
+          {
+            unsigned int u_mask;
+            u_mask=umask((unsigned int)0);
+            umask(u_mask);
+            tmp = ~u_mask;
+          }
+          permlist = permlist & tmp;
+          if((signed int)op == 45)
+            new_mode = new_mode & ~permlist;
+          else
+            new_mode = new_mode | permlist;
+        }
+        if(!((signed int)*s == 0))
+          bb_parse_mode$$1$$tmp_if_expr$1 = ((signed int)*s != 44 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        else
+          bb_parse_mode$$1$$tmp_if_expr$1 = 0 != 0;
+        if(bb_parse_mode$$1$$tmp_if_expr$1 == (_Bool)0)
+          break;
+      }
+    }
+  *current_mode = new_mode;
+  return 1;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+signed int __main(signed int argc, char **argv)
+{
+  signed long int mode = (signed long int)-1;
+  signed int status = 0;
+  signed int flags = 0;
+  unsigned int opt;
+  char *smode;
+  applet_long_options = mkdir_longopts;
+  opt=getopt32(argv, "m:pv", &smode);
+  if(!((1u & opt) == 0u))
+  {
+    unsigned int mmode = (unsigned int)511;
+    signed int return_value_bb_parse_mode$1;
+    return_value_bb_parse_mode$1=bb_parse_mode(smode, &mmode);
+    if(return_value_bb_parse_mode$1 == 0)
+      bb_error_msg_and_die("invalid mode '%s'", smode);
+    mode = (signed long int)mmode;
+  }
+  if(!((2u & opt) == 0u))
+    flags = flags | 4;
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+    bb_show_usage();
+  do
+  {
+    signed int return_value_bb_make_directory$2;
+    return_value_bb_make_directory$2=bb_make_directory(*argv, mode, flags);
+    if(!(return_value_bb_make_directory$2 == 0))
+      status = 1;
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  return status;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.c
@@ -537,7 +537,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.i
@@ -2752,7 +2752,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.c
@@ -1,0 +1,264 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file coreutils/libcoreutils/coreutils.h line 16
+unsigned int getopt_mk_fifo_nod(char **);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/mkfifo.c line 28
+signed int __main(signed int argc, char **argv)
+{
+  unsigned int mode;
+  signed int retval = 0;
+  mode=__VERIFIER_nondet_uint();
+  optind = __VERIFIER_nondet_int();
+  __VERIFIER_assume(optind > 0 && optind < argc);
+
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+    return 1;
+
+  do
+  {
+    signed int return_value_mkfifo$1;
+
+    return_value_mkfifo$1=mkfifo(*argv, mode);
+    if(return_value_mkfifo$1 < 0)
+    {
+
+      bb_simple_perror_msg(*argv);
+      retval = 1;
+    }
+
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  return retval;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.i
@@ -1,0 +1,2150 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __uid_t uid_t;
+typedef __pid_t pid_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+typedef __sigset_t sigset_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_perror_msg(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+unsigned int getopt_mk_fifo_nod(char **);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+signed int __main(signed int argc, char **argv)
+{
+  unsigned int mode;
+  signed int retval = 0;
+  mode=__VERIFIER_nondet_uint();
+  optind = __VERIFIER_nondet_int();
+  __VERIFIER_assume(optind > 0 && optind < argc);
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+    return 1;
+  do
+  {
+    signed int return_value_mkfifo$1;
+    return_value_mkfifo$1=mkfifo(*argv, mode);
+    if(return_value_mkfifo$1 < 0)
+    {
+      bb_simple_perror_msg(*argv);
+      retval = 1;
+    }
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  return retval;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.c
@@ -97,7 +97,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -1902,7 +1902,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/od_false-no-overflow.c
+++ b/c/busybox-1.22.0/od_false-no-overflow.c
@@ -1,0 +1,3337 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+// file coreutils/od_bloaty.c line 128
+struct tspec;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a);
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/bb_strtonum.c line 127
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file coreutils/od_bloaty.c line 502
+static void check_and_close(void);
+// file coreutils/od_bloaty.c line 737
+static void decode_format_string(const char *s);
+// file coreutils/od_bloaty.c line 536
+static const char * decode_one_format(const char *s_orig, const char *s, struct tspec *tspec);
+// 
+void print_function$object(unsigned long int, const char *, const char *);
+// file coreutils/od_bloaty.c line 979
+static void dump(signed long int current_offset, signed long int end_offset);
+// file coreutils/od_bloaty.c line 865
+static void dump_hexl_mode_trailer(unsigned long int n_bytes, const char *block);
+// file coreutils/od_bloaty.c line 1062
+static void dump_strings(signed long int address, signed long int end_offset);
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// 
+void format_address$object(signed long int, char);
+// file coreutils/od_bloaty.c line 857
+static void format_address_label(signed long int address, char c);
+// file coreutils/od_bloaty.c line 828
+static void format_address_none(signed long int address, char c);
+// file coreutils/od_bloaty.c line 849
+static void format_address_paren(signed long int address, char c);
+// file coreutils/od_bloaty.c line 839
+static void format_address_std(signed long int address, char c);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file coreutils/od_bloaty.c line 237
+static unsigned int gcd(unsigned int u, unsigned int v);
+// file coreutils/od_bloaty.c line 958
+static signed int get_lcm(void);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+// file coreutils/od_bloaty.c line 250
+static unsigned int lcm(unsigned int u, unsigned int v);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/llist.c line 36
+static void * llist_pop(struct llist_t **head);
+// file coreutils/od_bloaty.c line 478
+static void open_next_file(void);
+// file coreutils/od_bloaty.c line 1134
+static signed int parse_old_offset(const char *s, signed long int *offset);
+// file coreutils/od_bloaty.c line 418
+static void print_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string);
+// file coreutils/od_bloaty.c line 268
+static void print_char(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 352
+static void print_double(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 341
+static void print_float(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 300
+static void print_int(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 314
+static void print_long(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 363
+static void print_long_double(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 378
+static void print_named_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string);
+// file coreutils/od_bloaty.c line 258
+static void print_s_char(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 278
+static void print_s_short(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 289
+static void print_short(unsigned long int n_bytes, const char *block, const char *fmt_string);
+// file coreutils/od_bloaty.c line 930
+static void read_block(unsigned long int n, char *block, unsigned long int *n_bytes_in_buffer);
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file coreutils/od_bloaty.c line 763
+static void skip(signed long int n_skip);
+// file coreutils/od_bloaty.c line 888
+static void write_block(signed long int current_offset, unsigned long int n_bytes, const char *prev_block, const char *curr_block);
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file include/libbb.h line 707
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file libbb/xatonum_template.c line 84
+static unsigned int xstrtou_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes);
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+// file libbb/xatonum_template.c line 84
+static unsigned long long int xstrtoull_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+struct tspec
+{
+  // fmt
+  signed int fmt;
+  // size
+  signed int size;
+  // print_function
+  void (*print_function)(unsigned long int, const char *, const char *);
+  // fmt_string
+  char *fmt_string;
+  // hexl_mode_trailer
+  signed int hexl_mode_trailer;
+  // field_width
+  signed int field_width;
+};
+
+// file coreutils/od_bloaty.c line 832
+static char address_fmt[7l] = { (char)37, (char)48, (char)110, (char)108, (char)120, (char)99, (char)0 };
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/getopt32.c line 297
+static const char * const bb_argv_dash[2l] = { "-", (const char *)NULL };
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xatonum.c line 72
+static struct suffix_mult bkm_suffixes[4l] = { { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 }, 
+    { .suffix={ (char)107, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 }, 
+    { .suffix={ (char)109, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(1024 * 1024) }, 
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+// file coreutils/od_bloaty.c line 202
+static unsigned int bytes_per_block = (unsigned int)32;
+// file coreutils/od_bloaty.c line 156
+static const unsigned char bytes_to_hex_digits[17l] = { (const unsigned char)0, (const unsigned char)2, (const unsigned char)4, (const unsigned char)6, (const unsigned char)8, (const unsigned char)10, (const unsigned char)12, (const unsigned char)14, (const unsigned char)16, (const unsigned char)18, (const unsigned char)20, (const unsigned char)22, (const unsigned char)24, (const unsigned char)26, (const unsigned char)28, (const unsigned char)30, (const unsigned char)32 };
+// file coreutils/od_bloaty.c line 147
+static const unsigned char bytes_to_oct_digits[17l] = { (const unsigned char)0, (const unsigned char)3, (const unsigned char)6, (const unsigned char)8, (const unsigned char)11, (const unsigned char)14, (const unsigned char)16, (const unsigned char)19, (const unsigned char)22, (const unsigned char)25, (const unsigned char)27, (const unsigned char)30, (const unsigned char)32, (const unsigned char)35, (const unsigned char)38, (const unsigned char)41, (const unsigned char)43 };
+// file coreutils/od_bloaty.c line 150
+static const unsigned char bytes_to_signed_dec_digits[17l] = { (const unsigned char)1, (const unsigned char)4, (const unsigned char)6, (const unsigned char)8, (const unsigned char)11, (const unsigned char)13, (const unsigned char)16, (const unsigned char)18, (const unsigned char)20, (const unsigned char)23, (const unsigned char)25, (const unsigned char)28, (const unsigned char)30, (const unsigned char)33, (const unsigned char)35, (const unsigned char)37, (const unsigned char)40 };
+// file coreutils/od_bloaty.c line 153
+static const unsigned char bytes_to_unsigned_dec_digits[17l] = { (const unsigned char)0, (const unsigned char)3, (const unsigned char)5, (const unsigned char)8, (const unsigned char)10, (const unsigned char)13, (const unsigned char)15, (const unsigned char)17, (const unsigned char)20, (const unsigned char)22, (const unsigned char)25, (const unsigned char)27, (const unsigned char)29, (const unsigned char)32, (const unsigned char)34, (const unsigned char)37, (const unsigned char)39 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file coreutils/od_bloaty.c line 177
+static signed char exit_code;
+// file coreutils/od_bloaty.c line 205
+static const char * const *file_list;
+// file coreutils/od_bloaty.c line 187
+static void (*format_address)(signed long int, char);
+// file coreutils/od_bloaty.c line 228
+static const unsigned char fp_type_size[17l] = { (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)6, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)7, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)8 };
+// file coreutils/od_bloaty.c line 208
+static struct _IO_FILE *in_stream;
+// file coreutils/od_bloaty.c line 211
+static const unsigned char integral_type_size[9l] = { (const unsigned char)0, (const unsigned char)1, (const unsigned char)2, (const unsigned char)0, (const unsigned char)3, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)4 };
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file coreutils/od_bloaty.c line 182
+static unsigned long int n_specs;
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file coreutils/od_bloaty.c line 191
+static signed long int pseudo_offset;
+// file coreutils/od_bloaty.c line 183
+static struct tspec *spec;
+// file coreutils/od_bloaty.c line 179
+static unsigned int string_min;
+// file coreutils/od_bloaty.c line 160
+static const signed char width_bytes[9l] = { (const signed char)-1, (const signed char)sizeof(char) /*1ul*/ , 
+    (const signed char)sizeof(signed short int) /*2ul*/ , 
+    (const signed char)sizeof(signed int) /*4ul*/ , 
+    (const signed char)sizeof(signed long int) /*8ul*/ , 
+    (const signed char)sizeof(unsigned long long int) /*8ul*/ , 
+    (const signed char)sizeof(float) /*4ul*/ , 
+    (const signed char)sizeof(double) /*8ul*/ , 
+    (const signed char)sizeof(long double) /*16ul*/  };
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/bb_strtonum.c line 127
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base)
+{
+  unsigned long int v;
+  char *endptr;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int return_value_bb_ascii_isalnum$2;
+  return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(arg[(signed long int)0]);
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(return_value_bb_ascii_isalnum$2 == 0)
+  {
+    return_value_ret_ERANGE$1=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$1;
+  }
+
+  *bb_errno = 0;
+  v=strtoul(arg, endp, base);
+  unsigned long long int return_value_ret_ERANGE$3;
+  if(v > 4294967295ul)
+  {
+    return_value_ret_ERANGE$3=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$3;
+  }
+
+  unsigned long long int return_value_handle_errors$4;
+  return_value_handle_errors$4=handle_errors(v, endp);
+  return (unsigned int)return_value_handle_errors$4;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/od_bloaty.c line 502
+static void check_and_close(void)
+{
+  const char *tmp_if_expr$1;
+  if(!(in_stream == ((struct _IO_FILE *)NULL)))
+  {
+    signed int return_value_ferror$2;
+    return_value_ferror$2=ferror(in_stream);
+    if(!(return_value_ferror$2 == 0))
+    {
+      if(in_stream == stdin)
+        tmp_if_expr$1 = bb_msg_standard_input;
+
+      else
+      {
+
+        tmp_if_expr$1 = file_list[(signed long int)-1];
+      }
+      bb_error_msg("%s: read error", tmp_if_expr$1);
+      exit_code = (signed char)1;
+    }
+
+    fclose_if_not_stdin(in_stream);
+    in_stream = (struct _IO_FILE *)NULL;
+  }
+
+  signed int return_value_ferror$3;
+  return_value_ferror$3=ferror(stdout);
+  if(!(return_value_ferror$3 == 0))
+    bb_error_msg_and_die("write error");
+
+}
+
+// file coreutils/od_bloaty.c line 737
+static void decode_format_string(const char *s)
+{
+  const char *s_orig = s;
+  while((_Bool)1)
+  {
+
+    if((signed int)*s == 0)
+      break;
+
+    struct tspec tspec;
+    const char *next;
+    next=decode_one_format(s_orig, s, &tspec);
+    (void)0;
+    s = next;
+    void *return_value_xrealloc_vector_helper$1;
+    return_value_xrealloc_vector_helper$1=xrealloc_vector_helper((void *)spec, (unsigned int)((sizeof(struct tspec) /*32ul*/  << 8) + (unsigned long int)4), (signed int)n_specs);
+    spec = (struct tspec *)return_value_xrealloc_vector_helper$1;
+    memcpy((void *)&spec[(signed long int)n_specs], (const void *)&tspec, sizeof(struct tspec) /*32ul*/ );
+    n_specs = n_specs + 1ul;
+  }
+}
+
+// file coreutils/od_bloaty.c line 536
+static const char * decode_one_format(const char *s_orig, const char *s, struct tspec *tspec)
+{
+  signed int size_spec;
+  unsigned int size;
+  signed int fmt;
+  const char *p;
+  char *end;
+  char *fmt_string = (char *)NULL;
+  void (*print_function)(unsigned long int, const char *, const char *);
+  unsigned int c;
+  unsigned int field_width = (unsigned int)0;
+  signed int pos;
+
+  if((signed int)*s == 120 || !(s == ((const char *)NULL)))
+    (void)0;
+
+  else
+    /* assertion !((signed int)*s == 120) ==> !(s == ((const char *)((void*)0))) */
+    __VERIFIER_error();
+  _Bool tmp_if_expr$1;
+  if(!((signed int)*s == 120))
+    tmp_if_expr$1 = !((signed int)*s == 117) ? (_Bool)1 : (_Bool)0;
+
+  else
+    tmp_if_expr$1 = (_Bool)0;
+  if(!(s == ((const char *)NULL)) || !tmp_if_expr$1)
+    (void)0;
+
+  else
+    /* assertion !((signed int)*s == 120) && !((signed int)*s == 117) ==> !(s == ((const char *)((void*)0))) */
+    __VERIFIER_error();
+  _Bool tmp_if_expr$2;
+  if(!((signed int)*s == 120))
+    tmp_if_expr$2 = !((signed int)*s == 117) ? (_Bool)1 : (_Bool)0;
+
+  else
+    tmp_if_expr$2 = (_Bool)0;
+  _Bool tmp_if_expr$3;
+  if(tmp_if_expr$2)
+    tmp_if_expr$3 = !((signed int)*s == 111) ? (_Bool)1 : (_Bool)0;
+
+  else
+    tmp_if_expr$3 = (_Bool)0;
+  if(!(s == ((const char *)NULL)) || !tmp_if_expr$3)
+    (void)0;
+
+  else
+    /* assertion !((signed int)*s == 120) && !((signed int)*s == 117) && !((signed int)*s == 111) ==> !(s == ((const char *)((void*)0))) */
+    __VERIFIER_error();
+  const char *tmp_post$1;
+  _Bool decode_one_format$$1$$tmp_if_expr$4;
+  _Bool decode_one_format$$1$$tmp_if_expr$3;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$4;
+  if(!((signed int)*s == 100))
+    tmp_if_expr$4 = !((signed int)*s == 111) ? (_Bool)1 : (_Bool)0;
+
+  else
+    tmp_if_expr$4 = (_Bool)0;
+  _Bool tmp_if_expr$5;
+  if(tmp_if_expr$4)
+    tmp_if_expr$5 = !((signed int)*s == 117) ? (_Bool)1 : (_Bool)0;
+
+  else
+    tmp_if_expr$5 = (_Bool)0;
+  _Bool tmp_if_expr$6;
+  if(tmp_if_expr$5)
+    tmp_if_expr$6 = !((signed int)*s == 120) ? (_Bool)1 : (_Bool)0;
+
+  else
+    tmp_if_expr$6 = (_Bool)0;
+  if(tmp_if_expr$6)
+  {
+    if((signed int)*s == 102)
+      goto __CPROVER_DUMP_L64;
+
+    if((signed int)*s == 97)
+      goto __CPROVER_DUMP_L89;
+
+    if((signed int)*s == 99)
+      goto __CPROVER_DUMP_L90;
+
+  }
+
+  else
+  {
+    tmp_post$1 = s;
+    s = s + 1l;
+
+    c = (unsigned int)*tmp_post$1;
+    char *return_value___builtin_strchr$2;
+
+    static const char CSIL[5l] = { (const char)67, (const char)83, (const char)73, (const char)76, (const char)0 };
+    return_value___builtin_strchr$2=strchr(CSIL, (signed int)*s);
+    p = return_value___builtin_strchr$2;
+    if(p == ((const char *)NULL))
+      decode_one_format$$1$$tmp_if_expr$4 = 1 != 0;
+
+    else
+    {
+
+      decode_one_format$$1$$tmp_if_expr$4 = ((signed int)*p == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(decode_one_format$$1$$tmp_if_expr$4 == (_Bool)0))
+    {
+      size = (unsigned int)sizeof(signed int) /*4ul*/ ;
+
+      if(208 + (signed int)(unsigned char)(signed int)*s <= 9)
+      {
+        size=bb_strtou(s, &end, 0);
+
+        if(*bb_errno == 34 || (unsigned long int)size > sizeof(unsigned long long int) /*8ul*/ )
+          decode_one_format$$1$$tmp_if_expr$3 = 1 != 0;
+
+        else
+        {
+          if((signed long int)size < 9l)
+            (void)0;
+
+          else
+            /* assertion (signed long int)size < 9l */
+            __VERIFIER_error();
+          decode_one_format$$1$$tmp_if_expr$3 = ((signed int)integral_type_size[(signed long int)size] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(decode_one_format$$1$$tmp_if_expr$3 == (_Bool)0))
+          bb_error_msg_and_die("invalid type string '%s'; %u-byte %s type is not supported", s_orig, size, (const void *)"integral");
+
+        s = end;
+      }
+
+    }
+
+    else
+    {
+      if(p - CSIL >= 0l)
+        (void)0;
+
+      else
+        /* assertion p - CSIL >= 0 */
+        __VERIFIER_error();
+      if(p - CSIL < 4l)
+        (void)0;
+
+      else
+        /* assertion p - CSIL < 4l */
+        __VERIFIER_error();
+      static const unsigned char CSIL_sizeof[4l] = { (const unsigned char)sizeof(char) /*1ul*/ , 
+    (const unsigned char)sizeof(signed short int) /*2ul*/ , 
+    (const unsigned char)sizeof(signed int) /*4ul*/ , 
+    (const unsigned char)sizeof(signed long int) /*8ul*/  };
+      size = (unsigned int)CSIL_sizeof[p - CSIL];
+      s = s + 1l;
+    }
+    if((signed long int)size < 9l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)size < 9l */
+      __VERIFIER_error();
+    size_spec = (signed int)integral_type_size[(signed long int)size];
+    char *return_value___builtin_strchr$5;
+    static const char doux[5l] = { (const char)100, (const char)111, (const char)117, (const char)120, (const char)0 };
+    return_value___builtin_strchr$5=strchr(doux, (signed int)c);
+    pos = (signed int)(return_value___builtin_strchr$5 - doux);
+    if(4l * (signed long int)pos >= 0l)
+      (void)0;
+
+    else
+      /* assertion 4 * (signed long int)pos >= 0 */
+      __VERIFIER_error();
+    if((signed long int)pos < 4l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)pos < 4l */
+      __VERIFIER_error();
+    static const signed int doux_fmt[4l] = { (const signed int)0, (const signed int)2, (const signed int)1, (const signed int)3 };
+    fmt = doux_fmt[(signed long int)pos];
+    if(8l * (signed long int)pos >= 0l)
+      (void)0;
+
+    else
+      /* assertion 8 * (signed long int)pos >= 0 */
+      __VERIFIER_error();
+    static const unsigned char * const doux_bytes_to_XXX[4l] = { bytes_to_signed_dec_digits, bytes_to_oct_digits, bytes_to_unsigned_dec_digits, bytes_to_hex_digits };
+
+    field_width = (unsigned int)doux_bytes_to_XXX[(signed long int)pos][(signed long int)size];
+    static const char doux_fmt_letter[4l][4l] = { { (const char)108, (const char)108, (const char)100, (const char)0 }, 
+    { (const char)108, (const char)108, (const char)111, (const char)0 }, 
+    { (const char)108, (const char)108, (const char)117, (const char)0 }, 
+    { (const char)108, (const char)108, (const char)120, (const char)0 } };
+    p = doux_fmt_letter[(signed long int)pos] + (signed long int)2;
+    if(size_spec == 4)
+      p = p - 1l;
+
+    if(size_spec == 5)
+      p = p - (signed long int)2;
+
+    static const char doux_fmtstring[4l][(signed long int)sizeof(char [9l]) /*9l*/ ] = { { (const char)32, (const char)37, (const char)37, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0, (const char)0 }, 
+    { (const char)32, (const char)37, (const char)37, (const char)48, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0 }, 
+    { (const char)32, (const char)37, (const char)37, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0, (const char)0 }, 
+    { (const char)32, (const char)37, (const char)37, (const char)48, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0 } };
+    fmt_string=xasprintf(doux_fmtstring[(signed long int)pos], field_width, p);
+    if(!(size_spec == 1))
+    {
+      if(size_spec == 2)
+        goto __CPROVER_DUMP_L59;
+
+      if(size_spec == 3)
+        goto __CPROVER_DUMP_L60;
+
+      if(size_spec == 4)
+        goto __CPROVER_DUMP_L61;
+
+    }
+
+    else
+    {
+      print_function = (signed int)fmt == 0 ? print_s_char : print_char;
+      goto __CPROVER_DUMP_L63;
+
+    __CPROVER_DUMP_L59:
+      ;
+      print_function = (signed int)fmt == 0 ? print_s_short : print_short;
+      goto __CPROVER_DUMP_L63;
+
+    __CPROVER_DUMP_L60:
+      ;
+      print_function = print_int;
+      goto __CPROVER_DUMP_L63;
+
+    __CPROVER_DUMP_L61:
+      ;
+      print_function = print_long;
+      goto __CPROVER_DUMP_L63;
+    }
+    print_function = print_long;
+
+  __CPROVER_DUMP_L63:
+    ;
+    goto __CPROVER_DUMP_L94;
+
+  __CPROVER_DUMP_L64:
+    ;
+    fmt = (signed int)4;
+    s = s + 1l;
+    char *return_value___builtin_strchr$6;
+
+    static const char FDL[4l] = { (const char)70, (const char)68, (const char)76, (const char)0 };
+    return_value___builtin_strchr$6=strchr(FDL, (signed int)*s);
+    p = return_value___builtin_strchr$6;
+    if(p == ((const char *)NULL))
+    {
+      size = (unsigned int)sizeof(double) /*8ul*/ ;
+
+      if(208 + (signed int)(unsigned char)(signed int)*s <= 9)
+      {
+        size=bb_strtou(s, &end, 0);
+
+        if(*bb_errno == 34 || (unsigned long int)size > sizeof(long double) /*16ul*/ )
+          tmp_if_expr$7 = 1 != 0;
+
+        else
+        {
+          if((signed long int)size < 17l)
+            (void)0;
+
+          else
+            /* assertion (signed long int)size < 17l */
+            __VERIFIER_error();
+          tmp_if_expr$7 = ((signed int)fp_type_size[(signed long int)size] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$7 == (_Bool)0))
+          bb_error_msg_and_die("invalid type string '%s'; %u-byte %s type is not supported", s_orig, size, (const void *)"floating point");
+
+        s = end;
+      }
+
+    }
+
+    else
+    {
+      if(p - FDL >= 0l)
+        (void)0;
+
+      else
+        /* assertion p - FDL >= 0 */
+        __VERIFIER_error();
+      if(p - FDL < 3l)
+        (void)0;
+
+      else
+        /* assertion p - FDL < 3l */
+        __VERIFIER_error();
+      static const unsigned char FDL_sizeof[3l] = { (const unsigned char)sizeof(float) /*4ul*/ , 
+    (const unsigned char)sizeof(double) /*8ul*/ , 
+    (const unsigned char)sizeof(long double) /*16ul*/  };
+      size = (unsigned int)FDL_sizeof[p - FDL];
+    }
+    if((signed long int)size < 17l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)size < 17l */
+      __VERIFIER_error();
+    size_spec = (signed int)fp_type_size[(signed long int)size];
+    if(!(size_spec == 6))
+    {
+      if(size_spec == 7)
+        goto __CPROVER_DUMP_L86;
+
+    }
+
+    else
+    {
+      print_function = print_float;
+      field_width = (unsigned int)(7 + 8);
+      fmt_string=xasprintf(" %%%d.%de", field_width, 7);
+      goto __CPROVER_DUMP_L88;
+
+    __CPROVER_DUMP_L86:
+      ;
+      print_function = print_double;
+      field_width = (unsigned int)(15 + 8);
+      fmt_string=xasprintf(" %%%d.%de", field_width, 15);
+      goto __CPROVER_DUMP_L88;
+    }
+    print_function = print_long_double;
+    field_width = (unsigned int)(15 + 8);
+    fmt_string=xasprintf(" %%%d.%dLe", field_width, 15);
+
+  __CPROVER_DUMP_L88:
+    ;
+    goto __CPROVER_DUMP_L94;
+
+  __CPROVER_DUMP_L89:
+    ;
+    s = s + 1l;
+    fmt = (signed int)5;
+    size_spec = (signed int)1;
+    print_function = print_named_ascii;
+    field_width = (unsigned int)3;
+    goto __CPROVER_DUMP_L94;
+
+  __CPROVER_DUMP_L90:
+    ;
+    s = s + 1l;
+    fmt = (signed int)6;
+    size_spec = (signed int)1;
+    print_function = print_ascii;
+    field_width = (unsigned int)3;
+    goto __CPROVER_DUMP_L94;
+  }
+
+  bb_error_msg_and_die("invalid character '%c' in type string '%s'", *s, s_orig);
+
+__CPROVER_DUMP_L94:
+  ;
+
+  tspec->size = size_spec;
+
+  tspec->fmt = fmt;
+
+  tspec->print_function = print_function;
+
+  tspec->fmt_string = fmt_string;
+
+  tspec->field_width = (signed int)field_width;
+
+
+  tspec->hexl_mode_trailer = (signed int)((signed int)*s == 122);
+
+  if(!(tspec->hexl_mode_trailer == 0))
+    s = s + 1l;
+
+  return s;
+}
+
+// file coreutils/od_bloaty.c line 979
+static void dump(signed long int current_offset, signed long int end_offset)
+{
+  char *block[2l];
+  signed int idx;
+  unsigned long int n_bytes_read;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)((unsigned int)2 * bytes_per_block));
+  block[(signed long int)0] = (char *)return_value_xmalloc$1;
+  block[(signed long int)1] = block[(signed long int)0] + (signed long int)bytes_per_block;
+  idx = 0;
+  if(!((2u & option_mask32) == 0u))
+    while((_Bool)1)
+    {
+      unsigned long int n_needed;
+      if(current_offset >= end_offset)
+      {
+        n_bytes_read = (unsigned long int)0;
+        break;
+      }
+
+      n_needed = (unsigned long int)(end_offset - current_offset < (signed long int)bytes_per_block ? end_offset - current_offset : (signed long int)bytes_per_block);
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)idx >= 0 */
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)idx < 2l */
+        __VERIFIER_error();
+      read_block(n_needed, block[(signed long int)idx], &n_bytes_read);
+      if(!(n_bytes_read >= (unsigned long int)bytes_per_block))
+        break;
+
+      (void)0;
+      if(8l * (signed long int)(1 ^ idx) >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)(1 ^ idx) >= 0 */
+        __VERIFIER_error();
+      if((signed long int)(1 ^ idx) < 2l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)(1 ^ idx) < 2l */
+        __VERIFIER_error();
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)idx >= 0 */
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)idx < 2l */
+        __VERIFIER_error();
+      write_block(current_offset, n_bytes_read, block[(signed long int)(idx ^ 1)], block[(signed long int)idx]);
+      current_offset = current_offset + (signed long int)n_bytes_read;
+      idx = idx ^ 1;
+    }
+
+  else
+    for( ; (_Bool)1; idx = idx ^ 1)
+    {
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)idx >= 0 */
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)idx < 2l */
+        __VERIFIER_error();
+      read_block((unsigned long int)bytes_per_block, block[(signed long int)idx], &n_bytes_read);
+      if(!(n_bytes_read >= (unsigned long int)bytes_per_block))
+        break;
+
+      (void)0;
+      if(8l * (signed long int)(1 ^ idx) >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)(1 ^ idx) >= 0 */
+        __VERIFIER_error();
+      if((signed long int)(1 ^ idx) < 2l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)(1 ^ idx) < 2l */
+        __VERIFIER_error();
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)idx >= 0 */
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)idx < 2l */
+        __VERIFIER_error();
+      write_block(current_offset, n_bytes_read, block[(signed long int)(idx ^ 1)], block[(signed long int)idx]);
+      current_offset = current_offset + (signed long int)n_bytes_read;
+    }
+  if(n_bytes_read > 0ul)
+  {
+    signed int l_c_m;
+    unsigned long int bytes_to_write;
+    l_c_m=get_lcm();
+    if(!((unsigned long int)l_c_m == 0ul))
+      (void)0;
+
+    else
+      /* assertion (unsigned long int)l_c_m != 0ul */
+      __VERIFIER_error();
+    bytes_to_write = (unsigned long int)l_c_m * (((n_bytes_read + (unsigned long int)l_c_m) - (unsigned long int)1) / (unsigned long int)l_c_m);
+    if(8l * (signed long int)idx >= 0l)
+      (void)0;
+
+    else
+      /* assertion 8 * (signed long int)idx >= 0 */
+      __VERIFIER_error();
+    if((signed long int)idx < 2l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)idx < 2l */
+      __VERIFIER_error();
+    memset((void *)(block[(signed long int)idx] + (signed long int)n_bytes_read), 0, bytes_to_write - n_bytes_read);
+    if(8l * (signed long int)(1 ^ idx) >= 0l)
+      (void)0;
+
+    else
+      /* assertion 8 * (signed long int)(1 ^ idx) >= 0 */
+      __VERIFIER_error();
+    if((signed long int)(1 ^ idx) < 2l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)(1 ^ idx) < 2l */
+      __VERIFIER_error();
+    if(8l * (signed long int)idx >= 0l)
+      (void)0;
+
+    else
+      /* assertion 8 * (signed long int)idx >= 0 */
+      __VERIFIER_error();
+    if((signed long int)idx < 2l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)idx < 2l */
+      __VERIFIER_error();
+    write_block(current_offset, bytes_to_write, block[(signed long int)(idx ^ 1)], block[(signed long int)idx]);
+    current_offset = current_offset + (signed long int)n_bytes_read;
+  }
+
+  if(!(format_address == ((void (*)(signed long int, char))NULL)))
+    (void)0;
+
+  else
+    /* assertion !(format_address == ((void (*)(signed long int, char))((void*)0))) */
+    __VERIFIER_error();
+  format_address(current_offset, (char)10);
+  if(!((2u & option_mask32) == 0u))
+  {
+    if(current_offset >= end_offset)
+      check_and_close();
+
+  }
+
+  free((void *)block[(signed long int)0]);
+}
+
+// file coreutils/od_bloaty.c line 865
+static void dump_hexl_mode_trailer(unsigned long int n_bytes, const char *block)
+{
+  fputs("  >", stdout);
+  unsigned long int tmp_post$1;
+  const char *tmp_post$2;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    unsigned int c;
+    tmp_post$2 = block;
+    block = block + 1l;
+
+    c = (unsigned int)*((unsigned char *)tmp_post$2);
+    c = c >= (unsigned int)32 && c < (unsigned int)127 ? c : (unsigned int)46;
+    putchar((signed int)c);
+  }
+  while((_Bool)1);
+  putchar(60);
+}
+
+// file coreutils/od_bloaty.c line 1062
+static void dump_strings(signed long int address, signed long int end_offset)
+{
+  unsigned int bufsize = (unsigned int)100 > string_min ? (unsigned int)100 : string_min;
+  unsigned char *buf;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)bufsize);
+  buf = (unsigned char *)return_value_xmalloc$1;
+  unsigned long int tmp_post$3;
+  while((_Bool)1)
+  {
+    unsigned long int i;
+    signed int c;
+    do
+    {
+
+    tryline:
+      ;
+
+    __CPROVER_DUMP_L3:
+      ;
+      if(!((2u & option_mask32) == 0u))
+      {
+        if(address >= end_offset + -((signed long int)string_min))
+          goto __CPROVER_DUMP_L13;
+
+      }
+
+      i = (unsigned long int)0;
+
+    __CPROVER_DUMP_L5:
+      ;
+      if(!((2u & option_mask32) == 0u))
+      {
+        if(address >= end_offset)
+          goto __CPROVER_DUMP_L11;
+
+      }
+
+      if(i == (unsigned long int)bufsize)
+      {
+        bufsize = bufsize + bufsize / (unsigned int)8;
+        void *return_value_xrealloc$2;
+        return_value_xrealloc$2=xrealloc((void *)buf, (unsigned long int)bufsize);
+        buf = (unsigned char *)return_value_xrealloc$2;
+      }
+
+      while(!(in_stream == ((struct _IO_FILE *)NULL)))
+      {
+        c=getc(in_stream);
+        if(c != -1)
+          goto got_char;
+
+        check_and_close();
+        open_next_file();
+      }
+      goto ret;
+
+    got_char:
+      ;
+      address = address + 1l;
+      if(c == 0)
+        goto __CPROVER_DUMP_L12;
+
+    }
+    while(!(c < 127) || !(c >= 32));
+    tmp_post$3 = i;
+    i = i + 1ul;
+
+
+  __CPROVER_DUMP_L11:
+    ;
+    buf[(signed long int)tmp_post$3] = (unsigned char)c;
+    goto __CPROVER_DUMP_L5;
+
+  __CPROVER_DUMP_L12:
+    ;
+    if(!(i >= (unsigned long int)string_min))
+      goto __CPROVER_DUMP_L3;
+
+  __CPROVER_DUMP_L13:
+    ;
+
+    buf[(signed long int)i] = (unsigned char)0;
+    if(!(format_address == ((void (*)(signed long int, char))NULL)))
+      (void)0;
+
+    else
+      /* assertion !(format_address == ((void (*)(signed long int, char))((void*)0))) */
+      __VERIFIER_error();
+    format_address((signed long int)(((unsigned long int)address - i) - (unsigned long int)1), (char)32);
+    i = (unsigned long int)0;
+    while((_Bool)1)
+    {
+
+      c = (signed int)buf[(signed long int)i];
+      if(c == 0)
+        break;
+
+      if(!(c == 7))
+      {
+        if(c == 8)
+          goto __CPROVER_DUMP_L22;
+
+        if(c == 12)
+          goto __CPROVER_DUMP_L23;
+
+        if(c == 10)
+          goto __CPROVER_DUMP_L24;
+
+        if(c == 13)
+          goto __CPROVER_DUMP_L25;
+
+        if(c == 9)
+          goto __CPROVER_DUMP_L26;
+
+        if(c == 11)
+          goto __CPROVER_DUMP_L27;
+
+      }
+
+      else
+      {
+        fputs("\\a", stdout);
+        goto __CPROVER_DUMP_L29;
+
+      __CPROVER_DUMP_L22:
+        ;
+        fputs("\\b", stdout);
+        goto __CPROVER_DUMP_L29;
+
+      __CPROVER_DUMP_L23:
+        ;
+        fputs("\\f", stdout);
+        goto __CPROVER_DUMP_L29;
+
+      __CPROVER_DUMP_L24:
+        ;
+        fputs("\\n", stdout);
+        goto __CPROVER_DUMP_L29;
+
+      __CPROVER_DUMP_L25:
+        ;
+        fputs("\\r", stdout);
+        goto __CPROVER_DUMP_L29;
+
+      __CPROVER_DUMP_L26:
+        ;
+        fputs("\\t", stdout);
+        goto __CPROVER_DUMP_L29;
+
+      __CPROVER_DUMP_L27:
+        ;
+        fputs("\\v", stdout);
+        goto __CPROVER_DUMP_L29;
+      }
+      putchar(c);
+
+    __CPROVER_DUMP_L29:
+      ;
+      i = i + 1ul;
+    }
+    putchar(10);
+  }
+  check_and_close();
+
+ret:
+  ;
+  free((void *)buf);
+}
+
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+
+  return r;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file coreutils/od_bloaty.c line 857
+static void format_address_label(signed long int address, char c)
+{
+  format_address_std(address, (char)32);
+  format_address_paren(address + pseudo_offset, c);
+}
+
+// file coreutils/od_bloaty.c line 828
+static void format_address_none(signed long int address, char c)
+{
+  ;
+}
+
+// file coreutils/od_bloaty.c line 849
+static void format_address_paren(signed long int address, char c)
+{
+  putchar(40);
+  format_address_std(address, (char)41);
+  if(!((signed int)c == 0))
+    putchar((signed int)c);
+
+}
+
+// file coreutils/od_bloaty.c line 839
+static void format_address_std(signed long int address, char c)
+{
+  address_fmt[(signed long int)(sizeof(char [7l]) /*7ul*/  - (unsigned long int)2)] = c;
+  printf(address_fmt, address);
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/od_bloaty.c line 237
+static unsigned int gcd(unsigned int u, unsigned int v)
+{
+  unsigned int t;
+  for( ; !(v == 0u); v = t)
+  {
+    if(!(v == 0u))
+      (void)0;
+
+    else
+      /* assertion v != 0u */
+      __VERIFIER_error();
+    t = u % v;
+    u = v;
+  }
+  return u;
+}
+
+// file coreutils/od_bloaty.c line 958
+static signed int get_lcm(void)
+{
+  unsigned long int i;
+  signed int l_c_m = 1;
+  i = (unsigned long int)0;
+  unsigned int return_value_lcm$1;
+  for( ; !(i >= n_specs); i = i + 1ul)
+  {
+
+    if((signed long int)(spec + (signed long int)i)->size >= 0l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)(signed int)(spec + (signed long int)i)->size >= 0 */
+      __VERIFIER_error();
+    if((signed long int)(spec + (signed long int)i)->size < 9l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)(signed int)(spec + (signed long int)i)->size < 9l */
+      __VERIFIER_error();
+    return_value_lcm$1=lcm((unsigned int)l_c_m, (unsigned int)width_bytes[(signed long int)(signed int)(spec + (signed long int)i)->size]);
+    l_c_m = (signed int)return_value_lcm$1;
+  }
+  return l_c_m;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+
+    *bb_errno = 22;
+  }
+
+  return v;
+}
+
+// file coreutils/od_bloaty.c line 250
+static unsigned int lcm(unsigned int u, unsigned int v)
+{
+  unsigned int t;
+  t=gcd(u, v);
+  if(t == 0u)
+    return (unsigned int)0;
+
+  if(!(t == 0u))
+    (void)0;
+
+  else
+    /* assertion t != 0u */
+    __VERIFIER_error();
+  return (u * v) / t;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/llist.c line 36
+static void * llist_pop(struct llist_t **head)
+{
+  void *data = NULL;
+  struct llist_t *temp = *head;
+  if(!(temp == ((struct llist_t *)NULL)))
+  {
+    data = (void *)temp->data;
+    *head = temp->link;
+    free((void *)temp);
+  }
+
+  return data;
+}
+
+// file coreutils/od_bloaty.c line 1167
+signed int __main(signed int argc, char **argv)
+{
+  const char *str_A;
+  const char *str_N;
+  const char *str_j;
+  const char *str_S = "3";
+  struct llist_t *lst_t = (struct llist_t *)NULL;
+  unsigned int opt;
+  signed int l_c_m;
+  signed long int n_bytes_to_skip = (signed long int)0;
+  signed long int end_offset = (signed long int)0;
+  signed long int max_bytes_to_format = (signed long int)0;
+  spec = (struct tspec *)NULL;
+  format_address = format_address_std;
+  address_fmt[(signed long int)(sizeof(char [7l]) /*7ul*/  - (unsigned long int)3)] = (char)111;
+  address_fmt[(signed long int)2] = (char)55;
+  opt_complementary = "w+:t::";
+  static const char od_longopts[104l] = { (const char)115, (const char)107, (const char)105, (const char)112, (const char)45, (const char)98, (const char)121, (const char)116, (const char)101, (const char)115, (const char)0, (const char)1, (const char)106, (const char)97, (const char)100, (const char)100, (const char)114, (const char)101, (const char)115, (const char)115, (const char)45, (const char)114, (const char)97, (const char)100, (const char)105, (const char)120, (const char)0, (const char)1, (const char)65, (const char)114, (const char)101, (const char)97, (const char)100, (const char)45, (const char)98, (const char)121, (const char)116, (const char)101, (const char)115, (const char)0, (const char)1, (const char)78, (const char)102, (const char)111, (const char)114, (const char)109, (const char)97, (const char)116, (const char)0, (const char)1, (const char)116, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)45, (const char)100, (const char)117, (const char)112, (const char)108, (const char)105, (const char)99, (const char)97, (const char)116, (const char)101, (const char)115, (const char)0, (const char)0, (const char)118, (const char)115, (const char)116, (const char)114, (const char)105, (const char)110, (const char)103, (const char)115, (const char)0, (const char)2, (const char)83, (const char)119, (const char)105, (const char)100, (const char)116, (const char)104, (const char)0, (const char)2, (const char)119, (const char)116, (const char)114, (const char)97, (const char)100, (const char)105, (const char)116, (const char)105, (const char)111, (const char)110, (const char)97, (const char)108, (const char)0, (const char)0, (const char)255, (const char)0 };
+  applet_long_options = od_longopts;
+  opt=getopt32(argv, "A:N:abcdfhij:lot:vxsS:w::", &str_A, &str_N, &str_j, &lst_t, &str_S, &bytes_per_block);
+  argv = argv + (signed long int)optind;
+  if(!((1u & opt) == 0u))
+  {
+    char *p;
+    signed int pos;
+    char *return_value___builtin_strchr$1;
+
+    static const char doxn[5l] = { (const char)100, (const char)111, (const char)120, (const char)110, (const char)0 };
+    return_value___builtin_strchr$1=strchr(doxn, (signed int)str_A[(signed long int)0]);
+    p = return_value___builtin_strchr$1;
+    if(p == ((char *)NULL))
+    {
+
+      bb_error_msg_and_die("bad output address radix '%c' (must be [doxn])", str_A[(signed long int)0]);
+    }
+
+    pos = (signed int)(p - doxn);
+    if(pos == 3)
+      format_address = format_address_none;
+
+    if((signed long int)pos >= 0l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)pos >= 0 */
+      __VERIFIER_error();
+    if((signed long int)pos < 3l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)pos < 3l */
+      __VERIFIER_error();
+    static const char doxn_address_base_char[3l] = { (const char)117, (const char)111, (const char)120 };
+    address_fmt[(signed long int)(sizeof(char [7l]) /*7ul*/  - (unsigned long int)3)] = doxn_address_base_char[(signed long int)pos];
+    static const unsigned char doxn_address_pad_len_char[3l] = { (const unsigned char)55, (const unsigned char)55, (const unsigned char)54 };
+    address_fmt[(signed long int)2] = doxn_address_pad_len_char[(signed long int)pos];
+  }
+
+  if(!((2u & opt) == 0u))
+  {
+    unsigned long long int return_value_xstrtoull_sfx$2;
+    return_value_xstrtoull_sfx$2=xstrtoull_sfx(str_N, 0, bkm_suffixes);
+    max_bytes_to_format = (signed long int)return_value_xstrtoull_sfx$2;
+  }
+
+  if(!((4u & opt) == 0u))
+    decode_format_string("a");
+
+  if(!((8u & opt) == 0u))
+    decode_format_string("oC");
+
+  if(!((16u & opt) == 0u))
+    decode_format_string("c");
+
+  if(!((32u & opt) == 0u))
+    decode_format_string("u2");
+
+  if(!((64u & opt) == 0u))
+    decode_format_string("fF");
+
+  if(!((128u & opt) == 0u))
+    decode_format_string("x2");
+
+  if(!((256u & opt) == 0u))
+    decode_format_string("d2");
+
+  unsigned long long int return_value_xstrtoull_sfx$3;
+  if(!((512u & opt) == 0u))
+  {
+    return_value_xstrtoull_sfx$3=xstrtoull_sfx(str_j, 0, bkm_suffixes);
+    n_bytes_to_skip = (signed long int)return_value_xstrtoull_sfx$3;
+  }
+
+  if(!((1024u & opt) == 0u))
+    decode_format_string("d4");
+
+  if(!((2048u & opt) == 0u))
+    decode_format_string("o2");
+
+  while(!(lst_t == ((struct llist_t *)NULL)))
+  {
+    void *return_value_llist_pop$4;
+    return_value_llist_pop$4=llist_pop(&lst_t);
+    decode_format_string((const char *)return_value_llist_pop$4);
+  }
+  if(!((16384u & opt) == 0u))
+    decode_format_string("x2");
+
+  if(!((32768u & opt) == 0u))
+    decode_format_string("d2");
+
+  if(!((65536u & opt) == 0u))
+    string_min=xstrtou_sfx(str_S, 0, bkm_suffixes);
+
+  _Bool tmp_if_expr$9;
+  signed int return_value_parse_old_offset$8;
+  signed int return_value_parse_old_offset$6;
+  _Bool tmp_if_expr$12;
+  signed int return_value_parse_old_offset$11;
+  if(!((262144u & opt) == 0u))
+  {
+
+    if(!(*argv == ((char *)NULL)))
+    {
+      signed long int pseudo_start = (signed long int)-1;
+      signed long int o1;
+      signed long int o2;
+
+      if(*(1l + argv) == ((char *)NULL))
+      {
+        signed int return_value_parse_old_offset$5;
+        return_value_parse_old_offset$5=parse_old_offset(argv[(signed long int)0], &o1);
+        if(!(return_value_parse_old_offset$5 == 0))
+        {
+          n_bytes_to_skip = o1;
+          argv = argv + 1l;
+        }
+
+      }
+
+      else
+      {
+
+        if(*(2l + argv) == ((char *)NULL))
+        {
+          signed int return_value_parse_old_offset$7;
+
+          return_value_parse_old_offset$7=parse_old_offset(argv[(signed long int)0], &o1);
+          if(!(return_value_parse_old_offset$7 == 0))
+          {
+
+            return_value_parse_old_offset$8=parse_old_offset(argv[(signed long int)1], &o2);
+            tmp_if_expr$9 = (return_value_parse_old_offset$8 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+
+          else
+            tmp_if_expr$9 = 0 != 0;
+          if(!(tmp_if_expr$9 == (_Bool)0))
+          {
+            n_bytes_to_skip = o1;
+            pseudo_start = o2;
+            argv = argv + (signed long int)2;
+          }
+
+          else
+          {
+
+            return_value_parse_old_offset$6=parse_old_offset(argv[(signed long int)1], &o2);
+            if(!(return_value_parse_old_offset$6 == 0))
+            {
+              n_bytes_to_skip = o2;
+
+              argv[(signed long int)1] = (char *)NULL;
+            }
+
+            else
+            {
+
+              bb_error_msg_and_die("invalid second argument '%s'", argv[(signed long int)1]);
+            }
+          }
+        }
+
+        else
+        {
+
+          if(*(3l + argv) == ((char *)NULL))
+          {
+            signed int return_value_parse_old_offset$10;
+
+            return_value_parse_old_offset$10=parse_old_offset(argv[(signed long int)1], &o1);
+            if(!(return_value_parse_old_offset$10 == 0))
+            {
+
+              return_value_parse_old_offset$11=parse_old_offset(argv[(signed long int)2], &o2);
+              tmp_if_expr$12 = (return_value_parse_old_offset$11 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+            }
+
+            else
+              tmp_if_expr$12 = 0 != 0;
+            if(!(tmp_if_expr$12 == (_Bool)0))
+            {
+              n_bytes_to_skip = o1;
+              pseudo_start = o2;
+
+              argv[(signed long int)1] = (char *)NULL;
+            }
+
+            else
+              bb_error_msg_and_die("the last two arguments must be offsets");
+          }
+
+          else
+            bb_error_msg_and_die("too many arguments");
+        }
+      }
+      if(pseudo_start >= 0l)
+      {
+        if(format_address == format_address_none)
+        {
+          address_fmt[(signed long int)(sizeof(char [7l]) /*7ul*/  - (unsigned long int)3)] = (char)111;
+          address_fmt[(signed long int)2] = (char)55;
+          format_address = format_address_paren;
+        }
+
+        else
+          format_address = format_address_label;
+        pseudo_offset = pseudo_start - n_bytes_to_skip;
+      }
+
+    }
+
+  }
+
+  if(!((2u & option_mask32) == 0u))
+  {
+    end_offset = n_bytes_to_skip + max_bytes_to_format;
+    if(!(end_offset >= n_bytes_to_skip))
+      bb_error_msg_and_die("SKIP + SIZE is too large");
+
+  }
+
+  if(n_specs == 0ul)
+    decode_format_string("o2");
+
+  file_list = bb_argv_dash;
+
+  if(!(*argv == ((char *)NULL)))
+    file_list = (const char * const *)argv;
+
+  open_next_file();
+  skip(n_bytes_to_skip);
+  if(in_stream == ((struct _IO_FILE *)NULL))
+    return 1;
+
+  l_c_m=get_lcm();
+  if(!((131072u & opt) == 0u))
+  {
+    if(!(bytes_per_block == 0u))
+    {
+      if(!((unsigned int)l_c_m == 0u))
+        (void)0;
+
+      else
+        /* assertion (unsigned int)l_c_m != 0u */
+        __VERIFIER_error();
+      if(bytes_per_block % (unsigned int)l_c_m != 0u)
+        goto __CPROVER_DUMP_L77;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L77:
+      ;
+      bb_error_msg("warning: invalid width %u; using %d instead", (unsigned int)bytes_per_block, l_c_m);
+      bytes_per_block = (unsigned int)l_c_m;
+    }
+  }
+
+  else
+  {
+    bytes_per_block = (unsigned int)l_c_m;
+    if(l_c_m < 16)
+    {
+      if(!(l_c_m == 0))
+        (void)0;
+
+      else
+        /* assertion l_c_m != 0 */
+        __VERIFIER_error();
+      bytes_per_block = bytes_per_block * (unsigned int)(16 / l_c_m);
+    }
+
+  }
+  if(!((65536u & option_mask32) == 0u))
+    dump_strings(n_bytes_to_skip, end_offset);
+
+  else
+    dump(n_bytes_to_skip, end_offset);
+  signed int return_value_fclose$13;
+  return_value_fclose$13=fclose(stdin);
+  if(!(return_value_fclose$13 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_input);
+
+  return (signed int)exit_code;
+}
+
+// file coreutils/od_bloaty.c line 478
+static void open_next_file(void)
+{
+  const char * const *tmp_post$1;
+  for( ; (_Bool)1; exit_code = (signed char)1)
+  {
+
+    if(*file_list == ((const char *)NULL))
+      return;
+
+    tmp_post$1 = file_list;
+    file_list = file_list + 1l;
+
+    in_stream=fopen_or_warn_stdin(*tmp_post$1);
+    if(!(in_stream == ((struct _IO_FILE *)NULL)))
+      break;
+
+  }
+  if((65538u & option_mask32) == 2u)
+    setbuf(in_stream, (char *)NULL);
+
+}
+
+// file coreutils/od_bloaty.c line 1134
+static signed int parse_old_offset(const char *s, signed long int *offset)
+{
+  char *p;
+  signed int radix;
+
+  if((signed int)*s == 43)
+    s = s + 1l;
+
+
+  if(!(208 + (signed int)(unsigned char)(signed int)*s <= 9))
+    return 0;
+
+  char *return_value___builtin_strchr$1;
+  return_value___builtin_strchr$1=strchr(s, 46);
+  p = return_value___builtin_strchr$1;
+  radix = 8;
+  _Bool tmp_if_expr$2;
+  if(!(p == ((char *)NULL)))
+  {
+
+    p[(signed long int)0] = (char)0;
+    radix = 10;
+  }
+
+  else
+  {
+
+    if((signed int)*s == 48)
+    {
+
+      if((signed int)*(1l + s) == 120)
+        tmp_if_expr$2 = 1 != 0;
+
+      else
+      {
+
+        tmp_if_expr$2 = ((signed int)s[(signed long int)1] == 88 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        radix = 16;
+
+    }
+
+  }
+  unsigned long long int return_value_xstrtoull_sfx$3;
+  static struct suffix_mult Bb[3l] = { { .suffix={ (char)66, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 }, 
+    { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 }, 
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+  return_value_xstrtoull_sfx$3=xstrtoull_sfx(s, radix, Bb);
+
+  *offset = (signed long int)return_value_xstrtoull_sfx$3;
+  if(!(p == ((char *)NULL)))
+  {
+
+    p[(signed long int)0] = (char)46;
+  }
+
+
+  return (signed int)(*offset >= (signed long int)0);
+}
+
+// file coreutils/od_bloaty.c line 418
+static void print_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string)
+{
+  char buf[12l] = { (char)32, (char)32, (char)32, (char)120, (char)0, (char)32, (char)48, (char)120, (char)120, (char)0, (char)0, (char)0 };
+  unsigned long int tmp_post$1;
+  const char *tmp_post$2;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    const char *s;
+    unsigned int c;
+    tmp_post$2 = block;
+    block = block + 1l;
+
+    c = (unsigned int)*((unsigned char *)tmp_post$2);
+    if(c >= 32u)
+    {
+      if(!(c < 127u))
+        goto __CPROVER_DUMP_L4;
+
+      buf[(signed long int)3] = (char)c;
+      fputs(buf, stdout);
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L4:
+      ;
+      if(!(c == 0u))
+      {
+        if(c == 7u)
+          goto __CPROVER_DUMP_L6;
+
+        if(c == 8u)
+          goto __CPROVER_DUMP_L7;
+
+        if(c == 12u)
+          goto __CPROVER_DUMP_L8;
+
+        if(c == 10u)
+          goto __CPROVER_DUMP_L9;
+
+        if(c == 13u)
+          goto __CPROVER_DUMP_L10;
+
+        if(c == 9u)
+          goto __CPROVER_DUMP_L11;
+
+        if(c == 11u)
+          goto __CPROVER_DUMP_L12;
+
+        if(c == 127u)
+          goto __CPROVER_DUMP_L13;
+
+      }
+
+      else
+      {
+        s = "  \\0";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L6:
+        ;
+        s = "  \\a";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L7:
+        ;
+        s = "  \\b";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L8:
+        ;
+        s = "  \\f";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L9:
+        ;
+        s = "  \\n";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L10:
+        ;
+        s = "  \\r";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L11:
+        ;
+        s = "  \\t";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L12:
+        ;
+        s = "  \\v";
+        goto __CPROVER_DUMP_L15;
+
+      __CPROVER_DUMP_L13:
+        ;
+        s = " 177";
+        goto __CPROVER_DUMP_L15;
+      }
+      buf[(signed long int)7] = (char)((c >> 3) + (unsigned int)48);
+      buf[(signed long int)8] = (char)((c & (unsigned int)7) + (unsigned int)48);
+      s = buf + (signed long int)5;
+
+    __CPROVER_DUMP_L15:
+      ;
+      fputs(s, stdout);
+    }
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 268
+static void print_char(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    unsigned int tmp;
+
+    tmp = (unsigned int)*((unsigned char *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned char) /*1ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 352
+static void print_double(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(double) /*8ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    double tmp;
+
+    tmp = *((double *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(double) /*8ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 341
+static void print_float(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(float) /*4ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    float tmp;
+
+    tmp = *((float *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(float) /*4ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 300
+static void print_int(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(unsigned int) /*4ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    unsigned int tmp;
+
+    tmp = *((unsigned int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned int) /*4ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 314
+static void print_long(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(unsigned long int) /*8ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    unsigned long int tmp;
+
+    tmp = *((unsigned long int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned long int) /*8ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 363
+static void print_long_double(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(long double) /*16ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    long double tmp;
+
+    tmp = *((long double *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(long double) /*16ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 378
+static void print_named_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string)
+{
+  char buf[12l] = { (char)32, (char)32, (char)32, (char)120, (char)0, (char)32, (char)48, (char)120, (char)120, (char)0, (char)0, (char)0 };
+  unsigned long int tmp_post$1;
+  const char *tmp_post$2;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    unsigned int masked_c;
+    tmp_post$2 = block;
+    block = block + 1l;
+
+    masked_c = (unsigned int)*((unsigned char *)tmp_post$2);
+    masked_c = masked_c & (unsigned int)127;
+    if(masked_c == 127u)
+      fputs(" del", stdout);
+
+    else
+      if(masked_c > 32u)
+      {
+        buf[(signed long int)3] = (char)masked_c;
+        fputs(buf, stdout);
+      }
+
+      else
+      {
+        if((signed long int)masked_c < 33l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)masked_c < 33l */
+          __VERIFIER_error();
+        if(3l * (signed long int)masked_c >= 0l)
+          (void)0;
+
+        else
+          /* assertion 3 * (signed long int)masked_c >= 0 */
+          __VERIFIER_error();
+        static const char charname[33l][3l] = { { (const char)110, (const char)117, (const char)108 }, 
+    { (const char)115, (const char)111, (const char)104 }, 
+    { (const char)115, (const char)116, (const char)120 }, 
+    { (const char)101, (const char)116, (const char)120 }, 
+    { (const char)101, (const char)111, (const char)116 }, 
+    { (const char)101, (const char)110, (const char)113 }, 
+    { (const char)97, (const char)99, (const char)107 }, 
+    { (const char)98, (const char)101, (const char)108 }, 
+    { (const char)32, (const char)98, (const char)115 }, 
+    { (const char)32, (const char)104, (const char)116 }, 
+    { (const char)32, (const char)110, (const char)108 }, 
+    { (const char)32, (const char)118, (const char)116 }, 
+    { (const char)32, (const char)102, (const char)102 }, 
+    { (const char)32, (const char)99, (const char)114 }, 
+    { (const char)32, (const char)115, (const char)111 }, 
+    { (const char)32, (const char)115, (const char)105 }, 
+    { (const char)100, (const char)108, (const char)101 }, 
+    { (const char)100, (const char)99, (const char)49 }, 
+    { (const char)100, (const char)99, (const char)50 }, 
+    { (const char)100, (const char)99, (const char)51 }, 
+    { (const char)100, (const char)99, (const char)52 }, 
+    { (const char)110, (const char)97, (const char)107 }, 
+    { (const char)115, (const char)121, (const char)110 }, 
+    { (const char)101, (const char)116, (const char)98 }, 
+    { (const char)99, (const char)97, (const char)110 }, 
+    { (const char)32, (const char)101, (const char)109 }, 
+    { (const char)115, (const char)117, (const char)98 }, 
+    { (const char)101, (const char)115, (const char)99 }, 
+    { (const char)32, (const char)102, (const char)115 }, 
+    { (const char)32, (const char)103, (const char)115 }, 
+    { (const char)32, (const char)114, (const char)115 }, 
+    { (const char)32, (const char)117, (const char)115 }, 
+    { (const char)32, (const char)115, (const char)112 } };
+        buf[(signed long int)6] = charname[(signed long int)masked_c][(signed long int)0];
+        if(3l * (signed long int)masked_c + 1l >= 0l)
+          (void)0;
+
+        else
+          /* assertion 3 * (signed long int)masked_c + 1l >= 0 */
+          __VERIFIER_error();
+        buf[(signed long int)7] = charname[(signed long int)masked_c][(signed long int)1];
+        if(3l * (signed long int)masked_c + 2l >= 0l)
+          (void)0;
+
+        else
+          /* assertion 3 * (signed long int)masked_c + 2 >= 0 */
+          __VERIFIER_error();
+        buf[(signed long int)8] = charname[(signed long int)masked_c][(signed long int)2];
+        fputs(buf + (signed long int)5, stdout);
+      }
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 258
+static void print_s_char(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    signed int tmp;
+
+    tmp = (signed int)*((signed char *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned char) /*1ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 278
+static void print_s_short(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(signed short int) /*2ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    signed int tmp;
+
+    tmp = (signed int)*((signed short int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned short int) /*2ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 289
+static void print_short(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(unsigned short int) /*2ul*/ ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+
+    unsigned int tmp;
+
+    tmp = (unsigned int)*((unsigned short int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned short int) /*2ul*/ ;
+  }
+  while((_Bool)1);
+}
+
+// file coreutils/od_bloaty.c line 930
+static void read_block(unsigned long int n, char *block, unsigned long int *n_bytes_in_buffer)
+{
+  (void)0;
+
+  *n_bytes_in_buffer = (unsigned long int)0;
+  if(n == 0ul)
+    return;
+
+  while(!(in_stream == ((struct _IO_FILE *)NULL)))
+  {
+    unsigned long int n_needed;
+    unsigned long int n_read;
+
+    n_needed = n - *n_bytes_in_buffer;
+    n_read=fread((void *)(block + (signed long int)*n_bytes_in_buffer), (unsigned long int)1, n_needed, in_stream);
+
+    *n_bytes_in_buffer = *n_bytes_in_buffer + n_read;
+    if(n_read == n_needed)
+      break;
+
+    check_and_close();
+    open_next_file();
+  }
+}
+
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/od_bloaty.c line 763
+static void skip(signed long int n_skip)
+{
+  if(n_skip == 0l)
+    return;
+
+  while(!(in_stream == ((struct _IO_FILE *)NULL)))
+  {
+    struct stat file_stats;
+    signed int return_value_fileno$2;
+    return_value_fileno$2=fileno(in_stream);
+    signed int return_value_fstat$3;
+    return_value_fstat$3=fstat(return_value_fileno$2, &file_stats);
+    if((61440u & file_stats.st_mode) == 32768u)
+    {
+      if(!(return_value_fstat$3 == 0))
+        goto __CPROVER_DUMP_L5;
+
+      if(!(file_stats.st_size > 0l))
+        goto __CPROVER_DUMP_L5;
+
+      if(!(file_stats.st_size >= n_skip))
+        n_skip = n_skip - file_stats.st_size;
+
+      else
+      {
+        signed int return_value_fseeko$1;
+        return_value_fseeko$1=fseeko(in_stream, n_skip, 1);
+        if(!(return_value_fseeko$1 == 0))
+          exit_code = (signed char)1;
+
+        return;
+      }
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L5:
+      ;
+      char buf[1024l];
+      unsigned long int n_bytes_to_read = (unsigned long int)1024;
+      unsigned long int n_bytes_read;
+      while(n_skip > 0l)
+      {
+        if(!((unsigned long int)n_skip >= n_bytes_to_read))
+          n_bytes_to_read = (unsigned long int)n_skip;
+
+        n_bytes_read=fread((void *)buf, (unsigned long int)1, n_bytes_to_read, in_stream);
+        n_skip = n_skip - (signed long int)n_bytes_read;
+        if(!(n_bytes_read == n_bytes_to_read))
+          break;
+
+      }
+    }
+    if(n_skip == 0l)
+      return;
+
+    check_and_close();
+    open_next_file();
+  }
+  if(!(n_skip == 0l))
+    bb_error_msg_and_die("can't skip past end of combined input");
+
+}
+
+// file coreutils/od_bloaty.c line 888
+static void write_block(signed long int current_offset, unsigned long int n_bytes, const char *prev_block, const char *curr_block)
+{
+  unsigned long int i;
+  _Bool tmp_if_expr$2;
+  signed int return_value_memcmp$1;
+  static char first = (char)1;
+  if((8192u & option_mask32) == 0u)
+  {
+    if((signed int)first != 0)
+      goto __CPROVER_DUMP_L1;
+
+    if(!(n_bytes == (unsigned long int)bytes_per_block))
+      goto __CPROVER_DUMP_L1;
+
+    return_value_memcmp$1=memcmp((const void *)prev_block, (const void *)curr_block, (unsigned long int)bytes_per_block);
+    tmp_if_expr$2 = (return_value_memcmp$1 == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L1:
+    ;
+    tmp_if_expr$2 = 0 != 0;
+  }
+  static char prev_pair_equal = (char)0;
+  if(!(tmp_if_expr$2 == (_Bool)0))
+  {
+    if((signed int)prev_pair_equal == 0)
+    {
+      puts("*");
+      prev_pair_equal = (char)1;
+    }
+
+  }
+
+  else
+  {
+    first = (char)0;
+    prev_pair_equal = (char)0;
+    i = (unsigned long int)0;
+    for( ; !(i >= n_specs); i = i + 1ul)
+    {
+      if(i == 0ul)
+      {
+        if(!(format_address == ((void (*)(signed long int, char))NULL)))
+          (void)0;
+
+        else
+          /* assertion !(format_address == ((void (*)(signed long int, char))((void*)0))) */
+          __VERIFIER_error();
+        format_address(current_offset, (char)0);
+      }
+
+      else
+        printf("%*s", (signed int)address_fmt[(signed long int)2] - 48, "");
+
+      if(!((spec + (signed long int)i)->print_function == ((void (*)(unsigned long int, const char *, const char *))NULL)))
+        (void)0;
+
+      else
+        /* assertion !((spec + (signed long int)i)->print_function == ((void (*)(unsigned long int, const char *, const char *))((void*)0))) */
+        __VERIFIER_error();
+      (spec + (signed long int)i)->print_function(n_bytes, curr_block, (spec + (signed long int)i)->fmt_string);
+
+      if(!((spec + (signed long int)i)->hexl_mode_trailer == 0))
+      {
+        unsigned int datum_width;
+        if((signed long int)(spec + (signed long int)i)->size >= 0l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)(spec + (signed long int)i)->size >= 0 */
+          __VERIFIER_error();
+        if((signed long int)(spec + (signed long int)i)->size < 9l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)(spec + (signed long int)i)->size < 9l */
+          __VERIFIER_error();
+        datum_width = (unsigned int)width_bytes[(signed long int)(spec + (signed long int)i)->size];
+        unsigned int blank_fields;
+        if(!((unsigned long int)datum_width == 0ul))
+          (void)0;
+
+        else
+          /* assertion (unsigned long int)datum_width != 0ul */
+          __VERIFIER_error();
+        blank_fields = (unsigned int)(((unsigned long int)bytes_per_block - n_bytes) / (unsigned long int)datum_width);
+        unsigned int field_width = (unsigned int)((spec + (signed long int)i)->field_width + 1);
+        printf("%*s", blank_fields * field_width, "");
+        dump_hexl_mode_trailer(n_bytes, curr_block);
+      }
+
+      putchar(10);
+    }
+  }
+}
+
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  va_start(p, format);
+  r=vasprintf(&string_ptr, format, p);
+  va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  return string_ptr;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 707
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx)
+{
+  signed int mask = 1 << (signed int)(unsigned char)sizeof_and_shift;
+  if((-1 + mask & idx) == 0)
+  {
+    sizeof_and_shift = sizeof_and_shift >> 8;
+    vector=xrealloc(vector, (unsigned long int)(sizeof_and_shift * (unsigned int)(idx + mask + 1)));
+    memset((void *)((char *)vector + (signed long int)(sizeof_and_shift * (unsigned int)idx)), 0, (unsigned long int)(sizeof_and_shift * (unsigned int)(mask + 1)));
+  }
+
+  return vector;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file libbb/xatonum_template.c line 84
+static unsigned int xstrtou_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, base, (unsigned int)0, (unsigned int)2147483647 * 2u + 1u, suffixes);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file libbb/xatonum_template.c line 84
+static unsigned long long int xstrtoull_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, base, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/od_false-no-overflow.i
+++ b/c/busybox-1.22.0/od_false-no-overflow.i
@@ -1,0 +1,5031 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+struct tspec;
+static inline signed int bb_ascii_isalnum(unsigned char a);
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void check_and_close(void);
+static void decode_format_string(const char *s);
+static const char * decode_one_format(const char *s_orig, const char *s, struct tspec *tspec);
+void print_function$object(unsigned long int, const char *, const char *);
+static void dump(signed long int current_offset, signed long int end_offset);
+static void dump_hexl_mode_trailer(unsigned long int n_bytes, const char *block);
+static void dump_strings(signed long int address, signed long int end_offset);
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+static signed int fflush_all(void);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+void format_address$object(signed long int, char);
+static void format_address_label(signed long int address, char c);
+static void format_address_none(signed long int address, char c);
+static void format_address_paren(signed long int address, char c);
+static void format_address_std(signed long int address, char c);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int gcd(unsigned int u, unsigned int v);
+static signed int get_lcm(void);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+static unsigned int lcm(unsigned int u, unsigned int v);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static void * llist_pop(struct llist_t **head);
+static void open_next_file(void);
+static signed int parse_old_offset(const char *s, signed long int *offset);
+static void print_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string);
+static void print_char(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_double(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_float(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_int(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_long(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_long_double(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_named_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string);
+static void print_s_char(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_s_short(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void print_short(unsigned long int n_bytes, const char *block, const char *fmt_string);
+static void read_block(unsigned long int n, char *block, unsigned long int *n_bytes_in_buffer);
+static unsigned long long int ret_ERANGE(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void skip(signed long int n_skip);
+static void write_block(signed long int current_offset, unsigned long int n_bytes, const char *prev_block, const char *curr_block);
+static char * xasprintf(const char *format, ...);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static void * xrealloc(void *ptr, unsigned long int size);
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static unsigned int xstrtou_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes);
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+static unsigned long long int xstrtoull_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+struct tspec
+{
+  signed int fmt;
+  signed int size;
+  void (*print_function)(unsigned long int, const char *, const char *);
+  char *fmt_string;
+  signed int hexl_mode_trailer;
+  signed int field_width;
+};
+static char address_fmt[7l] = { (char)37, (char)48, (char)110, (char)108, (char)120, (char)99, (char)0 };
+static const char *applet_long_options;
+static const char *applet_name;
+static const char * const bb_argv_dash[2l] = { "-", (const char *)((void *)0) };
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct suffix_mult bkm_suffixes[4l] = { { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 },
+    { .suffix={ (char)107, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 },
+    { .suffix={ (char)109, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(1024 * 1024) },
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+static unsigned int bytes_per_block = (unsigned int)32;
+static const unsigned char bytes_to_hex_digits[17l] = { (const unsigned char)0, (const unsigned char)2, (const unsigned char)4, (const unsigned char)6, (const unsigned char)8, (const unsigned char)10, (const unsigned char)12, (const unsigned char)14, (const unsigned char)16, (const unsigned char)18, (const unsigned char)20, (const unsigned char)22, (const unsigned char)24, (const unsigned char)26, (const unsigned char)28, (const unsigned char)30, (const unsigned char)32 };
+static const unsigned char bytes_to_oct_digits[17l] = { (const unsigned char)0, (const unsigned char)3, (const unsigned char)6, (const unsigned char)8, (const unsigned char)11, (const unsigned char)14, (const unsigned char)16, (const unsigned char)19, (const unsigned char)22, (const unsigned char)25, (const unsigned char)27, (const unsigned char)30, (const unsigned char)32, (const unsigned char)35, (const unsigned char)38, (const unsigned char)41, (const unsigned char)43 };
+static const unsigned char bytes_to_signed_dec_digits[17l] = { (const unsigned char)1, (const unsigned char)4, (const unsigned char)6, (const unsigned char)8, (const unsigned char)11, (const unsigned char)13, (const unsigned char)16, (const unsigned char)18, (const unsigned char)20, (const unsigned char)23, (const unsigned char)25, (const unsigned char)28, (const unsigned char)30, (const unsigned char)33, (const unsigned char)35, (const unsigned char)37, (const unsigned char)40 };
+static const unsigned char bytes_to_unsigned_dec_digits[17l] = { (const unsigned char)0, (const unsigned char)3, (const unsigned char)5, (const unsigned char)8, (const unsigned char)10, (const unsigned char)13, (const unsigned char)15, (const unsigned char)17, (const unsigned char)20, (const unsigned char)22, (const unsigned char)25, (const unsigned char)27, (const unsigned char)29, (const unsigned char)32, (const unsigned char)34, (const unsigned char)37, (const unsigned char)39 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char exit_code;
+static const char * const *file_list;
+static void (*format_address)(signed long int, char);
+static const unsigned char fp_type_size[17l] = { (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)6, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)7, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)8 };
+static struct _IO_FILE *in_stream;
+static const unsigned char integral_type_size[9l] = { (const unsigned char)0, (const unsigned char)1, (const unsigned char)2, (const unsigned char)0, (const unsigned char)3, (const unsigned char)0, (const unsigned char)0, (const unsigned char)0, (const unsigned char)4 };
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned long int n_specs;
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static signed long int pseudo_offset;
+static struct tspec *spec;
+static unsigned int string_min;
+static const signed char width_bytes[9l] = { (const signed char)-1, (const signed char)sizeof(char) ,
+    (const signed char)sizeof(signed short int) ,
+    (const signed char)sizeof(signed int) ,
+    (const signed char)sizeof(signed long int) ,
+    (const signed char)sizeof(unsigned long long int) ,
+    (const signed char)sizeof(float) ,
+    (const signed char)sizeof(double) ,
+    (const signed char)sizeof(long double) };
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base)
+{
+  unsigned long int v;
+  char *endptr;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int return_value_bb_ascii_isalnum$2;
+  return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(arg[(signed long int)0]);
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(return_value_bb_ascii_isalnum$2 == 0)
+  {
+    return_value_ret_ERANGE$1=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$1;
+  }
+  *bb_errno = 0;
+  v=strtoul(arg, endp, base);
+  unsigned long long int return_value_ret_ERANGE$3;
+  if(v > 4294967295ul)
+  {
+    return_value_ret_ERANGE$3=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$3;
+  }
+  unsigned long long int return_value_handle_errors$4;
+  return_value_handle_errors$4=handle_errors(v, endp);
+  return (unsigned int)return_value_handle_errors$4;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void check_and_close(void)
+{
+  const char *tmp_if_expr$1;
+  if(!(in_stream == ((struct _IO_FILE *)((void *)0))))
+  {
+    signed int return_value_ferror$2;
+    return_value_ferror$2=ferror(in_stream);
+    if(!(return_value_ferror$2 == 0))
+    {
+      if(in_stream == stdin)
+        tmp_if_expr$1 = bb_msg_standard_input;
+      else
+      {
+        tmp_if_expr$1 = file_list[(signed long int)-1];
+      }
+      bb_error_msg("%s: read error", tmp_if_expr$1);
+      exit_code = (signed char)1;
+    }
+    fclose_if_not_stdin(in_stream);
+    in_stream = (struct _IO_FILE *)((void *)0);
+  }
+  signed int return_value_ferror$3;
+  return_value_ferror$3=ferror(stdout);
+  if(!(return_value_ferror$3 == 0))
+    bb_error_msg_and_die("write error");
+}
+static void decode_format_string(const char *s)
+{
+  const char *s_orig = s;
+  while((_Bool)1)
+  {
+    if((signed int)*s == 0)
+      break;
+    struct tspec tspec;
+    const char *next;
+    next=decode_one_format(s_orig, s, &tspec);
+    (void)0;
+    s = next;
+    void *return_value_xrealloc_vector_helper$1;
+    return_value_xrealloc_vector_helper$1=xrealloc_vector_helper((void *)spec, (unsigned int)((sizeof(struct tspec) << 8) + (unsigned long int)4), (signed int)n_specs);
+    spec = (struct tspec *)return_value_xrealloc_vector_helper$1;
+    memcpy((void *)&spec[(signed long int)n_specs], (const void *)&tspec, sizeof(struct tspec) );
+    n_specs = n_specs + 1ul;
+  }
+}
+static const char * decode_one_format(const char *s_orig, const char *s, struct tspec *tspec)
+{
+  signed int size_spec;
+  unsigned int size;
+  signed int fmt;
+  const char *p;
+  char *end;
+  char *fmt_string = (char *)((void *)0);
+  void (*print_function)(unsigned long int, const char *, const char *);
+  unsigned int c;
+  unsigned int field_width = (unsigned int)0;
+  signed int pos;
+  if((signed int)*s == 120 || !(s == ((const char *)((void *)0))))
+    (void)0;
+  else
+    __VERIFIER_error();
+  _Bool tmp_if_expr$1;
+  if(!((signed int)*s == 120))
+    tmp_if_expr$1 = !((signed int)*s == 117) ? (_Bool)1 : (_Bool)0;
+  else
+    tmp_if_expr$1 = (_Bool)0;
+  if(!(s == ((const char *)((void *)0))) || !tmp_if_expr$1)
+    (void)0;
+  else
+    __VERIFIER_error();
+  _Bool tmp_if_expr$2;
+  if(!((signed int)*s == 120))
+    tmp_if_expr$2 = !((signed int)*s == 117) ? (_Bool)1 : (_Bool)0;
+  else
+    tmp_if_expr$2 = (_Bool)0;
+  _Bool tmp_if_expr$3;
+  if(tmp_if_expr$2)
+    tmp_if_expr$3 = !((signed int)*s == 111) ? (_Bool)1 : (_Bool)0;
+  else
+    tmp_if_expr$3 = (_Bool)0;
+  if(!(s == ((const char *)((void *)0))) || !tmp_if_expr$3)
+    (void)0;
+  else
+    __VERIFIER_error();
+  const char *tmp_post$1;
+  _Bool decode_one_format$$1$$tmp_if_expr$4;
+  _Bool decode_one_format$$1$$tmp_if_expr$3;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$4;
+  if(!((signed int)*s == 100))
+    tmp_if_expr$4 = !((signed int)*s == 111) ? (_Bool)1 : (_Bool)0;
+  else
+    tmp_if_expr$4 = (_Bool)0;
+  _Bool tmp_if_expr$5;
+  if(tmp_if_expr$4)
+    tmp_if_expr$5 = !((signed int)*s == 117) ? (_Bool)1 : (_Bool)0;
+  else
+    tmp_if_expr$5 = (_Bool)0;
+  _Bool tmp_if_expr$6;
+  if(tmp_if_expr$5)
+    tmp_if_expr$6 = !((signed int)*s == 120) ? (_Bool)1 : (_Bool)0;
+  else
+    tmp_if_expr$6 = (_Bool)0;
+  if(tmp_if_expr$6)
+  {
+    if((signed int)*s == 102)
+      goto __CPROVER_DUMP_L64;
+    if((signed int)*s == 97)
+      goto __CPROVER_DUMP_L89;
+    if((signed int)*s == 99)
+      goto __CPROVER_DUMP_L90;
+  }
+  else
+  {
+    tmp_post$1 = s;
+    s = s + 1l;
+    c = (unsigned int)*tmp_post$1;
+    char *return_value___builtin_strchr$2;
+    static const char CSIL[5l] = { (const char)67, (const char)83, (const char)73, (const char)76, (const char)0 };
+    return_value___builtin_strchr$2=strchr(CSIL, (signed int)*s);
+    p = return_value___builtin_strchr$2;
+    if(p == ((const char *)((void *)0)))
+      decode_one_format$$1$$tmp_if_expr$4 = 1 != 0;
+    else
+    {
+      decode_one_format$$1$$tmp_if_expr$4 = ((signed int)*p == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(decode_one_format$$1$$tmp_if_expr$4 == (_Bool)0))
+    {
+      size = (unsigned int)sizeof(signed int) ;
+      if(208 + (signed int)(unsigned char)(signed int)*s <= 9)
+      {
+        size=bb_strtou(s, &end, 0);
+        if(*bb_errno == 34 || (unsigned long int)size > sizeof(unsigned long long int) )
+          decode_one_format$$1$$tmp_if_expr$3 = 1 != 0;
+        else
+        {
+          if((signed long int)size < 9l)
+            (void)0;
+          else
+            __VERIFIER_error();
+          decode_one_format$$1$$tmp_if_expr$3 = ((signed int)integral_type_size[(signed long int)size] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(decode_one_format$$1$$tmp_if_expr$3 == (_Bool)0))
+          bb_error_msg_and_die("invalid type string '%s'; %u-byte %s type is not supported", s_orig, size, (const void *)"integral");
+        s = end;
+      }
+    }
+    else
+    {
+      if(p - CSIL >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if(p - CSIL < 4l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      static const unsigned char CSIL_sizeof[4l] = { (const unsigned char)sizeof(char) ,
+    (const unsigned char)sizeof(signed short int) ,
+    (const unsigned char)sizeof(signed int) ,
+    (const unsigned char)sizeof(signed long int) };
+      size = (unsigned int)CSIL_sizeof[p - CSIL];
+      s = s + 1l;
+    }
+    if((signed long int)size < 9l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    size_spec = (signed int)integral_type_size[(signed long int)size];
+    char *return_value___builtin_strchr$5;
+    static const char doux[5l] = { (const char)100, (const char)111, (const char)117, (const char)120, (const char)0 };
+    return_value___builtin_strchr$5=strchr(doux, (signed int)c);
+    pos = (signed int)(return_value___builtin_strchr$5 - doux);
+    if(4l * (signed long int)pos >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)pos < 4l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    static const signed int doux_fmt[4l] = { (const signed int)0, (const signed int)2, (const signed int)1, (const signed int)3 };
+    fmt = doux_fmt[(signed long int)pos];
+    if(8l * (signed long int)pos >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    static const unsigned char * const doux_bytes_to_XXX[4l] = { bytes_to_signed_dec_digits, bytes_to_oct_digits, bytes_to_unsigned_dec_digits, bytes_to_hex_digits };
+    field_width = (unsigned int)doux_bytes_to_XXX[(signed long int)pos][(signed long int)size];
+    static const char doux_fmt_letter[4l][4l] = { { (const char)108, (const char)108, (const char)100, (const char)0 },
+    { (const char)108, (const char)108, (const char)111, (const char)0 },
+    { (const char)108, (const char)108, (const char)117, (const char)0 },
+    { (const char)108, (const char)108, (const char)120, (const char)0 } };
+    p = doux_fmt_letter[(signed long int)pos] + (signed long int)2;
+    if(size_spec == 4)
+      p = p - 1l;
+    if(size_spec == 5)
+      p = p - (signed long int)2;
+    static const char doux_fmtstring[4l][(signed long int)sizeof(char [9l]) ] = { { (const char)32, (const char)37, (const char)37, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0, (const char)0 },
+    { (const char)32, (const char)37, (const char)37, (const char)48, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0 },
+    { (const char)32, (const char)37, (const char)37, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0, (const char)0 },
+    { (const char)32, (const char)37, (const char)37, (const char)48, (const char)37, (const char)117, (const char)37, (const char)115, (const char)0 } };
+    fmt_string=xasprintf(doux_fmtstring[(signed long int)pos], field_width, p);
+    if(!(size_spec == 1))
+    {
+      if(size_spec == 2)
+        goto __CPROVER_DUMP_L59;
+      if(size_spec == 3)
+        goto __CPROVER_DUMP_L60;
+      if(size_spec == 4)
+        goto __CPROVER_DUMP_L61;
+    }
+    else
+    {
+      print_function = (signed int)fmt == 0 ? print_s_char : print_char;
+      goto __CPROVER_DUMP_L63;
+    __CPROVER_DUMP_L59:
+      ;
+      print_function = (signed int)fmt == 0 ? print_s_short : print_short;
+      goto __CPROVER_DUMP_L63;
+    __CPROVER_DUMP_L60:
+      ;
+      print_function = print_int;
+      goto __CPROVER_DUMP_L63;
+    __CPROVER_DUMP_L61:
+      ;
+      print_function = print_long;
+      goto __CPROVER_DUMP_L63;
+    }
+    print_function = print_long;
+  __CPROVER_DUMP_L63:
+    ;
+    goto __CPROVER_DUMP_L94;
+  __CPROVER_DUMP_L64:
+    ;
+    fmt = (signed int)4;
+    s = s + 1l;
+    char *return_value___builtin_strchr$6;
+    static const char FDL[4l] = { (const char)70, (const char)68, (const char)76, (const char)0 };
+    return_value___builtin_strchr$6=strchr(FDL, (signed int)*s);
+    p = return_value___builtin_strchr$6;
+    if(p == ((const char *)((void *)0)))
+    {
+      size = (unsigned int)sizeof(double) ;
+      if(208 + (signed int)(unsigned char)(signed int)*s <= 9)
+      {
+        size=bb_strtou(s, &end, 0);
+        if(*bb_errno == 34 || (unsigned long int)size > sizeof(long double) )
+          tmp_if_expr$7 = 1 != 0;
+        else
+        {
+          if((signed long int)size < 17l)
+            (void)0;
+          else
+            __VERIFIER_error();
+          tmp_if_expr$7 = ((signed int)fp_type_size[(signed long int)size] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$7 == (_Bool)0))
+          bb_error_msg_and_die("invalid type string '%s'; %u-byte %s type is not supported", s_orig, size, (const void *)"floating point");
+        s = end;
+      }
+    }
+    else
+    {
+      if(p - FDL >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if(p - FDL < 3l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      static const unsigned char FDL_sizeof[3l] = { (const unsigned char)sizeof(float) ,
+    (const unsigned char)sizeof(double) ,
+    (const unsigned char)sizeof(long double) };
+      size = (unsigned int)FDL_sizeof[p - FDL];
+    }
+    if((signed long int)size < 17l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    size_spec = (signed int)fp_type_size[(signed long int)size];
+    if(!(size_spec == 6))
+    {
+      if(size_spec == 7)
+        goto __CPROVER_DUMP_L86;
+    }
+    else
+    {
+      print_function = print_float;
+      field_width = (unsigned int)(7 + 8);
+      fmt_string=xasprintf(" %%%d.%de", field_width, 7);
+      goto __CPROVER_DUMP_L88;
+    __CPROVER_DUMP_L86:
+      ;
+      print_function = print_double;
+      field_width = (unsigned int)(15 + 8);
+      fmt_string=xasprintf(" %%%d.%de", field_width, 15);
+      goto __CPROVER_DUMP_L88;
+    }
+    print_function = print_long_double;
+    field_width = (unsigned int)(15 + 8);
+    fmt_string=xasprintf(" %%%d.%dLe", field_width, 15);
+  __CPROVER_DUMP_L88:
+    ;
+    goto __CPROVER_DUMP_L94;
+  __CPROVER_DUMP_L89:
+    ;
+    s = s + 1l;
+    fmt = (signed int)5;
+    size_spec = (signed int)1;
+    print_function = print_named_ascii;
+    field_width = (unsigned int)3;
+    goto __CPROVER_DUMP_L94;
+  __CPROVER_DUMP_L90:
+    ;
+    s = s + 1l;
+    fmt = (signed int)6;
+    size_spec = (signed int)1;
+    print_function = print_ascii;
+    field_width = (unsigned int)3;
+    goto __CPROVER_DUMP_L94;
+  }
+  bb_error_msg_and_die("invalid character '%c' in type string '%s'", *s, s_orig);
+__CPROVER_DUMP_L94:
+  ;
+  tspec->size = size_spec;
+  tspec->fmt = fmt;
+  tspec->print_function = print_function;
+  tspec->fmt_string = fmt_string;
+  tspec->field_width = (signed int)field_width;
+  tspec->hexl_mode_trailer = (signed int)((signed int)*s == 122);
+  if(!(tspec->hexl_mode_trailer == 0))
+    s = s + 1l;
+  return s;
+}
+static void dump(signed long int current_offset, signed long int end_offset)
+{
+  char *block[2l];
+  signed int idx;
+  unsigned long int n_bytes_read;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)((unsigned int)2 * bytes_per_block));
+  block[(signed long int)0] = (char *)return_value_xmalloc$1;
+  block[(signed long int)1] = block[(signed long int)0] + (signed long int)bytes_per_block;
+  idx = 0;
+  if(!((2u & option_mask32) == 0u))
+    while((_Bool)1)
+    {
+      unsigned long int n_needed;
+      if(current_offset >= end_offset)
+      {
+        n_bytes_read = (unsigned long int)0;
+        break;
+      }
+      n_needed = (unsigned long int)(end_offset - current_offset < (signed long int)bytes_per_block ? end_offset - current_offset : (signed long int)bytes_per_block);
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      read_block(n_needed, block[(signed long int)idx], &n_bytes_read);
+      if(!(n_bytes_read >= (unsigned long int)bytes_per_block))
+        break;
+      (void)0;
+      if(8l * (signed long int)(1 ^ idx) >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)(1 ^ idx) < 2l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      write_block(current_offset, n_bytes_read, block[(signed long int)(idx ^ 1)], block[(signed long int)idx]);
+      current_offset = current_offset + (signed long int)n_bytes_read;
+      idx = idx ^ 1;
+    }
+  else
+    for( ; (_Bool)1; idx = idx ^ 1)
+    {
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      read_block((unsigned long int)bytes_per_block, block[(signed long int)idx], &n_bytes_read);
+      if(!(n_bytes_read >= (unsigned long int)bytes_per_block))
+        break;
+      (void)0;
+      if(8l * (signed long int)(1 ^ idx) >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)(1 ^ idx) < 2l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if(8l * (signed long int)idx >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)idx < 2l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      write_block(current_offset, n_bytes_read, block[(signed long int)(idx ^ 1)], block[(signed long int)idx]);
+      current_offset = current_offset + (signed long int)n_bytes_read;
+    }
+  if(n_bytes_read > 0ul)
+  {
+    signed int l_c_m;
+    unsigned long int bytes_to_write;
+    l_c_m=get_lcm();
+    if(!((unsigned long int)l_c_m == 0ul))
+      (void)0;
+    else
+      __VERIFIER_error();
+    bytes_to_write = (unsigned long int)l_c_m * (((n_bytes_read + (unsigned long int)l_c_m) - (unsigned long int)1) / (unsigned long int)l_c_m);
+    if(8l * (signed long int)idx >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)idx < 2l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    memset((void *)(block[(signed long int)idx] + (signed long int)n_bytes_read), 0, bytes_to_write - n_bytes_read);
+    if(8l * (signed long int)(1 ^ idx) >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)(1 ^ idx) < 2l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(8l * (signed long int)idx >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)idx < 2l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    write_block(current_offset, bytes_to_write, block[(signed long int)(idx ^ 1)], block[(signed long int)idx]);
+    current_offset = current_offset + (signed long int)n_bytes_read;
+  }
+  if(!(format_address == ((void (*)(signed long int, char))((void *)0))))
+    (void)0;
+  else
+    __VERIFIER_error();
+  format_address(current_offset, (char)10);
+  if(!((2u & option_mask32) == 0u))
+  {
+    if(current_offset >= end_offset)
+      check_and_close();
+  }
+  free((void *)block[(signed long int)0]);
+}
+static void dump_hexl_mode_trailer(unsigned long int n_bytes, const char *block)
+{
+  fputs("  >", stdout);
+  unsigned long int tmp_post$1;
+  const char *tmp_post$2;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    unsigned int c;
+    tmp_post$2 = block;
+    block = block + 1l;
+    c = (unsigned int)*((unsigned char *)tmp_post$2);
+    c = c >= (unsigned int)32 && c < (unsigned int)127 ? c : (unsigned int)46;
+    putchar((signed int)c);
+  }
+  while((_Bool)1);
+  putchar(60);
+}
+static void dump_strings(signed long int address, signed long int end_offset)
+{
+  unsigned int bufsize = (unsigned int)100 > string_min ? (unsigned int)100 : string_min;
+  unsigned char *buf;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc((unsigned long int)bufsize);
+  buf = (unsigned char *)return_value_xmalloc$1;
+  unsigned long int tmp_post$3;
+  while((_Bool)1)
+  {
+    unsigned long int i;
+    signed int c;
+    do
+    {
+    tryline:
+      ;
+    __CPROVER_DUMP_L3:
+      ;
+      if(!((2u & option_mask32) == 0u))
+      {
+        if(address >= end_offset + -((signed long int)string_min))
+          goto __CPROVER_DUMP_L13;
+      }
+      i = (unsigned long int)0;
+    __CPROVER_DUMP_L5:
+      ;
+      if(!((2u & option_mask32) == 0u))
+      {
+        if(address >= end_offset)
+          goto __CPROVER_DUMP_L11;
+      }
+      if(i == (unsigned long int)bufsize)
+      {
+        bufsize = bufsize + bufsize / (unsigned int)8;
+        void *return_value_xrealloc$2;
+        return_value_xrealloc$2=xrealloc((void *)buf, (unsigned long int)bufsize);
+        buf = (unsigned char *)return_value_xrealloc$2;
+      }
+      while(!(in_stream == ((struct _IO_FILE *)((void *)0))))
+      {
+        c=_IO_getc (in_stream);
+        if(c != -1)
+          goto got_char;
+        check_and_close();
+        open_next_file();
+      }
+      goto ret;
+    got_char:
+      ;
+      address = address + 1l;
+      if(c == 0)
+        goto __CPROVER_DUMP_L12;
+    }
+    while(!(c < 127) || !(c >= 32));
+    tmp_post$3 = i;
+    i = i + 1ul;
+  __CPROVER_DUMP_L11:
+    ;
+    buf[(signed long int)tmp_post$3] = (unsigned char)c;
+    goto __CPROVER_DUMP_L5;
+  __CPROVER_DUMP_L12:
+    ;
+    if(!(i >= (unsigned long int)string_min))
+      goto __CPROVER_DUMP_L3;
+  __CPROVER_DUMP_L13:
+    ;
+    buf[(signed long int)i] = (unsigned char)0;
+    if(!(format_address == ((void (*)(signed long int, char))((void *)0))))
+      (void)0;
+    else
+      __VERIFIER_error();
+    format_address((signed long int)(((unsigned long int)address - i) - (unsigned long int)1), (char)32);
+    i = (unsigned long int)0;
+    while((_Bool)1)
+    {
+      c = (signed int)buf[(signed long int)i];
+      if(c == 0)
+        break;
+      if(!(c == 7))
+      {
+        if(c == 8)
+          goto __CPROVER_DUMP_L22;
+        if(c == 12)
+          goto __CPROVER_DUMP_L23;
+        if(c == 10)
+          goto __CPROVER_DUMP_L24;
+        if(c == 13)
+          goto __CPROVER_DUMP_L25;
+        if(c == 9)
+          goto __CPROVER_DUMP_L26;
+        if(c == 11)
+          goto __CPROVER_DUMP_L27;
+      }
+      else
+      {
+        fputs("\\a", stdout);
+        goto __CPROVER_DUMP_L29;
+      __CPROVER_DUMP_L22:
+        ;
+        fputs("\\b", stdout);
+        goto __CPROVER_DUMP_L29;
+      __CPROVER_DUMP_L23:
+        ;
+        fputs("\\f", stdout);
+        goto __CPROVER_DUMP_L29;
+      __CPROVER_DUMP_L24:
+        ;
+        fputs("\\n", stdout);
+        goto __CPROVER_DUMP_L29;
+      __CPROVER_DUMP_L25:
+        ;
+        fputs("\\r", stdout);
+        goto __CPROVER_DUMP_L29;
+      __CPROVER_DUMP_L26:
+        ;
+        fputs("\\t", stdout);
+        goto __CPROVER_DUMP_L29;
+      __CPROVER_DUMP_L27:
+        ;
+        fputs("\\v", stdout);
+        goto __CPROVER_DUMP_L29;
+      }
+      putchar(c);
+    __CPROVER_DUMP_L29:
+      ;
+      i = i + 1ul;
+    }
+    putchar(10);
+  }
+  check_and_close();
+ret:
+  ;
+  free((void *)buf);
+}
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+  return r;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static void format_address_label(signed long int address, char c)
+{
+  format_address_std(address, (char)32);
+  format_address_paren(address + pseudo_offset, c);
+}
+static void format_address_none(signed long int address, char c)
+{
+  ;
+}
+static void format_address_paren(signed long int address, char c)
+{
+  putchar(40);
+  format_address_std(address, (char)41);
+  if(!((signed int)c == 0))
+    putchar((signed int)c);
+}
+static void format_address_std(signed long int address, char c)
+{
+  address_fmt[(signed long int)(sizeof(char [7l]) - (unsigned long int)2)] = c;
+  printf(address_fmt, address);
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int gcd(unsigned int u, unsigned int v)
+{
+  unsigned int t;
+  for( ; !(v == 0u); v = t)
+  {
+    if(!(v == 0u))
+      (void)0;
+    else
+      __VERIFIER_error();
+    t = u % v;
+    u = v;
+  }
+  return u;
+}
+static signed int get_lcm(void)
+{
+  unsigned long int i;
+  signed int l_c_m = 1;
+  i = (unsigned long int)0;
+  unsigned int return_value_lcm$1;
+  for( ; !(i >= n_specs); i = i + 1ul)
+  {
+    if((signed long int)(spec + (signed long int)i)->size >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)(spec + (signed long int)i)->size < 9l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    return_value_lcm$1=lcm((unsigned int)l_c_m, (unsigned int)width_bytes[(signed long int)(signed int)(spec + (signed long int)i)->size]);
+    l_c_m = (signed int)return_value_lcm$1;
+  }
+  return l_c_m;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+    *bb_errno = 22;
+  }
+  return v;
+}
+static unsigned int lcm(unsigned int u, unsigned int v)
+{
+  unsigned int t;
+  t=gcd(u, v);
+  if(t == 0u)
+    return (unsigned int)0;
+  if(!(t == 0u))
+    (void)0;
+  else
+    __VERIFIER_error();
+  return (u * v) / t;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static void * llist_pop(struct llist_t **head)
+{
+  void *data = ((void *)0);
+  struct llist_t *temp = *head;
+  if(!(temp == ((struct llist_t *)((void *)0))))
+  {
+    data = (void *)temp->data;
+    *head = temp->link;
+    free((void *)temp);
+  }
+  return data;
+}
+signed int __main(signed int argc, char **argv)
+{
+  const char *str_A;
+  const char *str_N;
+  const char *str_j;
+  const char *str_S = "3";
+  struct llist_t *lst_t = (struct llist_t *)((void *)0);
+  unsigned int opt;
+  signed int l_c_m;
+  signed long int n_bytes_to_skip = (signed long int)0;
+  signed long int end_offset = (signed long int)0;
+  signed long int max_bytes_to_format = (signed long int)0;
+  spec = (struct tspec *)((void *)0);
+  format_address = format_address_std;
+  address_fmt[(signed long int)(sizeof(char [7l]) - (unsigned long int)3)] = (char)111;
+  address_fmt[(signed long int)2] = (char)55;
+  opt_complementary = "w+:t::";
+  static const char od_longopts[104l] = { (const char)115, (const char)107, (const char)105, (const char)112, (const char)45, (const char)98, (const char)121, (const char)116, (const char)101, (const char)115, (const char)0, (const char)1, (const char)106, (const char)97, (const char)100, (const char)100, (const char)114, (const char)101, (const char)115, (const char)115, (const char)45, (const char)114, (const char)97, (const char)100, (const char)105, (const char)120, (const char)0, (const char)1, (const char)65, (const char)114, (const char)101, (const char)97, (const char)100, (const char)45, (const char)98, (const char)121, (const char)116, (const char)101, (const char)115, (const char)0, (const char)1, (const char)78, (const char)102, (const char)111, (const char)114, (const char)109, (const char)97, (const char)116, (const char)0, (const char)1, (const char)116, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)45, (const char)100, (const char)117, (const char)112, (const char)108, (const char)105, (const char)99, (const char)97, (const char)116, (const char)101, (const char)115, (const char)0, (const char)0, (const char)118, (const char)115, (const char)116, (const char)114, (const char)105, (const char)110, (const char)103, (const char)115, (const char)0, (const char)2, (const char)83, (const char)119, (const char)105, (const char)100, (const char)116, (const char)104, (const char)0, (const char)2, (const char)119, (const char)116, (const char)114, (const char)97, (const char)100, (const char)105, (const char)116, (const char)105, (const char)111, (const char)110, (const char)97, (const char)108, (const char)0, (const char)0, (const char)255, (const char)0 };
+  applet_long_options = od_longopts;
+  opt=getopt32(argv, "A:N:abcdfhij:lot:vxsS:w::", &str_A, &str_N, &str_j, &lst_t, &str_S, &bytes_per_block);
+  argv = argv + (signed long int)optind;
+  if(!((1u & opt) == 0u))
+  {
+    char *p;
+    signed int pos;
+    char *return_value___builtin_strchr$1;
+    static const char doxn[5l] = { (const char)100, (const char)111, (const char)120, (const char)110, (const char)0 };
+    return_value___builtin_strchr$1=strchr(doxn, (signed int)str_A[(signed long int)0]);
+    p = return_value___builtin_strchr$1;
+    if(p == ((char *)((void *)0)))
+    {
+      bb_error_msg_and_die("bad output address radix '%c' (must be [doxn])", str_A[(signed long int)0]);
+    }
+    pos = (signed int)(p - doxn);
+    if(pos == 3)
+      format_address = format_address_none;
+    if((signed long int)pos >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)pos < 3l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    static const char doxn_address_base_char[3l] = { (const char)117, (const char)111, (const char)120 };
+    address_fmt[(signed long int)(sizeof(char [7l]) - (unsigned long int)3)] = doxn_address_base_char[(signed long int)pos];
+    static const unsigned char doxn_address_pad_len_char[3l] = { (const unsigned char)55, (const unsigned char)55, (const unsigned char)54 };
+    address_fmt[(signed long int)2] = doxn_address_pad_len_char[(signed long int)pos];
+  }
+  if(!((2u & opt) == 0u))
+  {
+    unsigned long long int return_value_xstrtoull_sfx$2;
+    return_value_xstrtoull_sfx$2=xstrtoull_sfx(str_N, 0, bkm_suffixes);
+    max_bytes_to_format = (signed long int)return_value_xstrtoull_sfx$2;
+  }
+  if(!((4u & opt) == 0u))
+    decode_format_string("a");
+  if(!((8u & opt) == 0u))
+    decode_format_string("oC");
+  if(!((16u & opt) == 0u))
+    decode_format_string("c");
+  if(!((32u & opt) == 0u))
+    decode_format_string("u2");
+  if(!((64u & opt) == 0u))
+    decode_format_string("fF");
+  if(!((128u & opt) == 0u))
+    decode_format_string("x2");
+  if(!((256u & opt) == 0u))
+    decode_format_string("d2");
+  unsigned long long int return_value_xstrtoull_sfx$3;
+  if(!((512u & opt) == 0u))
+  {
+    return_value_xstrtoull_sfx$3=xstrtoull_sfx(str_j, 0, bkm_suffixes);
+    n_bytes_to_skip = (signed long int)return_value_xstrtoull_sfx$3;
+  }
+  if(!((1024u & opt) == 0u))
+    decode_format_string("d4");
+  if(!((2048u & opt) == 0u))
+    decode_format_string("o2");
+  while(!(lst_t == ((struct llist_t *)((void *)0))))
+  {
+    void *return_value_llist_pop$4;
+    return_value_llist_pop$4=llist_pop(&lst_t);
+    decode_format_string((const char *)return_value_llist_pop$4);
+  }
+  if(!((16384u & opt) == 0u))
+    decode_format_string("x2");
+  if(!((32768u & opt) == 0u))
+    decode_format_string("d2");
+  if(!((65536u & opt) == 0u))
+    string_min=xstrtou_sfx(str_S, 0, bkm_suffixes);
+  _Bool tmp_if_expr$9;
+  signed int return_value_parse_old_offset$8;
+  signed int return_value_parse_old_offset$6;
+  _Bool tmp_if_expr$12;
+  signed int return_value_parse_old_offset$11;
+  if(!((262144u & opt) == 0u))
+  {
+    if(!(*argv == ((char *)((void *)0))))
+    {
+      signed long int pseudo_start = (signed long int)-1;
+      signed long int o1;
+      signed long int o2;
+      if(*(1l + argv) == ((char *)((void *)0)))
+      {
+        signed int return_value_parse_old_offset$5;
+        return_value_parse_old_offset$5=parse_old_offset(argv[(signed long int)0], &o1);
+        if(!(return_value_parse_old_offset$5 == 0))
+        {
+          n_bytes_to_skip = o1;
+          argv = argv + 1l;
+        }
+      }
+      else
+      {
+        if(*(2l + argv) == ((char *)((void *)0)))
+        {
+          signed int return_value_parse_old_offset$7;
+          return_value_parse_old_offset$7=parse_old_offset(argv[(signed long int)0], &o1);
+          if(!(return_value_parse_old_offset$7 == 0))
+          {
+            return_value_parse_old_offset$8=parse_old_offset(argv[(signed long int)1], &o2);
+            tmp_if_expr$9 = (return_value_parse_old_offset$8 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          else
+            tmp_if_expr$9 = 0 != 0;
+          if(!(tmp_if_expr$9 == (_Bool)0))
+          {
+            n_bytes_to_skip = o1;
+            pseudo_start = o2;
+            argv = argv + (signed long int)2;
+          }
+          else
+          {
+            return_value_parse_old_offset$6=parse_old_offset(argv[(signed long int)1], &o2);
+            if(!(return_value_parse_old_offset$6 == 0))
+            {
+              n_bytes_to_skip = o2;
+              argv[(signed long int)1] = (char *)((void *)0);
+            }
+            else
+            {
+              bb_error_msg_and_die("invalid second argument '%s'", argv[(signed long int)1]);
+            }
+          }
+        }
+        else
+        {
+          if(*(3l + argv) == ((char *)((void *)0)))
+          {
+            signed int return_value_parse_old_offset$10;
+            return_value_parse_old_offset$10=parse_old_offset(argv[(signed long int)1], &o1);
+            if(!(return_value_parse_old_offset$10 == 0))
+            {
+              return_value_parse_old_offset$11=parse_old_offset(argv[(signed long int)2], &o2);
+              tmp_if_expr$12 = (return_value_parse_old_offset$11 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+            }
+            else
+              tmp_if_expr$12 = 0 != 0;
+            if(!(tmp_if_expr$12 == (_Bool)0))
+            {
+              n_bytes_to_skip = o1;
+              pseudo_start = o2;
+              argv[(signed long int)1] = (char *)((void *)0);
+            }
+            else
+              bb_error_msg_and_die("the last two arguments must be offsets");
+          }
+          else
+            bb_error_msg_and_die("too many arguments");
+        }
+      }
+      if(pseudo_start >= 0l)
+      {
+        if(format_address == format_address_none)
+        {
+          address_fmt[(signed long int)(sizeof(char [7l]) - (unsigned long int)3)] = (char)111;
+          address_fmt[(signed long int)2] = (char)55;
+          format_address = format_address_paren;
+        }
+        else
+          format_address = format_address_label;
+        pseudo_offset = pseudo_start - n_bytes_to_skip;
+      }
+    }
+  }
+  if(!((2u & option_mask32) == 0u))
+  {
+    end_offset = n_bytes_to_skip + max_bytes_to_format;
+    if(!(end_offset >= n_bytes_to_skip))
+      bb_error_msg_and_die("SKIP + SIZE is too large");
+  }
+  if(n_specs == 0ul)
+    decode_format_string("o2");
+  file_list = bb_argv_dash;
+  if(!(*argv == ((char *)((void *)0))))
+    file_list = (const char * const *)argv;
+  open_next_file();
+  skip(n_bytes_to_skip);
+  if(in_stream == ((struct _IO_FILE *)((void *)0)))
+    return 1;
+  l_c_m=get_lcm();
+  if(!((131072u & opt) == 0u))
+  {
+    if(!(bytes_per_block == 0u))
+    {
+      if(!((unsigned int)l_c_m == 0u))
+        (void)0;
+      else
+        __VERIFIER_error();
+      if(bytes_per_block % (unsigned int)l_c_m != 0u)
+        goto __CPROVER_DUMP_L77;
+    }
+    else
+    {
+    __CPROVER_DUMP_L77:
+      ;
+      bb_error_msg("warning: invalid width %u; using %d instead", (unsigned int)bytes_per_block, l_c_m);
+      bytes_per_block = (unsigned int)l_c_m;
+    }
+  }
+  else
+  {
+    bytes_per_block = (unsigned int)l_c_m;
+    if(l_c_m < 16)
+    {
+      if(!(l_c_m == 0))
+        (void)0;
+      else
+        __VERIFIER_error();
+      bytes_per_block = bytes_per_block * (unsigned int)(16 / l_c_m);
+    }
+  }
+  if(!((65536u & option_mask32) == 0u))
+    dump_strings(n_bytes_to_skip, end_offset);
+  else
+    dump(n_bytes_to_skip, end_offset);
+  signed int return_value_fclose$13;
+  return_value_fclose$13=fclose(stdin);
+  if(!(return_value_fclose$13 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_input);
+  return (signed int)exit_code;
+}
+static void open_next_file(void)
+{
+  const char * const *tmp_post$1;
+  for( ; (_Bool)1; exit_code = (signed char)1)
+  {
+    if(*file_list == ((const char *)((void *)0)))
+      return;
+    tmp_post$1 = file_list;
+    file_list = file_list + 1l;
+    in_stream=fopen_or_warn_stdin(*tmp_post$1);
+    if(!(in_stream == ((struct _IO_FILE *)((void *)0))))
+      break;
+  }
+  if((65538u & option_mask32) == 2u)
+    setbuf(in_stream, (char *)((void *)0));
+}
+static signed int parse_old_offset(const char *s, signed long int *offset)
+{
+  char *p;
+  signed int radix;
+  if((signed int)*s == 43)
+    s = s + 1l;
+  if(!(208 + (signed int)(unsigned char)(signed int)*s <= 9))
+    return 0;
+  char *return_value___builtin_strchr$1;
+  return_value___builtin_strchr$1=strchr(s, 46);
+  p = return_value___builtin_strchr$1;
+  radix = 8;
+  _Bool tmp_if_expr$2;
+  if(!(p == ((char *)((void *)0))))
+  {
+    p[(signed long int)0] = (char)0;
+    radix = 10;
+  }
+  else
+  {
+    if((signed int)*s == 48)
+    {
+      if((signed int)*(1l + s) == 120)
+        tmp_if_expr$2 = 1 != 0;
+      else
+      {
+        tmp_if_expr$2 = ((signed int)s[(signed long int)1] == 88 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        radix = 16;
+    }
+  }
+  unsigned long long int return_value_xstrtoull_sfx$3;
+  static struct suffix_mult Bb[3l] = { { .suffix={ (char)66, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 },
+    { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 },
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+  return_value_xstrtoull_sfx$3=xstrtoull_sfx(s, radix, Bb);
+  *offset = (signed long int)return_value_xstrtoull_sfx$3;
+  if(!(p == ((char *)((void *)0))))
+  {
+    p[(signed long int)0] = (char)46;
+  }
+  return (signed int)(*offset >= (signed long int)0);
+}
+static void print_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string)
+{
+  char buf[12l] = { (char)32, (char)32, (char)32, (char)120, (char)0, (char)32, (char)48, (char)120, (char)120, (char)0, (char)0, (char)0 };
+  unsigned long int tmp_post$1;
+  const char *tmp_post$2;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    const char *s;
+    unsigned int c;
+    tmp_post$2 = block;
+    block = block + 1l;
+    c = (unsigned int)*((unsigned char *)tmp_post$2);
+    if(c >= 32u)
+    {
+      if(!(c < 127u))
+        goto __CPROVER_DUMP_L4;
+      buf[(signed long int)3] = (char)c;
+      fputs(buf, stdout);
+    }
+    else
+    {
+    __CPROVER_DUMP_L4:
+      ;
+      if(!(c == 0u))
+      {
+        if(c == 7u)
+          goto __CPROVER_DUMP_L6;
+        if(c == 8u)
+          goto __CPROVER_DUMP_L7;
+        if(c == 12u)
+          goto __CPROVER_DUMP_L8;
+        if(c == 10u)
+          goto __CPROVER_DUMP_L9;
+        if(c == 13u)
+          goto __CPROVER_DUMP_L10;
+        if(c == 9u)
+          goto __CPROVER_DUMP_L11;
+        if(c == 11u)
+          goto __CPROVER_DUMP_L12;
+        if(c == 127u)
+          goto __CPROVER_DUMP_L13;
+      }
+      else
+      {
+        s = "  \\0";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L6:
+        ;
+        s = "  \\a";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L7:
+        ;
+        s = "  \\b";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L8:
+        ;
+        s = "  \\f";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L9:
+        ;
+        s = "  \\n";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L10:
+        ;
+        s = "  \\r";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L11:
+        ;
+        s = "  \\t";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L12:
+        ;
+        s = "  \\v";
+        goto __CPROVER_DUMP_L15;
+      __CPROVER_DUMP_L13:
+        ;
+        s = " 177";
+        goto __CPROVER_DUMP_L15;
+      }
+      buf[(signed long int)7] = (char)((c >> 3) + (unsigned int)48);
+      buf[(signed long int)8] = (char)((c & (unsigned int)7) + (unsigned int)48);
+      s = buf + (signed long int)5;
+    __CPROVER_DUMP_L15:
+      ;
+      fputs(s, stdout);
+    }
+  }
+  while((_Bool)1);
+}
+static void print_char(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    unsigned int tmp;
+    tmp = (unsigned int)*((unsigned char *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned char) ;
+  }
+  while((_Bool)1);
+}
+static void print_double(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(double) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    double tmp;
+    tmp = *((double *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(double) ;
+  }
+  while((_Bool)1);
+}
+static void print_float(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(float) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    float tmp;
+    tmp = *((float *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(float) ;
+  }
+  while((_Bool)1);
+}
+static void print_int(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(unsigned int) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    unsigned int tmp;
+    tmp = *((unsigned int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned int) ;
+  }
+  while((_Bool)1);
+}
+static void print_long(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(unsigned long int) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    unsigned long int tmp;
+    tmp = *((unsigned long int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned long int) ;
+  }
+  while((_Bool)1);
+}
+static void print_long_double(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(long double) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    long double tmp;
+    tmp = *((long double *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(long double) ;
+  }
+  while((_Bool)1);
+}
+static void print_named_ascii(unsigned long int n_bytes, const char *block, const char *unused_fmt_string)
+{
+  char buf[12l] = { (char)32, (char)32, (char)32, (char)120, (char)0, (char)32, (char)48, (char)120, (char)120, (char)0, (char)0, (char)0 };
+  unsigned long int tmp_post$1;
+  const char *tmp_post$2;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    unsigned int masked_c;
+    tmp_post$2 = block;
+    block = block + 1l;
+    masked_c = (unsigned int)*((unsigned char *)tmp_post$2);
+    masked_c = masked_c & (unsigned int)127;
+    if(masked_c == 127u)
+      fputs(" del", stdout);
+    else
+      if(masked_c > 32u)
+      {
+        buf[(signed long int)3] = (char)masked_c;
+        fputs(buf, stdout);
+      }
+      else
+      {
+        if((signed long int)masked_c < 33l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        if(3l * (signed long int)masked_c >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        static const char charname[33l][3l] = { { (const char)110, (const char)117, (const char)108 },
+    { (const char)115, (const char)111, (const char)104 },
+    { (const char)115, (const char)116, (const char)120 },
+    { (const char)101, (const char)116, (const char)120 },
+    { (const char)101, (const char)111, (const char)116 },
+    { (const char)101, (const char)110, (const char)113 },
+    { (const char)97, (const char)99, (const char)107 },
+    { (const char)98, (const char)101, (const char)108 },
+    { (const char)32, (const char)98, (const char)115 },
+    { (const char)32, (const char)104, (const char)116 },
+    { (const char)32, (const char)110, (const char)108 },
+    { (const char)32, (const char)118, (const char)116 },
+    { (const char)32, (const char)102, (const char)102 },
+    { (const char)32, (const char)99, (const char)114 },
+    { (const char)32, (const char)115, (const char)111 },
+    { (const char)32, (const char)115, (const char)105 },
+    { (const char)100, (const char)108, (const char)101 },
+    { (const char)100, (const char)99, (const char)49 },
+    { (const char)100, (const char)99, (const char)50 },
+    { (const char)100, (const char)99, (const char)51 },
+    { (const char)100, (const char)99, (const char)52 },
+    { (const char)110, (const char)97, (const char)107 },
+    { (const char)115, (const char)121, (const char)110 },
+    { (const char)101, (const char)116, (const char)98 },
+    { (const char)99, (const char)97, (const char)110 },
+    { (const char)32, (const char)101, (const char)109 },
+    { (const char)115, (const char)117, (const char)98 },
+    { (const char)101, (const char)115, (const char)99 },
+    { (const char)32, (const char)102, (const char)115 },
+    { (const char)32, (const char)103, (const char)115 },
+    { (const char)32, (const char)114, (const char)115 },
+    { (const char)32, (const char)117, (const char)115 },
+    { (const char)32, (const char)115, (const char)112 } };
+        buf[(signed long int)6] = charname[(signed long int)masked_c][(signed long int)0];
+        if(3l * (signed long int)masked_c + 1l >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        buf[(signed long int)7] = charname[(signed long int)masked_c][(signed long int)1];
+        if(3l * (signed long int)masked_c + 2l >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        buf[(signed long int)8] = charname[(signed long int)masked_c][(signed long int)2];
+        fputs(buf + (signed long int)5, stdout);
+      }
+  }
+  while((_Bool)1);
+}
+static void print_s_char(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    signed int tmp;
+    tmp = (signed int)*((signed char *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned char) ;
+  }
+  while((_Bool)1);
+}
+static void print_s_short(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(signed short int) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    signed int tmp;
+    tmp = (signed int)*((signed short int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned short int) ;
+  }
+  while((_Bool)1);
+}
+static void print_short(unsigned long int n_bytes, const char *block, const char *fmt_string)
+{
+  n_bytes = n_bytes / sizeof(unsigned short int) ;
+  unsigned long int tmp_post$1;
+  do
+  {
+    tmp_post$1 = n_bytes;
+    n_bytes = n_bytes - 1ul;
+    if(tmp_post$1 == 0ul)
+      break;
+    unsigned int tmp;
+    tmp = (unsigned int)*((unsigned short int *)block);
+    printf(fmt_string, tmp);
+    block = block + (signed long int)sizeof(unsigned short int) ;
+  }
+  while((_Bool)1);
+}
+static void read_block(unsigned long int n, char *block, unsigned long int *n_bytes_in_buffer)
+{
+  (void)0;
+  *n_bytes_in_buffer = (unsigned long int)0;
+  if(n == 0ul)
+    return;
+  while(!(in_stream == ((struct _IO_FILE *)((void *)0))))
+  {
+    unsigned long int n_needed;
+    unsigned long int n_read;
+    n_needed = n - *n_bytes_in_buffer;
+    n_read=fread((void *)(block + (signed long int)*n_bytes_in_buffer), (unsigned long int)1, n_needed, in_stream);
+    *n_bytes_in_buffer = *n_bytes_in_buffer + n_read;
+    if(n_read == n_needed)
+      break;
+    check_and_close();
+    open_next_file();
+  }
+}
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void skip(signed long int n_skip)
+{
+  if(n_skip == 0l)
+    return;
+  while(!(in_stream == ((struct _IO_FILE *)((void *)0))))
+  {
+    struct stat file_stats;
+    signed int return_value_fileno$2;
+    return_value_fileno$2=fileno(in_stream);
+    signed int return_value_fstat$3;
+    return_value_fstat$3=fstat(return_value_fileno$2, &file_stats);
+    if((61440u & file_stats.st_mode) == 32768u)
+    {
+      if(!(return_value_fstat$3 == 0))
+        goto __CPROVER_DUMP_L5;
+      if(!(file_stats.st_size > 0l))
+        goto __CPROVER_DUMP_L5;
+      if(!(file_stats.st_size >= n_skip))
+        n_skip = n_skip - file_stats.st_size;
+      else
+      {
+        signed int return_value_fseeko$1;
+        return_value_fseeko$1=fseeko(in_stream, n_skip, 1);
+        if(!(return_value_fseeko$1 == 0))
+          exit_code = (signed char)1;
+        return;
+      }
+    }
+    else
+    {
+    __CPROVER_DUMP_L5:
+      ;
+      char buf[1024l];
+      unsigned long int n_bytes_to_read = (unsigned long int)1024;
+      unsigned long int n_bytes_read;
+      while(n_skip > 0l)
+      {
+        if(!((unsigned long int)n_skip >= n_bytes_to_read))
+          n_bytes_to_read = (unsigned long int)n_skip;
+        n_bytes_read=fread((void *)buf, (unsigned long int)1, n_bytes_to_read, in_stream);
+        n_skip = n_skip - (signed long int)n_bytes_read;
+        if(!(n_bytes_read == n_bytes_to_read))
+          break;
+      }
+    }
+    if(n_skip == 0l)
+      return;
+    check_and_close();
+    open_next_file();
+  }
+  if(!(n_skip == 0l))
+    bb_error_msg_and_die("can't skip past end of combined input");
+}
+static void write_block(signed long int current_offset, unsigned long int n_bytes, const char *prev_block, const char *curr_block)
+{
+  unsigned long int i;
+  _Bool tmp_if_expr$2;
+  signed int return_value_memcmp$1;
+  static char first = (char)1;
+  if((8192u & option_mask32) == 0u)
+  {
+    if((signed int)first != 0)
+      goto __CPROVER_DUMP_L1;
+    if(!(n_bytes == (unsigned long int)bytes_per_block))
+      goto __CPROVER_DUMP_L1;
+    return_value_memcmp$1=memcmp((const void *)prev_block, (const void *)curr_block, (unsigned long int)bytes_per_block);
+    tmp_if_expr$2 = (return_value_memcmp$1 == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  else
+  {
+  __CPROVER_DUMP_L1:
+    ;
+    tmp_if_expr$2 = 0 != 0;
+  }
+  static char prev_pair_equal = (char)0;
+  if(!(tmp_if_expr$2 == (_Bool)0))
+  {
+    if((signed int)prev_pair_equal == 0)
+    {
+      puts("*");
+      prev_pair_equal = (char)1;
+    }
+  }
+  else
+  {
+    first = (char)0;
+    prev_pair_equal = (char)0;
+    i = (unsigned long int)0;
+    for( ; !(i >= n_specs); i = i + 1ul)
+    {
+      if(i == 0ul)
+      {
+        if(!(format_address == ((void (*)(signed long int, char))((void *)0))))
+          (void)0;
+        else
+          __VERIFIER_error();
+        format_address(current_offset, (char)0);
+      }
+      else
+        printf("%*s", (signed int)address_fmt[(signed long int)2] - 48, "");
+      if(!((spec + (signed long int)i)->print_function == ((void (*)(unsigned long int, const char *, const char *))((void *)0))))
+        (void)0;
+      else
+        __VERIFIER_error();
+      (spec + (signed long int)i)->print_function(n_bytes, curr_block, (spec + (signed long int)i)->fmt_string);
+      if(!((spec + (signed long int)i)->hexl_mode_trailer == 0))
+      {
+        unsigned int datum_width;
+        if((signed long int)(spec + (signed long int)i)->size >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        if((signed long int)(spec + (signed long int)i)->size < 9l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        datum_width = (unsigned int)width_bytes[(signed long int)(spec + (signed long int)i)->size];
+        unsigned int blank_fields;
+        if(!((unsigned long int)datum_width == 0ul))
+          (void)0;
+        else
+          __VERIFIER_error();
+        blank_fields = (unsigned int)(((unsigned long int)bytes_per_block - n_bytes) / (unsigned long int)datum_width);
+        unsigned int field_width = (unsigned int)((spec + (signed long int)i)->field_width + 1);
+        printf("%*s", blank_fields * field_width, "");
+        dump_hexl_mode_trailer(n_bytes, curr_block);
+      }
+      putchar(10);
+    }
+  }
+}
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  __builtin_va_start(p,format);
+  r=vasprintf(&string_ptr, format, p);
+  __builtin_va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+  return string_ptr;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc_vector_helper(void *vector, unsigned int sizeof_and_shift, signed int idx)
+{
+  signed int mask = 1 << (signed int)(unsigned char)sizeof_and_shift;
+  if((-1 + mask & idx) == 0)
+  {
+    sizeof_and_shift = sizeof_and_shift >> 8;
+    vector=xrealloc(vector, (unsigned long int)(sizeof_and_shift * (unsigned int)(idx + mask + 1)));
+    memset((void *)((char *)vector + (signed long int)(sizeof_and_shift * (unsigned int)idx)), 0, (unsigned long int)(sizeof_and_shift * (unsigned int)(mask + 1)));
+  }
+  return vector;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static unsigned int xstrtou_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, base, (unsigned int)0, (unsigned int)2147483647 * 2u + 1u, suffixes);
+  return return_value_xstrtou_range_sfx$1;
+}
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static unsigned long long int xstrtoull_sfx(const char *numstr, signed int base, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, base, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -444,7 +444,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2626,7 +2626,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/printf_false-no-overflow.c
+++ b/c/busybox-1.22.0/printf_false-no-overflow.c
@@ -1,0 +1,1332 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a);
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 374
+static char bb_process_escape_sequence(const char **ptr);
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/bb_strtonum.c line 142
+static signed int bb_strtoi(const char *arg, char **endp, signed int base);
+// file libbb/bb_strtonum.c line 73
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base);
+// file include/xatonum.h line 127
+static unsigned long long int bb_strtoull(const char *arg, char **endp, signed int base);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file coreutils/printf.c line 100
+static void conv_strtod(const char *arg, void *result);
+// file coreutils/printf.c line 96
+static void conv_strtoll(const char *arg, void *result);
+// file coreutils/printf.c line 84
+static void conv_strtoull(const char *arg, void *result);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file coreutils/printf.c line 251
+static signed int get_width_prec(const char *str);
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+// file coreutils/printf.c line 70
+static signed int multiconvert(const char *arg, void *result, void (*convert)(const char *, void *));
+// 
+void convert$object(const char *, void *);
+// file coreutils/printf.c line 127
+static double my_xstrtod(const char *arg);
+// file coreutils/printf.c line 120
+static signed long long int my_xstrtoll(const char *arg);
+// file coreutils/printf.c line 113
+static unsigned long long int my_xstrtoull(const char *arg);
+// file include/libbb.h line 650
+static void overlapping_strcpy(char *dst, const char *src);
+// file coreutils/printf.c line 160
+static void print_direc(char *format, unsigned int fmt_length, signed int field_width, signed int precision, const char *argument);
+// file coreutils/printf.c line 135
+static void print_esc_string(const char *str);
+// file coreutils/printf.c line 263
+static char ** print_formatted(char *f, char **argv, signed int *conv_err);
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 815
+static char * utoa(unsigned int n);
+// file include/libbb.h line 818
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/xfuncs.c line 114
+static char local_buf[(signed long int)(sizeof(signed int) * 3) /*12l*/ ];
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 374
+static char bb_process_escape_sequence(const char **ptr)
+{
+  const char *q;
+  unsigned int num_digits;
+  unsigned int n;
+  unsigned int base;
+  n = (unsigned int)0;
+  num_digits = n;
+  base = (unsigned int)8;
+  q = *ptr;
+  if((signed int)*q == 120)
+  {
+    q = q + 1l;
+    base = (unsigned int)16;
+    num_digits = num_digits + 1u;
+  }
+
+  do
+  {
+    unsigned int r;
+    unsigned int d = (unsigned int)((signed int)(unsigned char)((signed int)*q | (signed int)(char)32) - 48);
+    if(d >= 10u)
+      d = d + (unsigned int)((48 - 97) + 10);
+
+    if(d >= base)
+    {
+      if(base == 16u)
+      {
+        num_digits = num_digits - 1u;
+        if(num_digits == 0u)
+          return (char)92;
+
+      }
+
+      break;
+    }
+
+    r = n * base + d;
+    if(r > 255u)
+      break;
+
+    n = r;
+    q = q + 1l;
+    num_digits = num_digits + 1u;
+  }
+  while(num_digits < 3u);
+  if(num_digits == 0u)
+  {
+    static const char charmap[20l] = { (const char)97, (const char)98, (const char)101, (const char)102, (const char)110, (const char)114, (const char)116, (const char)118, (const char)92, (const char)0, (const char)7, (const char)8, (const char)27, (const char)12, (const char)10, (const char)13, (const char)9, (const char)11, (const char)92, (const char)92 };
+    const char *p = charmap;
+    while((_Bool)1)
+    {
+      if(*p == *q)
+      {
+        q = q + 1l;
+        break;
+      }
+
+      p = p + 1l;
+      if((signed int)*p == 0)
+        break;
+
+    }
+    n = (unsigned int)p[(signed long int)(sizeof(const char [20l]) /*20ul*/  / (unsigned long int)2)];
+  }
+
+  *ptr = q;
+  return (char)n;
+}
+
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/bb_strtonum.c line 142
+static signed int bb_strtoi(const char *arg, char **endp, signed int base)
+{
+  signed long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed int)return_value_ret_ERANGE$2;
+  }
+
+  *bb_errno = 0;
+  v=strtol(arg, endp, base);
+  unsigned long long int return_value_ret_ERANGE$4;
+  if(v > 2147483647l)
+  {
+    return_value_ret_ERANGE$4=ret_ERANGE();
+    return (signed int)return_value_ret_ERANGE$4;
+  }
+
+  unsigned long long int return_value_ret_ERANGE$5;
+  if(v < -2147483648l)
+  {
+    return_value_ret_ERANGE$5=ret_ERANGE();
+    return (signed int)return_value_ret_ERANGE$5;
+  }
+
+  unsigned long long int return_value_handle_errors$6;
+  return_value_handle_errors$6=handle_errors((unsigned long long int)v, endp);
+  return (signed int)return_value_handle_errors$6;
+}
+
+// file libbb/bb_strtonum.c line 73
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed long long int)return_value_ret_ERANGE$2;
+  }
+
+  *bb_errno = 0;
+  signed long long int return_value_strtoll$4;
+  return_value_strtoll$4=strtoll(arg, endp, base);
+  v = (unsigned long long int)return_value_strtoll$4;
+  unsigned long long int return_value_handle_errors$5;
+  return_value_handle_errors$5=handle_errors(v, endp);
+  return (signed long long int)return_value_handle_errors$5;
+}
+
+// file include/xatonum.h line 127
+static unsigned long long int bb_strtoull(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int return_value_bb_ascii_isalnum$2;
+  return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(arg[(signed long int)0]);
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(return_value_bb_ascii_isalnum$2 == 0)
+  {
+    return_value_ret_ERANGE$1=ret_ERANGE();
+    return return_value_ret_ERANGE$1;
+  }
+
+  *bb_errno = 0;
+  v=strtoull(arg, endp, base);
+  unsigned long long int return_value_handle_errors$3;
+  return_value_handle_errors$3=handle_errors(v, endp);
+  return return_value_handle_errors$3;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/printf.c line 100
+static void conv_strtod(const char *arg, void *result)
+{
+  char *end;
+  if(!(result == NULL))
+    (void)0;
+
+  else
+    /* assertion !(result == ((void*)0)) */
+    __VERIFIER_error();
+  *((double *)result)=strtod(arg, &end);
+
+  if(!((signed int)*end == 0))
+  {
+
+    *bb_errno = 34;
+    if(!(result == NULL))
+      (void)0;
+
+    else
+      /* assertion !(result == ((void*)0)) */
+      __VERIFIER_error();
+    *((double *)result) = (double)0;
+  }
+
+}
+
+// file coreutils/printf.c line 96
+static void conv_strtoll(const char *arg, void *result)
+{
+  if(!(result == NULL))
+    (void)0;
+
+  else
+    /* assertion !(result == ((void*)0)) */
+    __VERIFIER_error();
+  *((signed long long int *)result)=bb_strtoll(arg, (char **)NULL, 0);
+}
+
+// file coreutils/printf.c line 84
+static void conv_strtoull(const char *arg, void *result)
+{
+  if(!(result == NULL))
+    (void)0;
+
+  else
+    /* assertion !(result == ((void*)0)) */
+    __VERIFIER_error();
+  *((unsigned long long int *)result)=bb_strtoull(arg, (char **)NULL, 0);
+
+  if(!(*bb_errno == 0))
+  {
+    signed long long int return_value_bb_strtoll$1;
+    return_value_bb_strtoll$1=bb_strtoll(arg, (char **)NULL, 0);
+    if(!(result == NULL))
+      (void)0;
+
+    else
+      /* assertion !(result == ((void*)0)) */
+      __VERIFIER_error();
+    *((unsigned long long int *)result) = (unsigned long long int)return_value_bb_strtoll$1;
+  }
+
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/printf.c line 251
+static signed int get_width_prec(const char *str)
+{
+  signed int v;
+  v=bb_strtoi(str, (char **)NULL, 10);
+
+  if(!(*bb_errno == 0))
+  {
+    bb_error_msg("invalid number '%s'", str);
+    v = 0;
+  }
+
+  return v;
+}
+
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+
+    *bb_errno = 22;
+  }
+
+  return v;
+}
+
+// file coreutils/printf.c line 70
+static signed int multiconvert(const char *arg, void *result, void (*convert)(const char *, void *))
+{
+  _Bool tmp_if_expr$1;
+
+  if((signed int)*arg == 34)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+  {
+
+    tmp_if_expr$1 = ((signed int)*arg == 39 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$1 == (_Bool)0))
+  {
+
+    arg=utoa((unsigned int)(unsigned char)arg[(signed long int)1]);
+  }
+
+
+  *bb_errno = 0;
+  if(!(convert == ((void (*)(const char *, void *))NULL)))
+    (void)0;
+
+  else
+    /* assertion !(convert == ((void (*)(const char *, void *))((void*)0))) */
+    __VERIFIER_error();
+  convert(arg, result);
+
+  if(!(*bb_errno == 0))
+  {
+    bb_error_msg("invalid number '%s'", arg);
+    return 1;
+  }
+
+  return 0;
+}
+
+// file coreutils/printf.c line 127
+static double my_xstrtod(const char *arg)
+{
+  double result;
+  multiconvert(arg, (void *)&result, conv_strtod);
+  return result;
+}
+
+// file coreutils/printf.c line 120
+static signed long long int my_xstrtoll(const char *arg)
+{
+  signed long long int result;
+  signed int return_value_multiconvert$1;
+  return_value_multiconvert$1=multiconvert(arg, (void *)&result, conv_strtoll);
+  if(!(return_value_multiconvert$1 == 0))
+    result = (signed long long int)0;
+
+  return result;
+}
+
+// file coreutils/printf.c line 113
+static unsigned long long int my_xstrtoull(const char *arg)
+{
+  unsigned long long int result;
+  signed int return_value_multiconvert$1;
+  return_value_multiconvert$1=multiconvert(arg, (void *)&result, conv_strtoull);
+  if(!(return_value_multiconvert$1 == 0))
+    result = (unsigned long long int)0;
+
+  return result;
+}
+
+// file include/libbb.h line 650
+static void overlapping_strcpy(char *dst, const char *src)
+{
+  if(!(dst == src))
+    do
+    {
+      *dst = *src;
+      if((signed int)*dst == 0)
+        break;
+
+      dst = dst + 1l;
+      src = src + 1l;
+    }
+    while((_Bool)1);
+
+}
+
+// file coreutils/printf.c line 160
+static void print_direc(char *format, unsigned int fmt_length, signed int field_width, signed int precision, const char *argument)
+{
+  signed long long int llv;
+  double dv;
+  char saved;
+  char *have_prec;
+  char *have_width;
+
+  saved = format[(signed long int)fmt_length];
+  format[(signed long int)fmt_length] = (char)0;
+  have_prec=strstr(format, ".*");
+  char *return_value___builtin_strchr$1;
+  return_value___builtin_strchr$1=strchr(format, 42);
+  have_width = return_value___builtin_strchr$1;
+  if(-1l + have_width == have_prec)
+    have_width = (char *)NULL;
+
+
+  *bb_errno = 0;
+
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$5;
+  _Bool tmp_if_expr$6;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  _Bool tmp_if_expr$11;
+  _Bool tmp_if_expr$12;
+  _Bool tmp_if_expr$13;
+  _Bool tmp_if_expr$14;
+  _Bool tmp_if_expr$15;
+  _Bool tmp_if_expr$16;
+  _Bool tmp_if_expr$17;
+  if(!((signed int)format[(signed long int)(4294967295u + fmt_length)] == 99))
+  {
+    if((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 105 || !(format == ((char *)NULL)))
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 105) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 100)
+      tmp_if_expr$1 = (_Bool)1;
+
+    else
+      tmp_if_expr$1 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 105 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$1)
+      goto __CPROVER_DUMP_L61;
+
+    if((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 88 || !(format == ((char *)NULL)))
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 88) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 88))
+      tmp_if_expr$2 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 120) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$2 = (_Bool)0;
+    if(!(format == ((char *)NULL)) || !tmp_if_expr$2)
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 88) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 120) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 88))
+      tmp_if_expr$3 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 120) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$3 = (_Bool)0;
+    if(tmp_if_expr$3)
+      tmp_if_expr$4 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 117) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$4 = (_Bool)0;
+    if(!(format == ((char *)NULL)) || !tmp_if_expr$4)
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 88) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 120) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 117) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 88)
+      tmp_if_expr$5 = (_Bool)1;
+
+    else
+      tmp_if_expr$5 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 111 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$5)
+      tmp_if_expr$6 = (_Bool)1;
+
+    else
+      tmp_if_expr$6 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 117 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$6)
+      tmp_if_expr$7 = (_Bool)1;
+
+    else
+      tmp_if_expr$7 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 120 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$7)
+      goto __CPROVER_DUMP_L68;
+
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 115)
+      goto __CPROVER_DUMP_L69;
+
+    if((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71 || !(format == ((char *)NULL)))
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 71) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71))
+      tmp_if_expr$8 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$8 = (_Bool)0;
+    if(!(format == ((char *)NULL)) || !tmp_if_expr$8)
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 71) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71))
+      tmp_if_expr$9 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$9 = (_Bool)0;
+    if(tmp_if_expr$9)
+      tmp_if_expr$10 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 69) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$10 = (_Bool)0;
+    if(!(format == ((char *)NULL)) || !tmp_if_expr$10)
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 71) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 69) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71))
+      tmp_if_expr$11 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$11 = (_Bool)0;
+    if(tmp_if_expr$11)
+      tmp_if_expr$12 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 69) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$12 = (_Bool)0;
+    if(tmp_if_expr$12)
+      tmp_if_expr$13 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 101) ? (_Bool)1 : (_Bool)0;
+
+    else
+      tmp_if_expr$13 = (_Bool)0;
+    if(!(format == ((char *)NULL)) || !tmp_if_expr$13)
+      (void)0;
+
+    else
+      /* assertion !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 71) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 69) && !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 101) ==> !(format == ((char *)((void*)0))) */
+      __VERIFIER_error();
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 69)
+      tmp_if_expr$14 = (_Bool)1;
+
+    else
+      tmp_if_expr$14 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$14)
+      tmp_if_expr$15 = (_Bool)1;
+
+    else
+      tmp_if_expr$15 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 101 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$15)
+      tmp_if_expr$16 = (_Bool)1;
+
+    else
+      tmp_if_expr$16 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 102 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$16)
+      tmp_if_expr$17 = (_Bool)1;
+
+    else
+      tmp_if_expr$17 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 103 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$17)
+      goto __CPROVER_DUMP_L70;
+
+  }
+
+  else
+  {
+
+    printf(format, *argument);
+    goto __CPROVER_DUMP_L76;
+
+  __CPROVER_DUMP_L61:
+    ;
+    llv=my_xstrtoll(argument);
+
+  print_long:
+    ;
+    if(have_width == ((char *)NULL))
+    {
+      if(have_prec == ((char *)NULL))
+        printf(format, llv);
+
+      else
+        printf(format, precision, llv);
+    }
+
+    else
+      if(have_prec == ((char *)NULL))
+        printf(format, field_width, llv);
+
+      else
+        printf(format, field_width, precision, llv);
+    goto __CPROVER_DUMP_L76;
+
+  __CPROVER_DUMP_L68:
+    ;
+    unsigned long long int return_value_my_xstrtoull$2;
+    return_value_my_xstrtoull$2=my_xstrtoull(argument);
+    llv = (signed long long int)return_value_my_xstrtoull$2;
+    goto print_long;
+
+  __CPROVER_DUMP_L69:
+    ;
+    llv = (signed long int)argument;
+    goto print_long;
+
+  __CPROVER_DUMP_L70:
+    ;
+    dv=my_xstrtod(argument);
+    if(have_width == ((char *)NULL))
+    {
+      if(have_prec == ((char *)NULL))
+        printf(format, dv);
+
+      else
+        printf(format, precision, dv);
+    }
+
+    else
+      if(have_prec == ((char *)NULL))
+        printf(format, field_width, dv);
+
+      else
+        printf(format, field_width, precision, dv);
+    goto __CPROVER_DUMP_L76;
+  }
+
+__CPROVER_DUMP_L76:
+  ;
+
+  format[(signed long int)fmt_length] = saved;
+}
+
+// file coreutils/printf.c line 135
+static void print_esc_string(const char *str)
+{
+  char c;
+  while((_Bool)1)
+  {
+
+    c = *str;
+    if((signed int)c == 0)
+      break;
+
+    str = str + 1l;
+    if((signed int)c == 92)
+    {
+
+      if((signed int)*str == 48)
+      {
+
+        if(208 + (signed int)(unsigned char)(signed int)*(1l + str) < 8)
+          str = str + 1l;
+
+      }
+
+      const char *z = str;
+      c=bb_process_escape_sequence(&z);
+      str = z;
+    }
+
+    putchar((signed int)c);
+  }
+}
+
+// file coreutils/printf.c line 263
+static char ** print_formatted(char *f, char **argv, signed int *conv_err)
+{
+  char *direc_start;
+  unsigned int direc_length;
+  signed int field_width;
+  signed int precision;
+  char **saved_argv = argv;
+  char *tmp_post$1;
+  char *return_value___builtin_strchr$2;
+  char **tmp_post$3;
+  char **tmp_post$4;
+  char **tmp_post$7;
+  char return_value_bb_process_escape_sequence$8;
+  while((_Bool)1)
+  {
+
+    if((signed int)*f == 0)
+      break;
+
+    if(!((signed int)*f == 37))
+    {
+      if((signed int)*f == 92)
+        goto __CPROVER_DUMP_L68;
+
+    }
+
+    else
+    {
+      tmp_post$1 = f;
+      f = f + 1l;
+      direc_start = tmp_post$1;
+      direc_length = (unsigned int)1;
+      precision = 0;
+      field_width = precision;
+
+      if((signed int)*f == 37)
+      {
+        bb_putchar(37);
+        goto __CPROVER_DUMP_L75;
+      }
+
+
+      if((signed int)*f == 98)
+      {
+
+        if(!(*argv == ((char *)NULL)))
+        {
+          print_esc_string(*argv);
+          argv = argv + 1l;
+        }
+
+        goto __CPROVER_DUMP_L75;
+      }
+
+
+      return_value___builtin_strchr$2=strchr("-+ #", (signed int)*f);
+      if(!(return_value___builtin_strchr$2 == ((char *)NULL)))
+      {
+        f = f + 1l;
+        direc_length = direc_length + 1u;
+      }
+
+
+      if((signed int)*f == 42)
+      {
+        f = f + 1l;
+        direc_length = direc_length + 1u;
+
+        if(!(*argv == ((char *)NULL)))
+        {
+          tmp_post$3 = argv;
+          argv = argv + 1l;
+
+          field_width=get_width_prec(*tmp_post$3);
+        }
+
+      }
+
+      else
+        while((_Bool)1)
+        {
+
+          if(!(208 + (signed int)(unsigned char)(signed int)*f <= 9))
+            break;
+
+          f = f + 1l;
+          direc_length = direc_length + 1u;
+        }
+
+      if((signed int)*f == 46)
+      {
+        f = f + 1l;
+        direc_length = direc_length + 1u;
+
+        if((signed int)*f == 42)
+        {
+          f = f + 1l;
+          direc_length = direc_length + 1u;
+
+          if(!(*argv == ((char *)NULL)))
+          {
+            tmp_post$4 = argv;
+            argv = argv + 1l;
+
+            precision=get_width_prec(*tmp_post$4);
+          }
+
+        }
+
+        else
+          while((_Bool)1)
+          {
+
+            if(!(208 + (signed int)(unsigned char)(signed int)*f <= 9))
+              break;
+
+            f = f + 1l;
+            direc_length = direc_length + 1u;
+          }
+      }
+
+      while((_Bool)1)
+      {
+
+        if(!((32 | (signed int)*f) == 108))
+        {
+          if(!((signed int)*f == 104))
+          {
+            if(!((signed int)*f == 122))
+              break;
+
+          }
+
+        }
+
+        overlapping_strcpy(f, f + (signed long int)1);
+      }
+      char *p;
+      char *return_value___builtin_strchr$5;
+
+      static const char format_chars[14l] = { (const char)100, (const char)105, (const char)111, (const char)117, (const char)120, (const char)88, (const char)102, (const char)101, (const char)69, (const char)103, (const char)71, (const char)99, (const char)115, (const char)0 };
+      return_value___builtin_strchr$5=strchr(format_chars, (signed int)*f);
+      p = return_value___builtin_strchr$5;
+      if(p == ((char *)NULL))
+      {
+        bb_error_msg("%s: invalid format", direc_start);
+        return saved_argv - (signed long int)1;
+      }
+
+      direc_length = direc_length + 1u;
+      if(p - format_chars <= 5l)
+      {
+        void *return_value_xmalloc$6;
+        return_value_xmalloc$6=xmalloc((unsigned long int)(direc_length + (unsigned int)3));
+        p = (char *)return_value_xmalloc$6;
+        memcpy((void *)p, (const void *)direc_start, (unsigned long int)direc_length);
+
+
+        p[(signed long int)(direc_length + (unsigned int)1)] = p[(signed long int)(direc_length - (unsigned int)1)];
+
+        p[(signed long int)(direc_length - (unsigned int)1)] = (char)108;
+
+        p[(signed long int)direc_length] = (char)108;
+        direc_length = direc_length + (unsigned int)2;
+        direc_start = p;
+      }
+
+      else
+        p = (char *)NULL;
+
+      if(!(*argv == ((char *)NULL)))
+      {
+        tmp_post$7 = argv;
+        argv = argv + 1l;
+
+        print_direc(direc_start, direc_length, field_width, precision, *tmp_post$7);
+      }
+
+      else
+        print_direc(direc_start, direc_length, field_width, precision, "");
+
+
+      *conv_err = *conv_err | *bb_errno;
+      free((void *)p);
+      goto __CPROVER_DUMP_L75;
+
+    __CPROVER_DUMP_L68:
+      ;
+      f = f + 1l;
+
+      if((signed int)*f == 99)
+        return saved_argv;
+
+      return_value_bb_process_escape_sequence$8=bb_process_escape_sequence((const char **)&f);
+      bb_putchar((signed int)return_value_bb_process_escape_sequence$8);
+      f = f - 1l;
+      goto __CPROVER_DUMP_L75;
+    }
+
+    putchar((signed int)*f);
+
+  __CPROVER_DUMP_L75:
+    ;
+    f = f + 1l;
+  }
+  return argv;
+}
+
+// file coreutils/printf.c line 376
+signed int __main(signed int argc, char **argv)
+{
+  signed int conv_err;
+  char *format;
+  char **argv2;
+  signed int return_value_fcntl$1;
+  return_value_fcntl$1=fcntl(1, 3);
+  if(return_value_fcntl$1 == -1)
+    return 1;
+
+
+  if(!(*(1l + argv) == ((char *)NULL)))
+  {
+
+    if((signed int)*(*(1l + argv)) == 45)
+    {
+
+      if((signed int)*(1l + *(1l + argv)) == 45)
+      {
+
+        if((signed int)*(2l + *(1l + argv)) == 0)
+          argv = argv + 1l;
+
+      }
+
+    }
+
+  }
+
+
+  if(*(1l + argv) == ((char *)NULL))
+  {
+
+    if(!((signed int)*applet_name == 112))
+    {
+      bb_error_msg("usage: printf FORMAT [ARGUMENT...]");
+      return 2;
+    }
+
+    return 1;
+  }
+
+
+  format = argv[(signed long int)1];
+  argv2 = argv + (signed long int)2;
+  conv_err = 0;
+  _Bool tmp_if_expr$2;
+  do
+  {
+    argv = argv2;
+    argv2=print_formatted(format, argv, &conv_err);
+    if(!(argv >= argv2))
+    {
+
+      tmp_if_expr$2 = (*argv2 != (char *)NULL ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+
+    else
+      tmp_if_expr$2 = 0 != 0;
+  }
+  while(tmp_if_expr$2 != (_Bool)0);
+  return (signed int)(argv2 < argv || conv_err != 0);
+}
+
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 815
+static char * utoa(unsigned int n)
+{
+  char *return_value_utoa_to_buf$1;
+  return_value_utoa_to_buf$1=utoa_to_buf(n, local_buf, (unsigned int)(sizeof(char [12l]) /*12ul*/  - (unsigned long int)1));
+  *return_value_utoa_to_buf$1 = (char)0;
+  return local_buf;
+}
+
+// file include/libbb.h line 818
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen)
+{
+  unsigned int i;
+  unsigned int out;
+  unsigned int res;
+  char *tmp_post$1;
+  if(!(buflen == 0u))
+  {
+    out = (unsigned int)0;
+    i = (unsigned int)1000000000;
+    for( ; !(i == 0u); i = i / (unsigned int)10)
+    {
+      res = n / i;
+      n = n % i;
+      if(res == 0u)
+      {
+        if(out != 0u)
+          goto __CPROVER_DUMP_L2;
+
+        if(i == 1u)
+          goto __CPROVER_DUMP_L2;
+
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L2:
+        ;
+        buflen = buflen - 1u;
+        if(buflen == 0u)
+          break;
+
+        out = out + 1u;
+        tmp_post$1 = buf;
+        buf = buf + 1l;
+        *tmp_post$1 = (char)((unsigned int)48 + res);
+      }
+    }
+  }
+
+  return buf;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/printf_false-no-overflow.i
+++ b/c/busybox-1.22.0/printf_false-no-overflow.i
@@ -1,0 +1,3411 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+struct flock
+  {
+    short int l_type;
+    short int l_whence;
+    __off_t l_start;
+    __off_t l_len;
+    __pid_t l_pid;
+  };
+struct flock64
+  {
+    short int l_type;
+    short int l_whence;
+    __off64_t l_start;
+    __off64_t l_len;
+    __pid_t l_pid;
+  };
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __uid_t uid_t;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __pid_t pid_t;
+typedef __id_t id_t;
+typedef __ssize_t ssize_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef long unsigned int size_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+typedef __sigset_t sigset_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+
+struct iovec
+  {
+    void *iov_base;
+    size_t iov_len;
+  };
+enum __pid_type
+  {
+    F_OWNER_TID = 0,
+    F_OWNER_PID,
+    F_OWNER_PGRP,
+    F_OWNER_GID = F_OWNER_PGRP
+  };
+struct f_owner_ex
+  {
+    enum __pid_type type;
+    __pid_t pid;
+  };
+struct file_handle
+{
+  unsigned int handle_bytes;
+  int handle_type;
+  unsigned char f_handle[0];
+};
+
+extern ssize_t readahead (int __fd, __off64_t __offset, size_t __count)
+    __attribute__ ((__nothrow__ , __leaf__));
+extern int sync_file_range (int __fd, __off64_t __offset, __off64_t __count,
+       unsigned int __flags);
+extern ssize_t vmsplice (int __fdout, const struct iovec *__iov,
+    size_t __count, unsigned int __flags);
+extern ssize_t splice (int __fdin, __off64_t *__offin, int __fdout,
+         __off64_t *__offout, size_t __len,
+         unsigned int __flags);
+extern ssize_t tee (int __fdin, int __fdout, size_t __len,
+      unsigned int __flags);
+extern int fallocate (int __fd, int __mode, __off_t __offset, __off_t __len);
+extern int fallocate64 (int __fd, int __mode, __off64_t __offset,
+   __off64_t __len);
+extern int name_to_handle_at (int __dfd, const char *__name,
+         struct file_handle *__handle, int *__mnt_id,
+         int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern int open_by_handle_at (int __mountdirfd, struct file_handle *__handle,
+         int __flags);
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int fcntl (int __fd, int __cmd, ...);
+extern int open (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int open64 (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int openat (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int openat64 (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int creat (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int creat64 (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int lockf (int __fd, int __cmd, off_t __len);
+extern int lockf64 (int __fd, int __cmd, off64_t __len);
+extern int posix_fadvise (int __fd, off_t __offset, off_t __len,
+     int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fadvise64 (int __fd, off64_t __offset, off64_t __len,
+       int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fallocate (int __fd, off_t __offset, off_t __len);
+extern int posix_fallocate64 (int __fd, off64_t __offset, off64_t __len);
+
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static inline signed int bb_ascii_isalnum(unsigned char a);
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+static char bb_process_escape_sequence(const char **ptr);
+static signed int bb_putchar(signed int ch);
+static void bb_show_usage(void);
+static signed int bb_strtoi(const char *arg, char **endp, signed int base);
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base);
+static unsigned long long int bb_strtoull(const char *arg, char **endp, signed int base);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void conv_strtod(const char *arg, void *result);
+static void conv_strtoll(const char *arg, void *result);
+static void conv_strtoull(const char *arg, void *result);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed int get_width_prec(const char *str);
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+static signed int multiconvert(const char *arg, void *result, void (*convert)(const char *, void *));
+void convert$object(const char *, void *);
+static double my_xstrtod(const char *arg);
+static signed long long int my_xstrtoll(const char *arg);
+static unsigned long long int my_xstrtoull(const char *arg);
+static void overlapping_strcpy(char *dst, const char *src);
+static void print_direc(char *format, unsigned int fmt_length, signed int field_width, signed int precision, const char *argument);
+static void print_esc_string(const char *str);
+static char ** print_formatted(char *f, char **argv, signed int *conv_err);
+static unsigned long long int ret_ERANGE(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static char * utoa(unsigned int n);
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static char local_buf[(signed long int)(sizeof(signed int) * 3) ];
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char bb_process_escape_sequence(const char **ptr)
+{
+  const char *q;
+  unsigned int num_digits;
+  unsigned int n;
+  unsigned int base;
+  n = (unsigned int)0;
+  num_digits = n;
+  base = (unsigned int)8;
+  q = *ptr;
+  if((signed int)*q == 120)
+  {
+    q = q + 1l;
+    base = (unsigned int)16;
+    num_digits = num_digits + 1u;
+  }
+  do
+  {
+    unsigned int r;
+    unsigned int d = (unsigned int)((signed int)(unsigned char)((signed int)*q | (signed int)(char)32) - 48);
+    if(d >= 10u)
+      d = d + (unsigned int)((48 - 97) + 10);
+    if(d >= base)
+    {
+      if(base == 16u)
+      {
+        num_digits = num_digits - 1u;
+        if(num_digits == 0u)
+          return (char)92;
+      }
+      break;
+    }
+    r = n * base + d;
+    if(r > 255u)
+      break;
+    n = r;
+    q = q + 1l;
+    num_digits = num_digits + 1u;
+  }
+  while(num_digits < 3u);
+  if(num_digits == 0u)
+  {
+    static const char charmap[20l] = { (const char)97, (const char)98, (const char)101, (const char)102, (const char)110, (const char)114, (const char)116, (const char)118, (const char)92, (const char)0, (const char)7, (const char)8, (const char)27, (const char)12, (const char)10, (const char)13, (const char)9, (const char)11, (const char)92, (const char)92 };
+    const char *p = charmap;
+    while((_Bool)1)
+    {
+      if(*p == *q)
+      {
+        q = q + 1l;
+        break;
+      }
+      p = p + 1l;
+      if((signed int)*p == 0)
+        break;
+    }
+    n = (unsigned int)p[(signed long int)(sizeof(const char [20l]) / (unsigned long int)2)];
+  }
+  *ptr = q;
+  return (char)n;
+}
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static signed int bb_strtoi(const char *arg, char **endp, signed int base)
+{
+  signed long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed int)return_value_ret_ERANGE$2;
+  }
+  *bb_errno = 0;
+  v=strtol(arg, endp, base);
+  unsigned long long int return_value_ret_ERANGE$4;
+  if(v > 2147483647l)
+  {
+    return_value_ret_ERANGE$4=ret_ERANGE();
+    return (signed int)return_value_ret_ERANGE$4;
+  }
+  unsigned long long int return_value_ret_ERANGE$5;
+  if(v < -2147483648l)
+  {
+    return_value_ret_ERANGE$5=ret_ERANGE();
+    return (signed int)return_value_ret_ERANGE$5;
+  }
+  unsigned long long int return_value_handle_errors$6;
+  return_value_handle_errors$6=handle_errors((unsigned long long int)v, endp);
+  return (signed int)return_value_handle_errors$6;
+}
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed long long int)return_value_ret_ERANGE$2;
+  }
+  *bb_errno = 0;
+  signed long long int return_value_strtoll$4;
+  return_value_strtoll$4=strtoll(arg, endp, base);
+  v = (unsigned long long int)return_value_strtoll$4;
+  unsigned long long int return_value_handle_errors$5;
+  return_value_handle_errors$5=handle_errors(v, endp);
+  return (signed long long int)return_value_handle_errors$5;
+}
+static unsigned long long int bb_strtoull(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int return_value_bb_ascii_isalnum$2;
+  return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(arg[(signed long int)0]);
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(return_value_bb_ascii_isalnum$2 == 0)
+  {
+    return_value_ret_ERANGE$1=ret_ERANGE();
+    return return_value_ret_ERANGE$1;
+  }
+  *bb_errno = 0;
+  v=strtoull(arg, endp, base);
+  unsigned long long int return_value_handle_errors$3;
+  return_value_handle_errors$3=handle_errors(v, endp);
+  return return_value_handle_errors$3;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void conv_strtod(const char *arg, void *result)
+{
+  char *end;
+  if(!(result == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  *((double *)result)=strtod(arg, &end);
+  if(!((signed int)*end == 0))
+  {
+    *bb_errno = 34;
+    if(!(result == ((void *)0)))
+      (void)0;
+    else
+      __VERIFIER_error();
+    *((double *)result) = (double)0;
+  }
+}
+static void conv_strtoll(const char *arg, void *result)
+{
+  if(!(result == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  *((signed long long int *)result)=bb_strtoll(arg, (char **)((void *)0), 0);
+}
+static void conv_strtoull(const char *arg, void *result)
+{
+  if(!(result == ((void *)0)))
+    (void)0;
+  else
+    __VERIFIER_error();
+  *((unsigned long long int *)result)=bb_strtoull(arg, (char **)((void *)0), 0);
+  if(!(*bb_errno == 0))
+  {
+    signed long long int return_value_bb_strtoll$1;
+    return_value_bb_strtoll$1=bb_strtoll(arg, (char **)((void *)0), 0);
+    if(!(result == ((void *)0)))
+      (void)0;
+    else
+      __VERIFIER_error();
+    *((unsigned long long int *)result) = (unsigned long long int)return_value_bb_strtoll$1;
+  }
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed int get_width_prec(const char *str)
+{
+  signed int v;
+  v=bb_strtoi(str, (char **)((void *)0), 10);
+  if(!(*bb_errno == 0))
+  {
+    bb_error_msg("invalid number '%s'", str);
+    v = 0;
+  }
+  return v;
+}
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+    *bb_errno = 22;
+  }
+  return v;
+}
+static signed int multiconvert(const char *arg, void *result, void (*convert)(const char *, void *))
+{
+  _Bool tmp_if_expr$1;
+  if((signed int)*arg == 34)
+    tmp_if_expr$1 = 1 != 0;
+  else
+  {
+    tmp_if_expr$1 = ((signed int)*arg == 39 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$1 == (_Bool)0))
+  {
+    arg=utoa((unsigned int)(unsigned char)arg[(signed long int)1]);
+  }
+  *bb_errno = 0;
+  if(!(convert == ((void (*)(const char *, void *))((void *)0))))
+    (void)0;
+  else
+    __VERIFIER_error();
+  convert(arg, result);
+  if(!(*bb_errno == 0))
+  {
+    bb_error_msg("invalid number '%s'", arg);
+    return 1;
+  }
+  return 0;
+}
+static double my_xstrtod(const char *arg)
+{
+  double result;
+  multiconvert(arg, (void *)&result, conv_strtod);
+  return result;
+}
+static signed long long int my_xstrtoll(const char *arg)
+{
+  signed long long int result;
+  signed int return_value_multiconvert$1;
+  return_value_multiconvert$1=multiconvert(arg, (void *)&result, conv_strtoll);
+  if(!(return_value_multiconvert$1 == 0))
+    result = (signed long long int)0;
+  return result;
+}
+static unsigned long long int my_xstrtoull(const char *arg)
+{
+  unsigned long long int result;
+  signed int return_value_multiconvert$1;
+  return_value_multiconvert$1=multiconvert(arg, (void *)&result, conv_strtoull);
+  if(!(return_value_multiconvert$1 == 0))
+    result = (unsigned long long int)0;
+  return result;
+}
+static void overlapping_strcpy(char *dst, const char *src)
+{
+  if(!(dst == src))
+    do
+    {
+      *dst = *src;
+      if((signed int)*dst == 0)
+        break;
+      dst = dst + 1l;
+      src = src + 1l;
+    }
+    while((_Bool)1);
+}
+static void print_direc(char *format, unsigned int fmt_length, signed int field_width, signed int precision, const char *argument)
+{
+  signed long long int llv;
+  double dv;
+  char saved;
+  char *have_prec;
+  char *have_width;
+  saved = format[(signed long int)fmt_length];
+  format[(signed long int)fmt_length] = (char)0;
+  have_prec=strstr(format, ".*");
+  char *return_value___builtin_strchr$1;
+  return_value___builtin_strchr$1=strchr(format, 42);
+  have_width = return_value___builtin_strchr$1;
+  if(-1l + have_width == have_prec)
+    have_width = (char *)((void *)0);
+  *bb_errno = 0;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$5;
+  _Bool tmp_if_expr$6;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  _Bool tmp_if_expr$11;
+  _Bool tmp_if_expr$12;
+  _Bool tmp_if_expr$13;
+  _Bool tmp_if_expr$14;
+  _Bool tmp_if_expr$15;
+  _Bool tmp_if_expr$16;
+  _Bool tmp_if_expr$17;
+  if(!((signed int)format[(signed long int)(4294967295u + fmt_length)] == 99))
+  {
+    if((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 105 || !(format == ((char *)((void *)0))))
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 100)
+      tmp_if_expr$1 = (_Bool)1;
+    else
+      tmp_if_expr$1 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 105 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$1)
+      goto __CPROVER_DUMP_L61;
+    if((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 88 || !(format == ((char *)((void *)0))))
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 88))
+      tmp_if_expr$2 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 120) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$2 = (_Bool)0;
+    if(!(format == ((char *)((void *)0))) || !tmp_if_expr$2)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 88))
+      tmp_if_expr$3 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 120) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$3 = (_Bool)0;
+    if(tmp_if_expr$3)
+      tmp_if_expr$4 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 117) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$4 = (_Bool)0;
+    if(!(format == ((char *)((void *)0))) || !tmp_if_expr$4)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 88)
+      tmp_if_expr$5 = (_Bool)1;
+    else
+      tmp_if_expr$5 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 111 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$5)
+      tmp_if_expr$6 = (_Bool)1;
+    else
+      tmp_if_expr$6 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 117 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$6)
+      tmp_if_expr$7 = (_Bool)1;
+    else
+      tmp_if_expr$7 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 120 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$7)
+      goto __CPROVER_DUMP_L68;
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 115)
+      goto __CPROVER_DUMP_L69;
+    if((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71 || !(format == ((char *)((void *)0))))
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71))
+      tmp_if_expr$8 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$8 = (_Bool)0;
+    if(!(format == ((char *)((void *)0))) || !tmp_if_expr$8)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71))
+      tmp_if_expr$9 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$9 = (_Bool)0;
+    if(tmp_if_expr$9)
+      tmp_if_expr$10 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 69) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$10 = (_Bool)0;
+    if(!(format == ((char *)((void *)0))) || !tmp_if_expr$10)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if(!((signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71))
+      tmp_if_expr$11 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 103) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$11 = (_Bool)0;
+    if(tmp_if_expr$11)
+      tmp_if_expr$12 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 69) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$12 = (_Bool)0;
+    if(tmp_if_expr$12)
+      tmp_if_expr$13 = !((signed int)format[(signed long int)(fmt_length - (unsigned int)1)] == 101) ? (_Bool)1 : (_Bool)0;
+    else
+      tmp_if_expr$13 = (_Bool)0;
+    if(!(format == ((char *)((void *)0))) || !tmp_if_expr$13)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed int)format[(signed long int)(4294967295u + fmt_length)] == 69)
+      tmp_if_expr$14 = (_Bool)1;
+    else
+      tmp_if_expr$14 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 71 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$14)
+      tmp_if_expr$15 = (_Bool)1;
+    else
+      tmp_if_expr$15 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 101 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$15)
+      tmp_if_expr$16 = (_Bool)1;
+    else
+      tmp_if_expr$16 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 102 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$16)
+      tmp_if_expr$17 = (_Bool)1;
+    else
+      tmp_if_expr$17 = (signed int)format[(signed long int)(fmt_length + 4294967295u)] == 103 ? (_Bool)1 : (_Bool)0;
+    if(tmp_if_expr$17)
+      goto __CPROVER_DUMP_L70;
+  }
+  else
+  {
+    printf(format, *argument);
+    goto __CPROVER_DUMP_L76;
+  __CPROVER_DUMP_L61:
+    ;
+    llv=my_xstrtoll(argument);
+  print_long:
+    ;
+    if(have_width == ((char *)((void *)0)))
+    {
+      if(have_prec == ((char *)((void *)0)))
+        printf(format, llv);
+      else
+        printf(format, precision, llv);
+    }
+    else
+      if(have_prec == ((char *)((void *)0)))
+        printf(format, field_width, llv);
+      else
+        printf(format, field_width, precision, llv);
+    goto __CPROVER_DUMP_L76;
+  __CPROVER_DUMP_L68:
+    ;
+    unsigned long long int return_value_my_xstrtoull$2;
+    return_value_my_xstrtoull$2=my_xstrtoull(argument);
+    llv = (signed long long int)return_value_my_xstrtoull$2;
+    goto print_long;
+  __CPROVER_DUMP_L69:
+    ;
+    llv = (signed long int)argument;
+    goto print_long;
+  __CPROVER_DUMP_L70:
+    ;
+    dv=my_xstrtod(argument);
+    if(have_width == ((char *)((void *)0)))
+    {
+      if(have_prec == ((char *)((void *)0)))
+        printf(format, dv);
+      else
+        printf(format, precision, dv);
+    }
+    else
+      if(have_prec == ((char *)((void *)0)))
+        printf(format, field_width, dv);
+      else
+        printf(format, field_width, precision, dv);
+    goto __CPROVER_DUMP_L76;
+  }
+__CPROVER_DUMP_L76:
+  ;
+  format[(signed long int)fmt_length] = saved;
+}
+static void print_esc_string(const char *str)
+{
+  char c;
+  while((_Bool)1)
+  {
+    c = *str;
+    if((signed int)c == 0)
+      break;
+    str = str + 1l;
+    if((signed int)c == 92)
+    {
+      if((signed int)*str == 48)
+      {
+        if(208 + (signed int)(unsigned char)(signed int)*(1l + str) < 8)
+          str = str + 1l;
+      }
+      const char *z = str;
+      c=bb_process_escape_sequence(&z);
+      str = z;
+    }
+    putchar((signed int)c);
+  }
+}
+static char ** print_formatted(char *f, char **argv, signed int *conv_err)
+{
+  char *direc_start;
+  unsigned int direc_length;
+  signed int field_width;
+  signed int precision;
+  char **saved_argv = argv;
+  char *tmp_post$1;
+  char *return_value___builtin_strchr$2;
+  char **tmp_post$3;
+  char **tmp_post$4;
+  char **tmp_post$7;
+  char return_value_bb_process_escape_sequence$8;
+  while((_Bool)1)
+  {
+    if((signed int)*f == 0)
+      break;
+    if(!((signed int)*f == 37))
+    {
+      if((signed int)*f == 92)
+        goto __CPROVER_DUMP_L68;
+    }
+    else
+    {
+      tmp_post$1 = f;
+      f = f + 1l;
+      direc_start = tmp_post$1;
+      direc_length = (unsigned int)1;
+      precision = 0;
+      field_width = precision;
+      if((signed int)*f == 37)
+      {
+        bb_putchar(37);
+        goto __CPROVER_DUMP_L75;
+      }
+      if((signed int)*f == 98)
+      {
+        if(!(*argv == ((char *)((void *)0))))
+        {
+          print_esc_string(*argv);
+          argv = argv + 1l;
+        }
+        goto __CPROVER_DUMP_L75;
+      }
+      return_value___builtin_strchr$2=strchr("-+ #", (signed int)*f);
+      if(!(return_value___builtin_strchr$2 == ((char *)((void *)0))))
+      {
+        f = f + 1l;
+        direc_length = direc_length + 1u;
+      }
+      if((signed int)*f == 42)
+      {
+        f = f + 1l;
+        direc_length = direc_length + 1u;
+        if(!(*argv == ((char *)((void *)0))))
+        {
+          tmp_post$3 = argv;
+          argv = argv + 1l;
+          field_width=get_width_prec(*tmp_post$3);
+        }
+      }
+      else
+        while((_Bool)1)
+        {
+          if(!(208 + (signed int)(unsigned char)(signed int)*f <= 9))
+            break;
+          f = f + 1l;
+          direc_length = direc_length + 1u;
+        }
+      if((signed int)*f == 46)
+      {
+        f = f + 1l;
+        direc_length = direc_length + 1u;
+        if((signed int)*f == 42)
+        {
+          f = f + 1l;
+          direc_length = direc_length + 1u;
+          if(!(*argv == ((char *)((void *)0))))
+          {
+            tmp_post$4 = argv;
+            argv = argv + 1l;
+            precision=get_width_prec(*tmp_post$4);
+          }
+        }
+        else
+          while((_Bool)1)
+          {
+            if(!(208 + (signed int)(unsigned char)(signed int)*f <= 9))
+              break;
+            f = f + 1l;
+            direc_length = direc_length + 1u;
+          }
+      }
+      while((_Bool)1)
+      {
+        if(!((32 | (signed int)*f) == 108))
+        {
+          if(!((signed int)*f == 104))
+          {
+            if(!((signed int)*f == 122))
+              break;
+          }
+        }
+        overlapping_strcpy(f, f + (signed long int)1);
+      }
+      char *p;
+      char *return_value___builtin_strchr$5;
+      static const char format_chars[14l] = { (const char)100, (const char)105, (const char)111, (const char)117, (const char)120, (const char)88, (const char)102, (const char)101, (const char)69, (const char)103, (const char)71, (const char)99, (const char)115, (const char)0 };
+      return_value___builtin_strchr$5=strchr(format_chars, (signed int)*f);
+      p = return_value___builtin_strchr$5;
+      if(p == ((char *)((void *)0)))
+      {
+        bb_error_msg("%s: invalid format", direc_start);
+        return saved_argv - (signed long int)1;
+      }
+      direc_length = direc_length + 1u;
+      if(p - format_chars <= 5l)
+      {
+        void *return_value_xmalloc$6;
+        return_value_xmalloc$6=xmalloc((unsigned long int)(direc_length + (unsigned int)3));
+        p = (char *)return_value_xmalloc$6;
+        memcpy((void *)p, (const void *)direc_start, (unsigned long int)direc_length);
+        p[(signed long int)(direc_length + (unsigned int)1)] = p[(signed long int)(direc_length - (unsigned int)1)];
+        p[(signed long int)(direc_length - (unsigned int)1)] = (char)108;
+        p[(signed long int)direc_length] = (char)108;
+        direc_length = direc_length + (unsigned int)2;
+        direc_start = p;
+      }
+      else
+        p = (char *)((void *)0);
+      if(!(*argv == ((char *)((void *)0))))
+      {
+        tmp_post$7 = argv;
+        argv = argv + 1l;
+        print_direc(direc_start, direc_length, field_width, precision, *tmp_post$7);
+      }
+      else
+        print_direc(direc_start, direc_length, field_width, precision, "");
+      *conv_err = *conv_err | *bb_errno;
+      free((void *)p);
+      goto __CPROVER_DUMP_L75;
+    __CPROVER_DUMP_L68:
+      ;
+      f = f + 1l;
+      if((signed int)*f == 99)
+        return saved_argv;
+      return_value_bb_process_escape_sequence$8=bb_process_escape_sequence((const char **)&f);
+      bb_putchar((signed int)return_value_bb_process_escape_sequence$8);
+      f = f - 1l;
+      goto __CPROVER_DUMP_L75;
+    }
+    putchar((signed int)*f);
+  __CPROVER_DUMP_L75:
+    ;
+    f = f + 1l;
+  }
+  return argv;
+}
+signed int __main(signed int argc, char **argv)
+{
+  signed int conv_err;
+  char *format;
+  char **argv2;
+  signed int return_value_fcntl$1;
+  return_value_fcntl$1=fcntl(1, 3);
+  if(return_value_fcntl$1 == -1)
+    return 1;
+  if(!(*(1l + argv) == ((char *)((void *)0))))
+  {
+    if((signed int)*(*(1l + argv)) == 45)
+    {
+      if((signed int)*(1l + *(1l + argv)) == 45)
+      {
+        if((signed int)*(2l + *(1l + argv)) == 0)
+          argv = argv + 1l;
+      }
+    }
+  }
+  if(*(1l + argv) == ((char *)((void *)0)))
+  {
+    if(!((signed int)*applet_name == 112))
+    {
+      bb_error_msg("usage: printf FORMAT [ARGUMENT...]");
+      return 2;
+    }
+    return 1;
+  }
+  format = argv[(signed long int)1];
+  argv2 = argv + (signed long int)2;
+  conv_err = 0;
+  _Bool tmp_if_expr$2;
+  do
+  {
+    argv = argv2;
+    argv2=print_formatted(format, argv, &conv_err);
+    if(!(argv >= argv2))
+    {
+      tmp_if_expr$2 = (*argv2 != (char *)((void *)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    else
+      tmp_if_expr$2 = 0 != 0;
+  }
+  while(tmp_if_expr$2 != (_Bool)0);
+  return (signed int)(argv2 < argv || conv_err != 0);
+}
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static char * utoa(unsigned int n)
+{
+  char *return_value_utoa_to_buf$1;
+  return_value_utoa_to_buf$1=utoa_to_buf(n, local_buf, (unsigned int)(sizeof(char [12l]) - (unsigned long int)1));
+  *return_value_utoa_to_buf$1 = (char)0;
+  return local_buf;
+}
+static char * utoa_to_buf(unsigned int n, char *buf, unsigned int buflen)
+{
+  unsigned int i;
+  unsigned int out;
+  unsigned int res;
+  char *tmp_post$1;
+  if(!(buflen == 0u))
+  {
+    out = (unsigned int)0;
+    i = (unsigned int)1000000000;
+    for( ; !(i == 0u); i = i / (unsigned int)10)
+    {
+      res = n / i;
+      n = n % i;
+      if(res == 0u)
+      {
+        if(out != 0u)
+          goto __CPROVER_DUMP_L2;
+        if(i == 1u)
+          goto __CPROVER_DUMP_L2;
+      }
+      else
+      {
+      __CPROVER_DUMP_L2:
+        ;
+        buflen = buflen - 1u;
+        if(buflen == 0u)
+          break;
+        out = out + 1u;
+        tmp_post$1 = buf;
+        buf = buf + 1l;
+        *tmp_post$1 = (char)((unsigned int)48 + res);
+      }
+    }
+  }
+  return buf;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -353,7 +353,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2552,7 +2552,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/readlink_false-no-overflow.c
+++ b/c/busybox-1.22.0/readlink_false-no-overflow.c
@@ -1,0 +1,1095 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+#include <limits.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file include/libbb.h line 402
+static char * xmalloc_readlink(const char *path);
+// file include/libbb.h line 403
+static char * xmalloc_readlink_or_warn(const char *path);
+// file libbb/xreadlink.c line 109
+static char * xmalloc_realpath(const char *path);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file coreutils/readlink.c line 49
+signed int __main(signed int argc, char **argv)
+{
+  char *buf;
+  char *fname;
+  unsigned int opt;
+  opt_complementary = "=1";
+  opt=getopt32(argv, "fnvsq");
+
+  fname = argv[(signed long int)optind];
+  if((4u & opt) == 0u)
+    logmode = (signed char)0;
+
+  if(!((1u & opt) == 0u))
+    buf=xmalloc_realpath(fname);
+
+  else
+    buf=xmalloc_readlink_or_warn(fname);
+  if(buf == ((char *)NULL))
+    return 1;
+
+  printf((opt & (unsigned int)2) != 0u ? "%s" : "%s\n", buf);
+  // fflush_stdout_and_exit(0); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  free(buf);
+  return 0;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 402
+static char * xmalloc_readlink(const char *path)
+{
+  char *buf = (char *)NULL;
+  signed int bufsize = 0;
+  signed int readsize = 0;
+  do
+  {
+    bufsize = bufsize + 80;
+    void *return_value_xrealloc$1;
+    return_value_xrealloc$1=xrealloc((void *)buf, (unsigned long int)bufsize);
+    buf = (char *)return_value_xrealloc$1;
+    signed long int return_value_readlink$2;
+    return_value_readlink$2=readlink(path, buf, (unsigned long int)bufsize);
+    readsize = (signed int)return_value_readlink$2;
+    if(readsize == -1)
+    {
+      free((void *)buf);
+      return (char *)NULL;
+    }
+
+  }
+  while(!(bufsize >= 1 + readsize));
+  buf[(signed long int)readsize] = (char)0;
+  return buf;
+}
+
+// file include/libbb.h line 403
+static char * xmalloc_readlink_or_warn(const char *path)
+{
+  char *buf;
+  buf=xmalloc_readlink(path);
+  if(buf == ((char *)NULL))
+  {
+    const char *errmsg = "not a symlink";
+    signed int err = *bb_errno;
+    if(!(err == 22))
+      errmsg=strerror(err);
+
+    bb_error_msg("%s: cannot read link: %s", path, errmsg);
+  }
+
+  return buf;
+}
+
+// file libbb/xreadlink.c line 109
+static char * xmalloc_realpath(const char *path)
+{
+  char *return_value_realpath$1;
+  return_value_realpath$1=realpath(path, (char *)NULL);
+  return return_value_realpath$1;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp-readlink.h"
+#include "busybox_sv_comp-realpath.h"
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/readlink_false-no-overflow.i
+++ b/c/busybox-1.22.0/readlink_false-no-overflow.i
@@ -1,0 +1,3109 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_readlink(const char *path);
+static char * xmalloc_readlink_or_warn(const char *path);
+static char * xmalloc_realpath(const char *path);
+static void * xrealloc(void *ptr, unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+signed int __main(signed int argc, char **argv)
+{
+  char *buf;
+  char *fname;
+  unsigned int opt;
+  opt_complementary = "=1";
+  opt=getopt32(argv, "fnvsq");
+  fname = argv[(signed long int)optind];
+  if((4u & opt) == 0u)
+    logmode = (signed char)0;
+  if(!((1u & opt) == 0u))
+    buf=xmalloc_realpath(fname);
+  else
+    buf=xmalloc_readlink_or_warn(fname);
+  if(buf == ((char *)((void *)0)))
+    return 1;
+  printf((opt & (unsigned int)2) != 0u ? "%s" : "%s\n", buf);
+  fflush(stdout);
+  free(buf);
+  return 0;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_readlink(const char *path)
+{
+  char *buf = (char *)((void *)0);
+  signed int bufsize = 0;
+  signed int readsize = 0;
+  do
+  {
+    bufsize = bufsize + 80;
+    void *return_value_xrealloc$1;
+    return_value_xrealloc$1=xrealloc((void *)buf, (unsigned long int)bufsize);
+    buf = (char *)return_value_xrealloc$1;
+    signed long int return_value_readlink$2;
+    return_value_readlink$2=readlink(path, buf, (unsigned long int)bufsize);
+    readsize = (signed int)return_value_readlink$2;
+    if(readsize == -1)
+    {
+      free((void *)buf);
+      return (char *)((void *)0);
+    }
+  }
+  while(!(bufsize >= 1 + readsize));
+  buf[(signed long int)readsize] = (char)0;
+  return buf;
+}
+static char * xmalloc_readlink_or_warn(const char *path)
+{
+  char *buf;
+  buf=xmalloc_readlink(path);
+  if(buf == ((char *)((void *)0)))
+  {
+    const char *errmsg = "not a symlink";
+    signed int err = *bb_errno;
+    if(!(err == 22))
+      errmsg=strerror(err);
+    bb_error_msg("%s: cannot read link: %s", path, errmsg);
+  }
+  return buf;
+}
+static char * xmalloc_realpath(const char *path)
+{
+  char *return_value_realpath$1;
+  return_value_realpath$1=realpath(path, (char *)((void *)0));
+  return return_value_realpath$1;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+ssize_t readlink(const char *path, char *buf, size_t bufsiz)
+{
+  (void)*path;
+  if(__VERIFIER_nondet_int() || bufsiz < 1)
+    return -1;
+  unsigned long len = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(len <= bufsiz);
+  for(size_t i=0; i<len; ++i)
+    buf[i] = __VERIFIER_nondet_char();
+  return len;
+}
+char *realpath(const char *path, char *resolved_path)
+{
+  if(__VERIFIER_nondet_int())
+    return ((void *)0);
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(offset<4096);
+  if(resolved_path == ((void *)0))
+    resolved_path = malloc(offset+1);
+  *(resolved_path + offset) = '\0';
+  return resolved_path;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.c
@@ -224,7 +224,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.i
@@ -2258,7 +2258,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/realpath_false-no-overflow.c
+++ b/c/busybox-1.22.0/realpath_false-no-overflow.c
@@ -1,0 +1,347 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+#include <limits.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file libbb/xreadlink.c line 109
+static char * xmalloc_realpath(const char *path);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/realpath.c line 21
+signed int __main(signed int argc, char **argv)
+{
+  signed int retval = 0;
+  argv = argv + 1l;
+
+  if(*argv == ((char *)NULL))
+    return 1;
+
+  do
+  {
+    char *resolved_path;
+
+    resolved_path=xmalloc_realpath(*argv);
+    if(!(resolved_path == ((char *)NULL)))
+    {
+      puts(resolved_path);
+      free((void *)resolved_path);
+    }
+
+    else
+    {
+      retval = 1;
+
+      bb_simple_perror_msg(*argv);
+    }
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  // fflush_stdout_and_exit(retval); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return retval;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file libbb/xreadlink.c line 109
+static char * xmalloc_realpath(const char *path)
+{
+  char *return_value_realpath$1;
+  return_value_realpath$1=realpath(path, (char *)NULL);
+  return return_value_realpath$1;
+}
+
+#include "busybox_sv_comp-realpath.h"
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/realpath_false-no-overflow.i
+++ b/c/busybox-1.22.0/realpath_false-no-overflow.i
@@ -1,0 +1,2564 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void xfunc_die(void);
+static char * xmalloc_realpath(const char *path);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+signed int __main(signed int argc, char **argv)
+{
+  signed int retval = 0;
+  argv = argv + 1l;
+  if(*argv == ((char *)((void *)0)))
+    return 1;
+  do
+  {
+    char *resolved_path;
+    resolved_path=xmalloc_realpath(*argv);
+    if(!(resolved_path == ((char *)((void *)0))))
+    {
+      puts(resolved_path);
+      free((void *)resolved_path);
+    }
+    else
+    {
+      retval = 1;
+      bb_simple_perror_msg(*argv);
+    }
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  fflush(stdout);
+  return retval;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static char * xmalloc_realpath(const char *path)
+{
+  char *return_value_realpath$1;
+  return_value_realpath$1=realpath(path, (char *)((void *)0));
+  return return_value_realpath$1;
+}
+char *realpath(const char *path, char *resolved_path)
+{
+  if(__VERIFIER_nondet_int())
+    return ((void *)0);
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(offset<4096);
+  if(resolved_path == ((void *)0))
+    resolved_path = malloc(offset+1);
+  *(resolved_path + offset) = '\0';
+  return resolved_path;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.c
@@ -138,7 +138,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.i
@@ -2274,7 +2274,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/rm_false-no-overflow.c
+++ b/c/busybox-1.22.0/rm_false-no-overflow.c
@@ -1,0 +1,1389 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <dirent.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1197
+static signed int bb_ask_confirmation(void);
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/get_last_path_component.c line 25
+static char * bb_get_last_path_component_nostrip(const char *path);
+// file libbb/get_last_path_component.c line 41
+static char * bb_get_last_path_component_strip(char *path);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/concat_path_file.c line 19
+static char * concat_path_file(const char *path, const char *filename);
+// file libbb/concat_subpath_file.c line 18
+static char * concat_subpath_file(const char *path, const char *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 388
+static char * last_char_is(const char *s, signed int c);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/remove_file.c line 14
+static signed int remove_file(const char *path, signed int flags);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1197
+static signed int bb_ask_confirmation(void)
+{
+  signed int val;
+  return val;
+}
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/get_last_path_component.c line 25
+static char * bb_get_last_path_component_nostrip(const char *path)
+{
+  char *slash;
+  slash=strrchr(path, 47);
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  if(slash == ((char *)NULL))
+    tmp_if_expr$2 = 1 != 0;
+
+  else
+  {
+    if(slash == path)
+      tmp_if_expr$1 = (!((signed int)slash[(signed long int)1] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+    tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$2 == (_Bool)0))
+    return (char *)path;
+
+  return slash + (signed long int)1;
+}
+
+// file libbb/get_last_path_component.c line 41
+static char * bb_get_last_path_component_strip(char *path)
+{
+  char *slash;
+  slash=last_char_is(path, 47);
+  char *tmp_post$1;
+  if(!(slash == ((char *)NULL)))
+    for( ; (signed int)*slash == 47; *tmp_post$1 = (char)0)
+    {
+      if(slash == path)
+        break;
+
+      tmp_post$1 = slash;
+      slash = slash - 1l;
+    }
+
+  char *return_value_bb_get_last_path_component_nostrip$2;
+  return_value_bb_get_last_path_component_nostrip$2=bb_get_last_path_component_nostrip(path);
+  return return_value_bb_get_last_path_component_nostrip$2;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/concat_path_file.c line 19
+static char * concat_path_file(const char *path, const char *filename)
+{
+  char *lc;
+  if(path == ((const char *)NULL))
+    path = "";
+
+  lc=last_char_is(path, 47);
+  for( ; (signed int)*filename == 47; filename = filename + 1l)
+    ;
+  char *return_value_xasprintf$1;
+  return_value_xasprintf$1=xasprintf("%s%s%s", path, lc == (char *)NULL ? "/" : "", filename);
+  return return_value_xasprintf$1;
+}
+
+// file libbb/concat_subpath_file.c line 18
+static char * concat_subpath_file(const char *path, const char *f)
+{
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  if(!(f == ((const char *)NULL)))
+  {
+    if((signed int)*f == 46)
+    {
+      if((signed int)*(1l + f) == 0)
+        tmp_if_expr$2 = 1 != 0;
+
+      else
+      {
+        if((signed int)*(1l + f) == 46)
+          tmp_if_expr$1 = (!((signed int)f[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+        else
+          tmp_if_expr$1 = 0 != 0;
+        tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        return (char *)NULL;
+
+    }
+
+  }
+
+  char *return_value_concat_path_file$3;
+  return_value_concat_path_file$3=concat_path_file(path, f);
+  return return_value_concat_path_file$3;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 388
+static char * last_char_is(const char *s, signed int c)
+{
+  if(!(s == ((const char *)NULL)))
+  {
+    if(!((signed int)*s == 0))
+    {
+      unsigned long int sz;
+      unsigned long int return_value_strlen$1;
+      return_value_strlen$1=strlen(s);
+      sz = return_value_strlen$1 - (unsigned long int)1;
+      s = s + (signed long int)sz;
+      if((signed int)*s == c)
+        return (char *)s;
+
+    }
+
+  }
+
+  return (char *)NULL;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/remove_file.c line 14
+static signed int remove_file(const char *path, signed int flags)
+{
+  struct stat path_stat;
+  signed int return_value_lstat$1;
+  return_value_lstat$1=lstat(path, &path_stat);
+  if(return_value_lstat$1 < 0)
+  {
+    if(!(*bb_errno == 2))
+    {
+      bb_perror_msg("can't stat '%s'", path);
+      return -1;
+    }
+
+    if((8 & flags) == 0)
+    {
+      bb_perror_msg("can't remove '%s'", path);
+      return -1;
+    }
+
+    return 0;
+  }
+
+  _Bool tmp_if_expr$4;
+  signed int return_value_access$3;
+  _Bool tmp_if_expr$6;
+  signed int return_value_isatty$5;
+  if((61440u & path_stat.st_mode) == 16384u)
+  {
+    struct __dirstream *dp;
+    struct dirent *d;
+    signed int status = 0;
+    if((4 & flags) == 0)
+    {
+      bb_error_msg("'%s' is a directory", path);
+      return -1;
+    }
+
+    if((8 & flags) == 0)
+    {
+      return_value_access$3=access(path, 2);
+      tmp_if_expr$4 = (return_value_access$3 < 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+
+    else
+      tmp_if_expr$4 = 0 != 0;
+    if(!(tmp_if_expr$4 == (_Bool)0))
+    {
+      return_value_isatty$5=isatty(0);
+      tmp_if_expr$6 = (return_value_isatty$5 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+
+    else
+      tmp_if_expr$6 = 0 != 0;
+    if((16 & flags) == 0)
+    {
+      if(tmp_if_expr$6 != (_Bool)0)
+        goto __CPROVER_DUMP_L9;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L9:
+      ;
+      fprintf(stderr, "%s: descend into directory '%s'? ", applet_name, path);
+      signed int return_value_bb_ask_confirmation$2;
+      return_value_bb_ask_confirmation$2=bb_ask_confirmation();
+      if(return_value_bb_ask_confirmation$2 == 0)
+        return 0;
+
+    }
+    dp=opendir(path);
+    if(dp == ((struct __dirstream *)NULL))
+      return -1;
+
+    do
+    {
+      d=readdir(dp);
+      if(d == ((struct dirent *)NULL))
+        break;
+
+      char *new_path;
+      new_path=concat_subpath_file(path, d->d_name);
+      if(!(new_path == ((char *)NULL)))
+      {
+        signed int return_value_remove_file$7;
+        return_value_remove_file$7=remove_file(new_path, flags);
+        if(return_value_remove_file$7 < 0)
+          status = -1;
+
+        free((void *)new_path);
+      }
+
+    }
+    while((_Bool)1);
+    signed int return_value_closedir$8;
+    return_value_closedir$8=closedir(dp);
+    if(return_value_closedir$8 < 0)
+    {
+      bb_perror_msg("can't close '%s'", path);
+      return -1;
+    }
+
+    if(!((16 & flags) == 0))
+    {
+      fprintf(stderr, "%s: remove directory '%s'? ", applet_name, path);
+      signed int return_value_bb_ask_confirmation$9;
+      return_value_bb_ask_confirmation$9=bb_ask_confirmation();
+      if(return_value_bb_ask_confirmation$9 == 0)
+        return status;
+
+    }
+
+    signed int return_value_rmdir$10;
+    return_value_rmdir$10=rmdir(path);
+    if(return_value_rmdir$10 < 0)
+    {
+      bb_perror_msg("can't remove '%s'", path);
+      return -1;
+    }
+
+    return status;
+  }
+
+  _Bool tmp_if_expr$13;
+  signed int return_value_access$12;
+  if((8 & flags) == 0)
+  {
+    return_value_access$12=access(path, 2);
+    tmp_if_expr$13 = (return_value_access$12 < 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+
+  else
+    tmp_if_expr$13 = 0 != 0;
+  _Bool tmp_if_expr$15;
+  signed int return_value_isatty$14;
+  if(!((61440u & path_stat.st_mode) == 40960u))
+  {
+    if(tmp_if_expr$13 == (_Bool)0)
+      goto __CPROVER_DUMP_L23;
+
+    return_value_isatty$14=isatty(0);
+    tmp_if_expr$15 = (return_value_isatty$14 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L23:
+    ;
+    tmp_if_expr$15 = 0 != 0;
+  }
+  if((16 & flags) == 0)
+  {
+    if(tmp_if_expr$15 != (_Bool)0)
+      goto __CPROVER_DUMP_L25;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L25:
+    ;
+    fprintf(stderr, "%s: remove '%s'? ", applet_name, path);
+    signed int return_value_bb_ask_confirmation$11;
+    return_value_bb_ask_confirmation$11=bb_ask_confirmation();
+    if(return_value_bb_ask_confirmation$11 == 0)
+      return 0;
+
+  }
+  signed int return_value_unlink$16;
+  return_value_unlink$16=unlink(path);
+  if(return_value_unlink$16 < 0)
+  {
+    bb_perror_msg("can't remove '%s'", path);
+    return -1;
+  }
+
+  return 0;
+}
+
+// file coreutils/rm.c line 34
+signed int __main(signed int argc, char **argv)
+{
+  signed int status = 0;
+  signed int flags = 0;
+  unsigned int opt;
+  opt_complementary = "f-i:i-f";
+  opt=getopt32(argv, "fiRrv");
+  argv = argv + (signed long int)optind;
+  if(!((1u & opt) == 0u))
+    flags = flags | 8;
+
+  if(!((2u & opt) == 0u))
+    flags = flags | 16;
+
+  if(!((12u & opt) == 0u))
+    flags = flags | 4;
+
+
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$2;
+  signed int return_value_remove_file$1;
+  if(!(*argv == ((char *)NULL)))
+    do
+    {
+      const char *base;
+
+      base=bb_get_last_path_component_strip(*argv);
+
+      if((signed int)*base == 46)
+      {
+
+        if((signed int)*(1l + base) == 0)
+          tmp_if_expr$3 = 1 != 0;
+
+        else
+        {
+
+          if((signed int)*(1l + base) == 46)
+          {
+
+            tmp_if_expr$2 = (!((signed int)base[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+
+          else
+            tmp_if_expr$2 = 0 != 0;
+          tmp_if_expr$3 = (tmp_if_expr$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        tmp_if_expr$4 = (tmp_if_expr$3 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+
+      else
+        tmp_if_expr$4 = 0 != 0;
+      if(!(tmp_if_expr$4 == (_Bool)0))
+        bb_error_msg("can't remove '.' or '..'");
+
+      else
+      {
+
+        return_value_remove_file$1=remove_file(*argv, flags);
+        if(return_value_remove_file$1 >= 0)
+          goto __CPROVER_DUMP_L27;
+
+      }
+      status = 1;
+
+    __CPROVER_DUMP_L27:
+      ;
+      argv = argv + 1l;
+
+    }
+    while(!(*argv == ((char *)NULL)));
+
+  else
+    if((8 & flags) == 0)
+      bb_show_usage();
+
+  return status;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 658
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  va_start(p, format);
+  r=vasprintf(&string_ptr, format, p);
+  va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  return string_ptr;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/rm_false-no-overflow.i
+++ b/c/busybox-1.22.0/rm_false-no-overflow.i
@@ -1,0 +1,3647 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+struct dirent
+  {
+    __ino_t d_ino;
+    __off_t d_off;
+    unsigned short int d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+  };
+struct dirent64
+  {
+    __ino64_t d_ino;
+    __off64_t d_off;
+    unsigned short int d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+  };
+enum
+  {
+    DT_UNKNOWN = 0,
+    DT_FIFO = 1,
+    DT_CHR = 2,
+    DT_DIR = 4,
+    DT_BLK = 6,
+    DT_REG = 8,
+    DT_LNK = 10,
+    DT_SOCK = 12,
+    DT_WHT = 14
+  };
+typedef struct __dirstream DIR;
+extern DIR *opendir (const char *__name) __attribute__ ((__nonnull__ (1)));
+extern DIR *fdopendir (int __fd);
+extern int closedir (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern struct dirent *readdir (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern struct dirent64 *readdir64 (DIR *__dirp) __attribute__ ((__nonnull__ (1)));
+extern int readdir_r (DIR *__restrict __dirp,
+        struct dirent *__restrict __entry,
+        struct dirent **__restrict __result)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int readdir64_r (DIR *__restrict __dirp,
+   struct dirent64 *__restrict __entry,
+   struct dirent64 **__restrict __result)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern void rewinddir (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void seekdir (DIR *__dirp, long int __pos) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int telldir (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int dirfd (DIR *__dirp) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+typedef long unsigned int size_t;
+extern int scandir (const char *__restrict __dir,
+      struct dirent ***__restrict __namelist,
+      int (*__selector) (const struct dirent *),
+      int (*__cmp) (const struct dirent **,
+      const struct dirent **))
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int scandir64 (const char *__restrict __dir,
+        struct dirent64 ***__restrict __namelist,
+        int (*__selector) (const struct dirent64 *),
+        int (*__cmp) (const struct dirent64 **,
+        const struct dirent64 **))
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int scandirat (int __dfd, const char *__restrict __dir,
+        struct dirent ***__restrict __namelist,
+        int (*__selector) (const struct dirent *),
+        int (*__cmp) (const struct dirent **,
+        const struct dirent **))
+     __attribute__ ((__nonnull__ (2, 3)));
+extern int scandirat64 (int __dfd, const char *__restrict __dir,
+   struct dirent64 ***__restrict __namelist,
+   int (*__selector) (const struct dirent64 *),
+   int (*__cmp) (const struct dirent64 **,
+          const struct dirent64 **))
+     __attribute__ ((__nonnull__ (2, 3)));
+extern int alphasort (const struct dirent **__e1,
+        const struct dirent **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int alphasort64 (const struct dirent64 **__e1,
+   const struct dirent64 **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern __ssize_t getdirentries (int __fd, char *__restrict __buf,
+    size_t __nbytes,
+    __off_t *__restrict __basep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern __ssize_t getdirentries64 (int __fd, char *__restrict __buf,
+      size_t __nbytes,
+      __off64_t *__restrict __basep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int versionsort (const struct dirent **__e1,
+   const struct dirent **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int versionsort64 (const struct dirent64 **__e1,
+     const struct dirent64 **__e2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static signed int bb_ask_confirmation(void);
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+static char * bb_get_last_path_component_nostrip(const char *path);
+static char * bb_get_last_path_component_strip(char *path);
+static void bb_perror_msg(const char *s, ...);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static char * concat_path_file(const char *path, const char *filename);
+static char * concat_subpath_file(const char *path, const char *f);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static char * last_char_is(const char *s, signed int c);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed int remove_file(const char *path, signed int flags);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static char * xasprintf(const char *format, ...);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static signed int bb_ask_confirmation(void)
+{
+  signed int val;
+  return val;
+}
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char * bb_get_last_path_component_nostrip(const char *path)
+{
+  char *slash;
+  slash=strrchr(path, 47);
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  if(slash == ((char *)((void *)0)))
+    tmp_if_expr$2 = 1 != 0;
+  else
+  {
+    if(slash == path)
+      tmp_if_expr$1 = (!((signed int)slash[(signed long int)1] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+    tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$2 == (_Bool)0))
+    return (char *)path;
+  return slash + (signed long int)1;
+}
+static char * bb_get_last_path_component_strip(char *path)
+{
+  char *slash;
+  slash=last_char_is(path, 47);
+  char *tmp_post$1;
+  if(!(slash == ((char *)((void *)0))))
+    for( ; (signed int)*slash == 47; *tmp_post$1 = (char)0)
+    {
+      if(slash == path)
+        break;
+      tmp_post$1 = slash;
+      slash = slash - 1l;
+    }
+  char *return_value_bb_get_last_path_component_nostrip$2;
+  return_value_bb_get_last_path_component_nostrip$2=bb_get_last_path_component_nostrip(path);
+  return return_value_bb_get_last_path_component_nostrip$2;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static char * concat_path_file(const char *path, const char *filename)
+{
+  char *lc;
+  if(path == ((const char *)((void *)0)))
+    path = "";
+  lc=last_char_is(path, 47);
+  for( ; (signed int)*filename == 47; filename = filename + 1l)
+    ;
+  char *return_value_xasprintf$1;
+  return_value_xasprintf$1=xasprintf("%s%s%s", path, lc == (char *)((void *)0) ? "/" : "", filename);
+  return return_value_xasprintf$1;
+}
+static char * concat_subpath_file(const char *path, const char *f)
+{
+  _Bool tmp_if_expr$2;
+  _Bool tmp_if_expr$1;
+  if(!(f == ((const char *)((void *)0))))
+  {
+    if((signed int)*f == 46)
+    {
+      if((signed int)*(1l + f) == 0)
+        tmp_if_expr$2 = 1 != 0;
+      else
+      {
+        if((signed int)*(1l + f) == 46)
+          tmp_if_expr$1 = (!((signed int)f[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        else
+          tmp_if_expr$1 = 0 != 0;
+        tmp_if_expr$2 = (tmp_if_expr$1 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$2 == (_Bool)0))
+        return (char *)((void *)0);
+    }
+  }
+  char *return_value_concat_path_file$3;
+  return_value_concat_path_file$3=concat_path_file(path, f);
+  return return_value_concat_path_file$3;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static char * last_char_is(const char *s, signed int c)
+{
+  if(!(s == ((const char *)((void *)0))))
+  {
+    if(!((signed int)*s == 0))
+    {
+      unsigned long int sz;
+      unsigned long int return_value_strlen$1;
+      return_value_strlen$1=strlen(s);
+      sz = return_value_strlen$1 - (unsigned long int)1;
+      s = s + (signed long int)sz;
+      if((signed int)*s == c)
+        return (char *)s;
+    }
+  }
+  return (char *)((void *)0);
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed int remove_file(const char *path, signed int flags)
+{
+  struct stat path_stat;
+  signed int return_value_lstat$1;
+  return_value_lstat$1=lstat(path, &path_stat);
+  if(return_value_lstat$1 < 0)
+  {
+    if(!(*bb_errno == 2))
+    {
+      bb_perror_msg("can't stat '%s'", path);
+      return -1;
+    }
+    if((8 & flags) == 0)
+    {
+      bb_perror_msg("can't remove '%s'", path);
+      return -1;
+    }
+    return 0;
+  }
+  _Bool tmp_if_expr$4;
+  signed int return_value_access$3;
+  _Bool tmp_if_expr$6;
+  signed int return_value_isatty$5;
+  if((61440u & path_stat.st_mode) == 16384u)
+  {
+    struct __dirstream *dp;
+    struct dirent *d;
+    signed int status = 0;
+    if((4 & flags) == 0)
+    {
+      bb_error_msg("'%s' is a directory", path);
+      return -1;
+    }
+    if((8 & flags) == 0)
+    {
+      return_value_access$3=access(path, 2);
+      tmp_if_expr$4 = (return_value_access$3 < 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    else
+      tmp_if_expr$4 = 0 != 0;
+    if(!(tmp_if_expr$4 == (_Bool)0))
+    {
+      return_value_isatty$5=isatty(0);
+      tmp_if_expr$6 = (return_value_isatty$5 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    else
+      tmp_if_expr$6 = 0 != 0;
+    if((16 & flags) == 0)
+    {
+      if(tmp_if_expr$6 != (_Bool)0)
+        goto __CPROVER_DUMP_L9;
+    }
+    else
+    {
+    __CPROVER_DUMP_L9:
+      ;
+      fprintf(stderr, "%s: descend into directory '%s'? ", applet_name, path);
+      signed int return_value_bb_ask_confirmation$2;
+      return_value_bb_ask_confirmation$2=bb_ask_confirmation();
+      if(return_value_bb_ask_confirmation$2 == 0)
+        return 0;
+    }
+    dp=opendir(path);
+    if(dp == ((struct __dirstream *)((void *)0)))
+      return -1;
+    do
+    {
+      d=readdir(dp);
+      if(d == ((struct dirent *)((void *)0)))
+        break;
+      char *new_path;
+      new_path=concat_subpath_file(path, d->d_name);
+      if(!(new_path == ((char *)((void *)0))))
+      {
+        signed int return_value_remove_file$7;
+        return_value_remove_file$7=remove_file(new_path, flags);
+        if(return_value_remove_file$7 < 0)
+          status = -1;
+        free((void *)new_path);
+      }
+    }
+    while((_Bool)1);
+    signed int return_value_closedir$8;
+    return_value_closedir$8=closedir(dp);
+    if(return_value_closedir$8 < 0)
+    {
+      bb_perror_msg("can't close '%s'", path);
+      return -1;
+    }
+    if(!((16 & flags) == 0))
+    {
+      fprintf(stderr, "%s: remove directory '%s'? ", applet_name, path);
+      signed int return_value_bb_ask_confirmation$9;
+      return_value_bb_ask_confirmation$9=bb_ask_confirmation();
+      if(return_value_bb_ask_confirmation$9 == 0)
+        return status;
+    }
+    signed int return_value_rmdir$10;
+    return_value_rmdir$10=rmdir(path);
+    if(return_value_rmdir$10 < 0)
+    {
+      bb_perror_msg("can't remove '%s'", path);
+      return -1;
+    }
+    return status;
+  }
+  _Bool tmp_if_expr$13;
+  signed int return_value_access$12;
+  if((8 & flags) == 0)
+  {
+    return_value_access$12=access(path, 2);
+    tmp_if_expr$13 = (return_value_access$12 < 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  else
+    tmp_if_expr$13 = 0 != 0;
+  _Bool tmp_if_expr$15;
+  signed int return_value_isatty$14;
+  if(!((61440u & path_stat.st_mode) == 40960u))
+  {
+    if(tmp_if_expr$13 == (_Bool)0)
+      goto __CPROVER_DUMP_L23;
+    return_value_isatty$14=isatty(0);
+    tmp_if_expr$15 = (return_value_isatty$14 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  else
+  {
+  __CPROVER_DUMP_L23:
+    ;
+    tmp_if_expr$15 = 0 != 0;
+  }
+  if((16 & flags) == 0)
+  {
+    if(tmp_if_expr$15 != (_Bool)0)
+      goto __CPROVER_DUMP_L25;
+  }
+  else
+  {
+  __CPROVER_DUMP_L25:
+    ;
+    fprintf(stderr, "%s: remove '%s'? ", applet_name, path);
+    signed int return_value_bb_ask_confirmation$11;
+    return_value_bb_ask_confirmation$11=bb_ask_confirmation();
+    if(return_value_bb_ask_confirmation$11 == 0)
+      return 0;
+  }
+  signed int return_value_unlink$16;
+  return_value_unlink$16=unlink(path);
+  if(return_value_unlink$16 < 0)
+  {
+    bb_perror_msg("can't remove '%s'", path);
+    return -1;
+  }
+  return 0;
+}
+signed int __main(signed int argc, char **argv)
+{
+  signed int status = 0;
+  signed int flags = 0;
+  unsigned int opt;
+  opt_complementary = "f-i:i-f";
+  opt=getopt32(argv, "fiRrv");
+  argv = argv + (signed long int)optind;
+  if(!((1u & opt) == 0u))
+    flags = flags | 8;
+  if(!((2u & opt) == 0u))
+    flags = flags | 16;
+  if(!((12u & opt) == 0u))
+    flags = flags | 4;
+  _Bool tmp_if_expr$4;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$2;
+  signed int return_value_remove_file$1;
+  if(!(*argv == ((char *)((void *)0))))
+    do
+    {
+      const char *base;
+      base=bb_get_last_path_component_strip(*argv);
+      if((signed int)*base == 46)
+      {
+        if((signed int)*(1l + base) == 0)
+          tmp_if_expr$3 = 1 != 0;
+        else
+        {
+          if((signed int)*(1l + base) == 46)
+          {
+            tmp_if_expr$2 = (!((signed int)base[(signed long int)2] != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          else
+            tmp_if_expr$2 = 0 != 0;
+          tmp_if_expr$3 = (tmp_if_expr$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        tmp_if_expr$4 = (tmp_if_expr$3 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      else
+        tmp_if_expr$4 = 0 != 0;
+      if(!(tmp_if_expr$4 == (_Bool)0))
+        bb_error_msg("can't remove '.' or '..'");
+      else
+      {
+        return_value_remove_file$1=remove_file(*argv, flags);
+        if(return_value_remove_file$1 >= 0)
+          goto __CPROVER_DUMP_L27;
+      }
+      status = 1;
+    __CPROVER_DUMP_L27:
+      ;
+      argv = argv + 1l;
+    }
+    while(!(*argv == ((char *)((void *)0))));
+  else
+    if((8 & flags) == 0)
+      bb_show_usage();
+  return status;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static char * xasprintf(const char *format, ...)
+{
+  va_list p;
+  signed int r;
+  char *string_ptr;
+  __builtin_va_start(p,format);
+  r=vasprintf(&string_ptr, format, p);
+  __builtin_va_end(p);
+  if(r < 0)
+    bb_error_msg_and_die(bb_msg_memory_exhausted);
+  return string_ptr;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.c
@@ -282,7 +282,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.i
@@ -2625,7 +2625,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/seq_false-no-overflow.c
+++ b/c/busybox-1.22.0/seq_false-no-overflow.c
@@ -1,0 +1,1068 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/seq.c line 23
+signed int __main(signed int argc, char **argv)
+{
+  double first;
+  double last;
+  double increment;
+  double v;
+  unsigned int n;
+  unsigned int width;
+  unsigned int frac_part;
+  const char *sep;
+  const char *opt_s = "\n";
+  unsigned int opt;
+  opt=getopt32(argv, "+ws:", &opt_s);
+  argc = argc - optind;
+  argv = argv + (signed long int)optind;
+  increment = (double)1;
+  first = increment;
+
+  *bb_errno = 0;
+  char *pp;
+  if(!(argc == 3))
+  {
+    if(argc == 2)
+      goto __CPROVER_DUMP_L10;
+
+    if(argc == 1)
+      goto __CPROVER_DUMP_L17;
+
+  }
+
+  else
+  {
+
+    increment=strtod(argv[(signed long int)1], &pp);
+
+
+    *bb_errno = *bb_errno | (signed int)*pp;
+
+  __CPROVER_DUMP_L10:
+    ;
+
+    first=strtod(argv[(signed long int)0], &pp);
+
+
+    *bb_errno = *bb_errno | (signed int)*pp;
+
+  __CPROVER_DUMP_L17:
+    ;
+
+    last=strtod(argv[(signed long int)(argc - 1)], &pp);
+
+    if(*bb_errno == 0)
+    {
+
+      if((signed int)*pp == 0)
+        goto __CPROVER_DUMP_L25;
+
+    }
+
+  }
+  bb_show_usage();
+
+__CPROVER_DUMP_L25:
+  ;
+  width = (unsigned int)0;
+  frac_part = (unsigned int)0;
+  while((_Bool)1)
+  {
+    char *dot;
+
+    dot=strchrnul(*argv, 46);
+    signed int w;
+
+    w = (signed int)(dot - *argv);
+    signed int f;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(dot);
+    f = (signed int)return_value_strlen$1;
+    if(!(width >= (unsigned int)w))
+      width = (unsigned int)w;
+
+    argv = argv + 1l;
+
+    if(*argv == ((char *)NULL))
+      break;
+
+    if(!(frac_part >= (unsigned int)f))
+      frac_part = (unsigned int)f;
+
+  }
+  if(!(frac_part == 0u))
+  {
+    frac_part = frac_part - 1u;
+    if(!(frac_part == 0u))
+      width = width + frac_part + (unsigned int)1;
+
+  }
+
+  if((1u & opt) == 0u)
+    width = (unsigned int)0;
+
+  sep = "";
+  v = first;
+  n = (unsigned int)0;
+  while(!((increment >= 0.000000 ? (signed int)(v <= last) : (signed int)(v >= last)) == 0))
+  {
+    signed int return_value_printf$2 = printf("%s%0*.*f", sep, width, frac_part, v);
+    if(return_value_printf$2 < 0)
+      break;
+
+    sep = opt_s;
+    n = n + 1u;
+    v = first + (double)n * increment;
+  }
+  if(!(n == 0u))
+    bb_putchar(10);
+
+  signed int return_value_fflush_all$3;
+  return_value_fflush_all$3=fflush_all();
+  return return_value_fflush_all$3;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/seq_false-no-overflow.i
+++ b/c/busybox-1.22.0/seq_false-no-overflow.i
@@ -1,0 +1,3066 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static signed int bb_putchar(signed int ch);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  double first;
+  double last;
+  double increment;
+  double v;
+  unsigned int n;
+  unsigned int width;
+  unsigned int frac_part;
+  const char *sep;
+  const char *opt_s = "\n";
+  unsigned int opt;
+  opt=getopt32(argv, "+ws:", &opt_s);
+  argc = argc - optind;
+  argv = argv + (signed long int)optind;
+  increment = (double)1;
+  first = increment;
+  *bb_errno = 0;
+  char *pp;
+  if(!(argc == 3))
+  {
+    if(argc == 2)
+      goto __CPROVER_DUMP_L10;
+    if(argc == 1)
+      goto __CPROVER_DUMP_L17;
+  }
+  else
+  {
+    increment=strtod(argv[(signed long int)1], &pp);
+    *bb_errno = *bb_errno | (signed int)*pp;
+  __CPROVER_DUMP_L10:
+    ;
+    first=strtod(argv[(signed long int)0], &pp);
+    *bb_errno = *bb_errno | (signed int)*pp;
+  __CPROVER_DUMP_L17:
+    ;
+    last=strtod(argv[(signed long int)(argc - 1)], &pp);
+    if(*bb_errno == 0)
+    {
+      if((signed int)*pp == 0)
+        goto __CPROVER_DUMP_L25;
+    }
+  }
+  bb_show_usage();
+__CPROVER_DUMP_L25:
+  ;
+  width = (unsigned int)0;
+  frac_part = (unsigned int)0;
+  while((_Bool)1)
+  {
+    char *dot;
+    dot=strchrnul(*argv, 46);
+    signed int w;
+    w = (signed int)(dot - *argv);
+    signed int f;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(dot);
+    f = (signed int)return_value_strlen$1;
+    if(!(width >= (unsigned int)w))
+      width = (unsigned int)w;
+    argv = argv + 1l;
+    if(*argv == ((char *)((void *)0)))
+      break;
+    if(!(frac_part >= (unsigned int)f))
+      frac_part = (unsigned int)f;
+  }
+  if(!(frac_part == 0u))
+  {
+    frac_part = frac_part - 1u;
+    if(!(frac_part == 0u))
+      width = width + frac_part + (unsigned int)1;
+  }
+  if((1u & opt) == 0u)
+    width = (unsigned int)0;
+  sep = "";
+  v = first;
+  n = (unsigned int)0;
+  while(!((increment >= 0.000000 ? (signed int)(v <= last) : (signed int)(v >= last)) == 0))
+  {
+    signed int return_value_printf$2 = printf("%s%0*.*f", sep, width, frac_part, v);
+    if(return_value_printf$2 < 0)
+      break;
+    sep = opt_s;
+    n = n + 1u;
+    v = first + (double)n * increment;
+  }
+  if(!(n == 0u))
+    bb_putchar(10);
+  signed int return_value_fflush_all$3;
+  return_value_fflush_all$3=fflush_all();
+  return return_value_fflush_all$3;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.c
@@ -188,7 +188,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.i
@@ -2233,7 +2233,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/sleep_false-no-overflow.c
+++ b/c/busybox-1.22.0/sleep_false-no-overflow.c
@@ -1,0 +1,465 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx);
+// file libbb/xatonum_template.c line 110
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file coreutils/sleep.c line 42
+static struct suffix_mult sfx[5l] = { { .suffix={ (char)115, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1 }, 
+    { .suffix={ (char)109, (char)0, (char)0, (char)0 }, .mult=(unsigned int)60 }, 
+    { .suffix={ (char)104, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(60 * 60) }, 
+    { .suffix={ (char)100, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(24 * 60 * 60) }, 
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  abort();
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/sleep.c line 52
+signed int __main(signed int argc, char **argv)
+{
+  double duration;
+  struct timespec ts;
+  argv = argv + 1l;
+
+  if(*argv == ((char *)NULL))
+    bb_show_usage();
+
+  duration = (double)0;
+  signed int tmp_statement_expression$1;
+  unsigned long int tmp_if_expr$9;
+  unsigned long int tmp_if_expr$7;
+  unsigned long int tmp_if_expr$6;
+  unsigned long int return_value___strspn_c1$2;
+  unsigned long int tmp_if_expr$5;
+  unsigned long int return_value___strspn_c2$3;
+  unsigned long int return_value___builtin_strspn$4;
+  unsigned long int return_value___builtin_strspn$8;
+  _Bool tmp_if_expr$10;
+  char *tmp_post$11;
+  do
+  {
+    char *arg;
+
+    arg = *argv;
+    char *return_value___builtin_strchr$14;
+    return_value___builtin_strchr$14=strchr(arg, 46);
+    if(!(return_value___builtin_strchr$14 == ((char *)NULL)))
+    {
+      double d;
+      char *pp;
+      signed int len;
+      len = strspn(arg, "0123456789.");
+      char sv;
+
+      sv = arg[(signed long int)len];
+      arg[(signed long int)len] = (char)0;
+
+      *bb_errno = 0;
+      d=strtod(arg, &pp);
+
+      if(!(*bb_errno == 0))
+        tmp_if_expr$10 = 1 != 0;
+
+      else
+      {
+
+        tmp_if_expr$10 = ((arg == pp || (signed int)*pp != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$10 == (_Bool)0))
+        bb_show_usage();
+
+      arg = arg + (signed long int)len;
+      tmp_post$11 = arg;
+      arg = arg - 1l;
+
+      *tmp_post$11 = sv;
+
+      sv = *arg;
+      *arg = (char)49;
+      unsigned long int return_value_xatoul_sfx$12;
+      return_value_xatoul_sfx$12=xatoul_sfx(arg, sfx);
+      duration = duration + d * (double)return_value_xatoul_sfx$12;
+
+      *arg = sv;
+    }
+
+    else
+    {
+      unsigned long int return_value_xatoul_sfx$13;
+      return_value_xatoul_sfx$13=xatoul_sfx(arg, sfx);
+      duration = duration + (double)return_value_xatoul_sfx$13;
+    }
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  ts.tv_sec = (signed long int)((signed long int)-1 > (signed long int)0 ? (signed long int)-1 : (signed long int)~((signed long int)1 << sizeof(signed long int) /*8ul*/  * (unsigned long int)8 - (unsigned long int)1));
+  ts.tv_nsec = (signed long int)0;
+  if(duration >= 0.000000)
+  {
+    if(duration < (double)ts.tv_sec)
+    {
+      ts.tv_sec = (signed long int)duration;
+      ts.tv_nsec = (signed long int)((duration - (double)ts.tv_sec) * (double)1000000000);
+    }
+
+  }
+
+  while((_Bool)1)
+  {
+
+    *bb_errno = 0;
+    nanosleep(&ts, &ts);
+
+    if(!(*bb_errno == 4))
+      break;
+
+  }
+  return 0;
+}
+
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_sfx$1;
+  return_value_xatoull_sfx$1=xatoull_sfx(str, sfx);
+  return return_value_xatoull_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 110
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/sleep_false-no-overflow.i
+++ b/c/busybox-1.22.0/sleep_false-no-overflow.i
@@ -1,0 +1,2777 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx);
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes);
+static void xfunc_die(void);
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static struct suffix_mult sfx[5l] = { { .suffix={ (char)115, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1 },
+    { .suffix={ (char)109, (char)0, (char)0, (char)0 }, .mult=(unsigned int)60 },
+    { .suffix={ (char)104, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(60 * 60) },
+    { .suffix={ (char)100, (char)0, (char)0, (char)0 }, .mult=(unsigned int)(24 * 60 * 60) },
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  abort();
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  double duration;
+  struct timespec ts;
+  argv = argv + 1l;
+  if(*argv == ((char *)((void *)0)))
+    bb_show_usage();
+  duration = (double)0;
+  signed int tmp_statement_expression$1;
+  unsigned long int tmp_if_expr$9;
+  unsigned long int tmp_if_expr$7;
+  unsigned long int tmp_if_expr$6;
+  unsigned long int return_value___strspn_c1$2;
+  unsigned long int tmp_if_expr$5;
+  unsigned long int return_value___strspn_c2$3;
+  unsigned long int return_value___builtin_strspn$4;
+  unsigned long int return_value___builtin_strspn$8;
+  _Bool tmp_if_expr$10;
+  char *tmp_post$11;
+  do
+  {
+    char *arg;
+    arg = *argv;
+    char *return_value___builtin_strchr$14;
+    return_value___builtin_strchr$14=strchr(arg, 46);
+    if(!(return_value___builtin_strchr$14 == ((char *)((void *)0))))
+    {
+      double d;
+      char *pp;
+      signed int len;
+      len = strspn(arg, "0123456789.");
+      char sv;
+      sv = arg[(signed long int)len];
+      arg[(signed long int)len] = (char)0;
+      *bb_errno = 0;
+      d=strtod(arg, &pp);
+      if(!(*bb_errno == 0))
+        tmp_if_expr$10 = 1 != 0;
+      else
+      {
+        tmp_if_expr$10 = ((arg == pp || (signed int)*pp != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$10 == (_Bool)0))
+        bb_show_usage();
+      arg = arg + (signed long int)len;
+      tmp_post$11 = arg;
+      arg = arg - 1l;
+      *tmp_post$11 = sv;
+      sv = *arg;
+      *arg = (char)49;
+      unsigned long int return_value_xatoul_sfx$12;
+      return_value_xatoul_sfx$12=xatoul_sfx(arg, sfx);
+      duration = duration + d * (double)return_value_xatoul_sfx$12;
+      *arg = sv;
+    }
+    else
+    {
+      unsigned long int return_value_xatoul_sfx$13;
+      return_value_xatoul_sfx$13=xatoul_sfx(arg, sfx);
+      duration = duration + (double)return_value_xatoul_sfx$13;
+    }
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  ts.tv_sec = (signed long int)((signed long int)-1 > (signed long int)0 ? (signed long int)-1 : (signed long int)~((signed long int)1 << sizeof(signed long int) * (unsigned long int)8 - (unsigned long int)1));
+  ts.tv_nsec = (signed long int)0;
+  if(duration >= 0.000000)
+  {
+    if(duration < (double)ts.tv_sec)
+    {
+      ts.tv_sec = (signed long int)duration;
+      ts.tv_nsec = (signed long int)((duration - (double)ts.tv_sec) * (double)1000000000);
+    }
+  }
+  while((_Bool)1)
+  {
+    *bb_errno = 0;
+    nanosleep(&ts, &ts);
+    if(!(*bb_errno == 4))
+      break;
+  }
+  return 0;
+}
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_sfx$1;
+  return_value_xatoull_sfx$1=xatoull_sfx(str, sfx);
+  return return_value_xatoull_sfx$1;
+}
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/sleep_false-valid-deref.c
+++ b/c/busybox-1.22.0/sleep_false-valid-deref.c
@@ -116,7 +116,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/sleep_false-valid-deref.i
+++ b/c/busybox-1.22.0/sleep_false-valid-deref.i
@@ -2381,7 +2381,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-deref.c
+++ b/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-deref.c
@@ -116,7 +116,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-deref.i
+++ b/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-deref.i
@@ -2381,7 +2381,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/stty_false-no-overflow.c
+++ b/c/busybox-1.22.0/stty_false-no-overflow.c
@@ -1,0 +1,2690 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file coreutils/stty.c line 636
+struct control_info;
+
+// file libbb/ptr_to_globals.c line 10
+struct globals;
+
+// file coreutils/stty.c line 275
+struct mode_info;
+
+// file libbb/speed_table.c line 12
+struct speed_map;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+// file /usr/include/x86_64-linux-gnu/bits/ioctl-types.h line 27
+struct winsize;
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file coreutils/stty.c line 965
+static void display_recoverable(struct termios *mode, signed int dummy);
+// file coreutils/stty.c line 977
+static void display_speed(struct termios *mode, signed int fancy);
+// file coreutils/stty.c line 870
+static void display_window_size(signed int fancy);
+// file coreutils/stty.c line 994
+static void do_display(struct termios *mode, signed int all);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file coreutils/stty.c line 898
+static struct control_info * find_control(const char *name);
+// file coreutils/stty.c line 892
+static struct mode_info * find_mode(const char *name);
+// file coreutils/stty.c line 916
+static signed int find_param(const char *name);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file coreutils/stty.c line 251
+static unsigned int * get_ptr_to_tcflag(unsigned int type, struct termios *mode);
+// file include/libbb.h line 1348
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height);
+// file libbb/compare_string_array.c line 22
+static signed int index_in_strings(const char *strings, const char *key);
+// file libbb/xfuncs.c line 36
+static void ndelay_off(signed int fd);
+// file coreutils/stty.c line 841
+static void newline(void);
+// file libbb/compare_string_array.c line 76
+static const char * nth_string(const char *strings, signed int n);
+// file coreutils/stty.c line 804
+static void perror_on_device(const char *fmt);
+// file coreutils/stty.c line 799
+static void perror_on_device_and_die(const char *fmt);
+// file coreutils/stty.c line 935
+static signed int recover_mode(const char *arg, struct termios *mode);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file coreutils/stty.c line 1062
+static void sane_mode(struct termios *mode);
+// file coreutils/stty.c line 1224
+static void set_control_char_or_die(struct control_info *info, const char *arg, struct termios *mode);
+// file coreutils/stty.c line 1090
+static void set_mode(struct mode_info *info, signed int reversed, struct termios *mode);
+// file coreutils/stty.c line 784
+static void set_speed_or_die(signed int type, const char *arg, struct termios *mode);
+// file coreutils/stty.c line 848
+static void set_window_size(signed int rows, signed int cols);
+// 
+void output_func$object(struct termios *, signed int);
+// file libbb/speed_table.c line 61
+static unsigned int tty_baud_to_value(unsigned int speed);
+// file libbb/speed_table.c line 77
+static unsigned int tty_value_to_baud(unsigned int value);
+// file libbb/printable.c line 36
+static void visible(unsigned int ch, char *buf, signed int flags);
+// file libbb/xfuncs.c line 237
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err);
+// file coreutils/stty.c line 812
+static void wrapf(const char *message, ...);
+// file libbb/xatonum_template.c line 116
+static unsigned int xatou(const char *numstr);
+// file libbb/xatonum_template.c line 110
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes);
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_range_sfx(const char *str, unsigned long int l, unsigned long int u, struct suffix_mult *sfx);
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx);
+// file libbb/xatonum_template.c line 95
+static unsigned long long int xatoull_range_sfx(const char *numstr, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+// file libbb/xatonum_template.c line 110
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes);
+// file libbb/xfuncs_printf.c line 213
+static void xdup2(signed int from, signed int to);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file libbb/xfuncs_printf.c line 220
+static void xmove_fd(signed int from, signed int to);
+// file include/libbb.h line 477
+static signed int xopen(const char *pathname, signed int flags);
+// file libbb/xfuncs_printf.c line 126
+static signed int xopen3(const char *pathname, signed int flags, signed int mode);
+// file libbb/xfuncs_printf.c line 165
+static signed int xopen_nonblocking(const char *pathname);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct control_info
+{
+  // saneval
+  const unsigned char saneval;
+  // offset
+  const unsigned char offset;
+};
+
+struct globals
+{
+  // device_name
+  const char *device_name;
+  // max_col
+  unsigned int max_col;
+  // current_col
+  unsigned int current_col;
+  // buf
+  char buf[10l];
+};
+
+struct mode_info
+{
+  // type
+  const unsigned char type;
+  // flags
+  const unsigned char flags;
+  // mask
+  const unsigned short int mask;
+  // bits
+  const unsigned int bits;
+};
+
+struct speed_map
+{
+  // speed
+  unsigned short int speed;
+  // value
+  unsigned short int value;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/messages.c line 66
+static char bb_common_bufsiz1[8193l];
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 31
+static const char bb_msg_requires_arg[24l] = { (const char)37, (const char)115, (const char)32, (const char)114, (const char)101, (const char)113, (const char)117, (const char)105, (const char)114, (const char)101, (const char)115, (const char)32, (const char)97, (const char)110, (const char)32, (const char)97, (const char)114, (const char)103, (const char)117, (const char)109, (const char)101, (const char)110, (const char)116, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file coreutils/stty.c line 725
+static struct control_info control_info[17l] = { { .saneval=(const unsigned char)(99 & 31), .offset=(const unsigned char)0 }, 
+    { .saneval=(const unsigned char)28, .offset=(const unsigned char)1 }, 
+    { .saneval=(const unsigned char)127, .offset=(const unsigned char)2 }, 
+    { .saneval=(const unsigned char)(117 & 31), .offset=(const unsigned char)3 }, 
+    { .saneval=(const unsigned char)(100 & 31), .offset=(const unsigned char)4 }, 
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)11 }, 
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)16 }, 
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)7 }, 
+    { .saneval=(const unsigned char)(113 & 31), .offset=(const unsigned char)8 }, 
+    { .saneval=(const unsigned char)(115 & 31), .offset=(const unsigned char)9 }, 
+    { .saneval=(const unsigned char)(122 & 31), .offset=(const unsigned char)10 }, 
+    { .saneval=(const unsigned char)(114 & 31), .offset=(const unsigned char)12 }, 
+    { .saneval=(const unsigned char)(119 & 31), .offset=(const unsigned char)14 }, 
+    { .saneval=(const unsigned char)(118 & 31), .offset=(const unsigned char)15 }, 
+    { .saneval=(const unsigned char)(111 & 31), .offset=(const unsigned char)13 }, 
+    { .saneval=(const unsigned char)1, .offset=(const unsigned char)6 }, 
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)5 } };
+// file coreutils/stty.c line 683
+static const char control_name[91l] = { (const char)105, (const char)110, (const char)116, (const char)114, (const char)0, (const char)113, (const char)117, (const char)105, (const char)116, (const char)0, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)107, (const char)105, (const char)108, (const char)108, (const char)0, (const char)101, (const char)111, (const char)102, (const char)0, (const char)101, (const char)111, (const char)108, (const char)0, (const char)101, (const char)111, (const char)108, (const char)50, (const char)0, (const char)115, (const char)119, (const char)116, (const char)99, (const char)104, (const char)0, (const char)115, (const char)116, (const char)97, (const char)114, (const char)116, (const char)0, (const char)115, (const char)116, (const char)111, (const char)112, (const char)0, (const char)115, (const char)117, (const char)115, (const char)112, (const char)0, (const char)114, (const char)112, (const char)114, (const char)110, (const char)116, (const char)0, (const char)119, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)108, (const char)110, (const char)101, (const char)120, (const char)116, (const char)0, (const char)102, (const char)108, (const char)117, (const char)115, (const char)104, (const char)0, (const char)109, (const char)105, (const char)110, (const char)0, (const char)116, (const char)105, (const char)109, (const char)101, (const char)0, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file coreutils/stty.c line 476
+static struct mode_info mode_info[86l] = { { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)256 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)16 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)32 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)48 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 }, 
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=2147483648u }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)256 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4096 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4096 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8192 }, 
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16384 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)256,
+    .bits=(const unsigned int)256 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)256,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)1536 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)1024 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)512 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)6144 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)4096 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)2048 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)8192,
+    .bits=(const unsigned int)8192 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)8192,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)16384,
+    .bits=(const unsigned int)16384 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)16384,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)32768,
+    .bits=(const unsigned int)32768 }, 
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)32768,
+    .bits=(const unsigned int)0 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32768 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)256 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 }, 
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 } };
+// file coreutils/stty.c line 320
+static const char mode_name[502l] = { (const char)101, (const char)118, (const char)101, (const char)110, (const char)112, (const char)0, (const char)112, (const char)97, (const char)114, (const char)105, (const char)116, (const char)121, (const char)0, (const char)111, (const char)100, (const char)100, (const char)112, (const char)0, (const char)110, (const char)108, (const char)0, (const char)101, (const char)107, (const char)0, (const char)115, (const char)97, (const char)110, (const char)101, (const char)0, (const char)99, (const char)111, (const char)111, (const char)107, (const char)101, (const char)100, (const char)0, (const char)114, (const char)97, (const char)119, (const char)0, (const char)112, (const char)97, (const char)115, (const char)115, (const char)56, (const char)0, (const char)108, (const char)105, (const char)116, (const char)111, (const char)117, (const char)116, (const char)0, (const char)99, (const char)98, (const char)114, (const char)101, (const char)97, (const char)107, (const char)0, (const char)99, (const char)114, (const char)116, (const char)0, (const char)100, (const char)101, (const char)99, (const char)0, (const char)100, (const char)101, (const char)99, (const char)99, (const char)116, (const char)108, (const char)113, (const char)0, (const char)116, (const char)97, (const char)98, (const char)115, (const char)0, (const char)108, (const char)99, (const char)97, (const char)115, (const char)101, (const char)0, (const char)76, (const char)67, (const char)65, (const char)83, (const char)69, (const char)0, (const char)112, (const char)97, (const char)114, (const char)101, (const char)110, (const char)98, (const char)0, (const char)112, (const char)97, (const char)114, (const char)111, (const char)100, (const char)100, (const char)0, (const char)99, (const char)115, (const char)53, (const char)0, (const char)99, (const char)115, (const char)54, (const char)0, (const char)99, (const char)115, (const char)55, (const char)0, (const char)99, (const char)115, (const char)56, (const char)0, (const char)104, (const char)117, (const char)112, (const char)99, (const char)108, (const char)0, (const char)104, (const char)117, (const char)112, (const char)0, (const char)99, (const char)115, (const char)116, (const char)111, (const char)112, (const char)98, (const char)0, (const char)99, (const char)114, (const char)101, (const char)97, (const char)100, (const char)0, (const char)99, (const char)108, (const char)111, (const char)99, (const char)97, (const char)108, (const char)0, (const char)99, (const char)114, (const char)116, (const char)115, (const char)99, (const char)116, (const char)115, (const char)0, (const char)105, (const char)103, (const char)110, (const char)98, (const char)114, (const char)107, (const char)0, (const char)98, (const char)114, (const char)107, (const char)105, (const char)110, (const char)116, (const char)0, (const char)105, (const char)103, (const char)110, (const char)112, (const char)97, (const char)114, (const char)0, (const char)112, (const char)97, (const char)114, (const char)109, (const char)114, (const char)107, (const char)0, (const char)105, (const char)110, (const char)112, (const char)99, (const char)107, (const char)0, (const char)105, (const char)115, (const char)116, (const char)114, (const char)105, (const char)112, (const char)0, (const char)105, (const char)110, (const char)108, (const char)99, (const char)114, (const char)0, (const char)105, (const char)103, (const char)110, (const char)99, (const char)114, (const char)0, (const char)105, (const char)99, (const char)114, (const char)110, (const char)108, (const char)0, (const char)105, (const char)120, (const char)111, (const char)110, (const char)0, (const char)105, (const char)120, (const char)111, (const char)102, (const char)102, (const char)0, (const char)116, (const char)97, (const char)110, (const char)100, (const char)101, (const char)109, (const char)0, (const char)105, (const char)117, (const char)99, (const char)108, (const char)99, (const char)0, (const char)105, (const char)120, (const char)97, (const char)110, (const char)121, (const char)0, (const char)105, (const char)109, (const char)97, (const char)120, (const char)98, (const char)101, (const char)108, (const char)0, (const char)105, (const char)117, (const char)116, (const char)102, (const char)56, (const char)0, (const char)111, (const char)112, (const char)111, (const char)115, (const char)116, (const char)0, (const char)111, (const char)108, (const char)99, (const char)117, (const char)99, (const char)0, (const char)111, (const char)99, (const char)114, (const char)110, (const char)108, (const char)0, (const char)111, (const char)110, (const char)108, (const char)99, (const char)114, (const char)0, (const char)111, (const char)110, (const char)111, (const char)99, (const char)114, (const char)0, (const char)111, (const char)110, (const char)108, (const char)114, (const char)101, (const char)116, (const char)0, (const char)111, (const char)102, (const char)105, (const char)108, (const char)108, (const char)0, (const char)111, (const char)102, (const char)100, (const char)101, (const char)108, (const char)0, (const char)110, (const char)108, (const char)49, (const char)0, (const char)110, (const char)108, (const char)48, (const char)0, (const char)99, (const char)114, (const char)51, (const char)0, (const char)99, (const char)114, (const char)50, (const char)0, (const char)99, (const char)114, (const char)49, (const char)0, (const char)99, (const char)114, (const char)48, (const char)0, (const char)116, (const char)97, (const char)98, (const char)51, (const char)0, (const char)116, (const char)97, (const char)98, (const char)50, (const char)0, (const char)116, (const char)97, (const char)98, (const char)49, (const char)0, (const char)116, (const char)97, (const char)98, (const char)48, (const char)0, (const char)98, (const char)115, (const char)49, (const char)0, (const char)98, (const char)115, (const char)48, (const char)0, (const char)118, (const char)116, (const char)49, (const char)0, (const char)118, (const char)116, (const char)48, (const char)0, (const char)102, (const char)102, (const char)49, (const char)0, (const char)102, (const char)102, (const char)48, (const char)0, (const char)105, (const char)115, (const char)105, (const char)103, (const char)0, (const char)105, (const char)99, (const char)97, (const char)110, (const char)111, (const char)110, (const char)0, (const char)105, (const char)101, (const char)120, (const char)116, (const char)101, (const char)110, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)101, (const char)0, (const char)99, (const char)114, (const char)116, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)107, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)110, (const char)108, (const char)0, (const char)110, (const char)111, (const char)102, (const char)108, (const char)115, (const char)104, (const char)0, (const char)120, (const char)99, (const char)97, (const char)115, (const char)101, (const char)0, (const char)116, (const char)111, (const char)115, (const char)116, (const char)111, (const char)112, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)112, (const char)114, (const char)116, (const char)0, (const char)112, (const char)114, (const char)116, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)99, (const char)116, (const char)108, (const char)0, (const char)99, (const char)116, (const char)108, (const char)101, (const char)99, (const char)104, (const char)111, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)107, (const char)101, (const char)0, (const char)99, (const char)114, (const char)116, (const char)107, (const char)105, (const char)108, (const char)108, (const char)0, (const char)0 };
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/speed_table.c line 17
+static struct speed_map speeds[21l] = { { .speed=(unsigned short int)0, .value=(unsigned short int)0 }, 
+    { .speed=(unsigned short int)1, .value=(unsigned short int)50 }, 
+    { .speed=(unsigned short int)2, .value=(unsigned short int)75 }, 
+    { .speed=(unsigned short int)3, .value=(unsigned short int)110 }, 
+    { .speed=(unsigned short int)4, .value=(unsigned short int)134 }, 
+    { .speed=(unsigned short int)5, .value=(unsigned short int)150 }, 
+    { .speed=(unsigned short int)6, .value=(unsigned short int)200 }, 
+    { .speed=(unsigned short int)7, .value=(unsigned short int)300 }, 
+    { .speed=(unsigned short int)8, .value=(unsigned short int)600 }, 
+    { .speed=(unsigned short int)9, .value=(unsigned short int)1200 }, 
+    { .speed=(unsigned short int)10, .value=(unsigned short int)1800 }, 
+    { .speed=(unsigned short int)11, .value=(unsigned short int)2400 }, 
+    { .speed=(unsigned short int)12, .value=(unsigned short int)4800 }, 
+    { .speed=(unsigned short int)13, .value=(unsigned short int)9600 }, 
+    { .speed=(unsigned short int)14, .value=(unsigned short int)19200 }, 
+    { .speed=(unsigned short int)15, .value=(unsigned short int)((unsigned int)(38400 / 256) + 32768u) }, 
+    { .speed=(unsigned short int)4097, .value=(unsigned short int)((unsigned int)(57600 / 256) + 32768u) }, 
+    { .speed=(unsigned short int)4098, .value=(unsigned short int)((unsigned int)(115200 / 256) + 32768u) }, 
+    { .speed=(unsigned short int)4099, .value=(unsigned short int)((unsigned int)(230400 / 256) + 32768u) }, 
+    { .speed=(unsigned short int)4100, .value=(unsigned short int)((unsigned int)(460800 / 256) + 32768u) }, 
+    { .speed=(unsigned short int)4103, .value=(unsigned short int)((unsigned int)(921600 / 256) + 32768u) } };
+// file coreutils/stty.c line 885
+static struct suffix_mult stty_suffixes[4l] = { { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 }, 
+    { .suffix={ (char)107, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 }, 
+    { .suffix={ (char)66, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 }, 
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/stty.c line 965
+static void display_recoverable(struct termios *mode, signed int dummy)
+{
+  signed int i;
+
+  printf("%lx:%lx:%lx:%lx", (unsigned long int)mode->c_iflag, (unsigned long int)mode->c_oflag, (unsigned long int)mode->c_cflag, (unsigned long int)mode->c_lflag);
+  i = 0;
+  for( ; i < 32; i = i + 1)
+  {
+
+    printf(":%x", (unsigned int)mode->c_cc[(signed long int)i]);
+  }
+  bb_putchar(10);
+}
+
+// file coreutils/stty.c line 977
+static void display_speed(struct termios *mode, signed int fancy)
+{
+  const char *fmt_str = "%lu %lu\n";
+  unsigned long int ispeed;
+  unsigned long int ospeed;
+  unsigned int return_value_cfgetispeed$1;
+  return_value_cfgetispeed$1=cfgetispeed(mode);
+  ispeed = (unsigned long int)return_value_cfgetispeed$1;
+  unsigned int return_value_cfgetospeed$2;
+  return_value_cfgetospeed$2=cfgetospeed(mode);
+  ospeed = (unsigned long int)return_value_cfgetospeed$2;
+  if(!(ispeed == 0ul))
+  {
+    if(ispeed == ospeed)
+      goto __CPROVER_DUMP_L1;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L1:
+    ;
+    ispeed = ospeed;
+    fmt_str = "%lu\n";
+  }
+  if(!(fancy == 0))
+    fmt_str = fmt_str + (signed long int)9;
+
+  unsigned int return_value_tty_baud_to_value$3;
+  return_value_tty_baud_to_value$3=tty_baud_to_value((unsigned int)ispeed);
+  unsigned int return_value_tty_baud_to_value$4;
+  return_value_tty_baud_to_value$4=tty_baud_to_value((unsigned int)ospeed);
+  wrapf(fmt_str, return_value_tty_baud_to_value$3, return_value_tty_baud_to_value$4);
+}
+
+// file coreutils/stty.c line 870
+static void display_window_size(signed int fancy)
+{
+  const char *fmt_str = "%s";
+  unsigned int width;
+  unsigned int height;
+  signed int return_value_get_terminal_width_height$2;
+  return_value_get_terminal_width_height$2=get_terminal_width_height(0, &width, &height);
+  _Bool tmp_if_expr$1;
+  if(!(return_value_get_terminal_width_height$2 == 0))
+  {
+
+    if(!(*bb_errno == 22))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+    {
+      fmt_str = fmt_str + (signed long int)2;
+      tmp_if_expr$1 = (!(fancy != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      perror_on_device(fmt_str);
+
+  }
+
+  else
+    wrapf(fancy != 0 ? "rows %u; columns %u;" : "%u %u\n", height, width);
+}
+
+// file coreutils/stty.c line 994
+static void do_display(struct termios *mode, signed int all)
+{
+  signed int i;
+  unsigned int *bitsp;
+  unsigned long int mask;
+  signed int prev_type = 0;
+  display_speed(mode, 1);
+  if(!(all == 0))
+    display_window_size(1);
+
+
+  wrapf("line = %u;\n", mode->c_line);
+  i = 0;
+  for( ; !(i == 15); i = i + 1)
+  {
+    char ch;
+
+    if(2l * (signed long int)i >= 0l)
+      (void)0;
+
+    else
+      /* assertion 2 * (signed long int)i >= 0 */
+      __VERIFIER_error();
+    if((signed long int)i < 17l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)i < 17l */
+      __VERIFIER_error();
+    ch = mode->c_cc[(signed long int)control_info[(signed long int)i].offset];
+    if((signed int)ch == 0)
+      strcpy(((struct globals *)&bb_common_bufsiz1)->buf, "<undef>");
+
+    else
+      visible((unsigned int)ch, ((struct globals *)&bb_common_bufsiz1)->buf, 0);
+    const char *return_value_nth_string$1;
+    return_value_nth_string$1=nth_string(control_name, i);
+    wrapf("%s = %s;", return_value_nth_string$1, (const void *)((struct globals *)&bb_common_bufsiz1)->buf);
+  }
+
+  wrapf("min = %u; time = %u;", mode->c_cc[(signed long int)6], mode->c_cc[(signed long int)5]);
+  newline();
+  i = 0;
+  unsigned int tmp_if_expr$2;
+  _Bool tmp_if_expr$4;
+  const char *return_value_nth_string$3;
+  _Bool tmp_if_expr$6;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$7;
+  for( ; i < 86; i = i + 1)
+  {
+    if(8l * (signed long int)i >= 0l)
+      (void)0;
+
+    else
+      /* assertion 8 * (signed long int)i >= 0 */
+      __VERIFIER_error();
+    if((signed long int)i < 86l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)i < 86l */
+      __VERIFIER_error();
+    if((8 & (signed int)mode_info[(signed long int)i].flags) == 0)
+    {
+      if(!((signed int)mode_info[(signed long int)i].type == prev_type))
+      {
+        newline();
+        if(8l * (signed long int)i >= 0l)
+          (void)0;
+
+        else
+          /* assertion 8 * (signed long int)i >= 0 */
+          __VERIFIER_error();
+        if((signed long int)i < 86l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)i < 86l */
+          __VERIFIER_error();
+        prev_type = (signed int)mode_info[(signed long int)i].type;
+      }
+
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)i >= 0 */
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)i < 86l */
+        __VERIFIER_error();
+      bitsp=get_ptr_to_tcflag((unsigned int)mode_info[(signed long int)i].type, mode);
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)i >= 0 */
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)i < 86l */
+        __VERIFIER_error();
+      if(!((signed int)mode_info[(signed long int)i].mask == 0))
+        tmp_if_expr$2 = (unsigned int)mode_info[(signed long int)i].mask;
+
+      else
+      {
+        if(8l * (signed long int)i >= 0l)
+          (void)0;
+
+        else
+          /* assertion 8 * (signed long int)i >= 0 */
+          __VERIFIER_error();
+        if((signed long int)i < 86l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)i < 86l */
+          __VERIFIER_error();
+        tmp_if_expr$2 = mode_info[(signed long int)i].bits;
+      }
+      mask = (unsigned long int)tmp_if_expr$2;
+
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)i >= 0 */
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)i < 86l */
+        __VERIFIER_error();
+      if((mask & (unsigned long int)*bitsp) == (unsigned long int)mode_info[(signed long int)i].bits)
+      {
+        if(!(all == 0))
+          tmp_if_expr$4 = 1 != 0;
+
+        else
+        {
+          if(8l * (signed long int)i >= 0l)
+            (void)0;
+
+          else
+            /* assertion 8 * (signed long int)i >= 0 */
+            __VERIFIER_error();
+          if((signed long int)i < 86l)
+            (void)0;
+
+          else
+            /* assertion (signed long int)i < 86l */
+            __VERIFIER_error();
+          tmp_if_expr$4 = (((signed int)mode_info[(signed long int)i].flags & 2) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$4 == (_Bool)0))
+        {
+          return_value_nth_string$3=nth_string(mode_name, i);
+          wrapf("-%s" + (signed long int)1, return_value_nth_string$3);
+        }
+
+      }
+
+      else
+      {
+        if(!(all == 0))
+        {
+          if(8l * (signed long int)i >= 0l)
+            (void)0;
+
+          else
+            /* assertion 8 * (signed long int)i >= 0 */
+            __VERIFIER_error();
+          if((signed long int)i < 86l)
+            (void)0;
+
+          else
+            /* assertion (signed long int)i < 86l */
+            __VERIFIER_error();
+          tmp_if_expr$6 = (((signed int)mode_info[(signed long int)i].flags & 4) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$6 = 0 != 0;
+        if(!(tmp_if_expr$6 == (_Bool)0))
+          tmp_if_expr$8 = 1 != 0;
+
+        else
+        {
+          if(all == 0)
+          {
+            if(8l * (signed long int)i >= 0l)
+              (void)0;
+
+            else
+              /* assertion 8 * (signed long int)i >= 0 */
+              __VERIFIER_error();
+            if((signed long int)i < 86l)
+              (void)0;
+
+            else
+              /* assertion (signed long int)i < 86l */
+              __VERIFIER_error();
+            tmp_if_expr$7 = (((signed int)mode_info[(signed long int)i].flags & (1 | 4)) == (1 | 4) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+
+          else
+            tmp_if_expr$7 = 0 != 0;
+          tmp_if_expr$8 = (tmp_if_expr$7 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$8 == (_Bool)0))
+        {
+          const char *return_value_nth_string$5;
+          return_value_nth_string$5=nth_string(mode_name, i);
+          wrapf("-%s", return_value_nth_string$5);
+        }
+
+      }
+    }
+
+  }
+  newline();
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file coreutils/stty.c line 898
+static struct control_info * find_control(const char *name)
+{
+  signed int i;
+  i=index_in_strings(control_name, name);
+  struct control_info *tmp_if_expr$1;
+  if(i >= 0)
+    tmp_if_expr$1 = &control_info[(signed long int)i];
+
+  else
+    tmp_if_expr$1 = (struct control_info *)NULL;
+  return tmp_if_expr$1;
+}
+
+// file coreutils/stty.c line 892
+static struct mode_info * find_mode(const char *name)
+{
+  signed int i;
+  i=index_in_strings(mode_name, name);
+  struct mode_info *tmp_if_expr$1;
+  if(i >= 0)
+    tmp_if_expr$1 = &mode_info[(signed long int)i];
+
+  else
+    tmp_if_expr$1 = (struct mode_info *)NULL;
+  return tmp_if_expr$1;
+}
+
+// file coreutils/stty.c line 916
+static signed int find_param(const char *name)
+{
+  signed int i;
+  signed int return_value_index_in_strings$1;
+  static const char params[49l] = { (const char)108, (const char)105, (const char)110, (const char)101, (const char)0, (const char)114, (const char)111, (const char)119, (const char)115, (const char)0, (const char)99, (const char)111, (const char)108, (const char)115, (const char)0, (const char)99, (const char)111, (const char)108, (const char)117, (const char)109, (const char)110, (const char)115, (const char)0, (const char)115, (const char)105, (const char)122, (const char)101, (const char)0, (const char)115, (const char)112, (const char)101, (const char)101, (const char)100, (const char)0, (const char)105, (const char)115, (const char)112, (const char)101, (const char)101, (const char)100, (const char)0, (const char)111, (const char)115, (const char)112, (const char)101, (const char)101, (const char)100, (const char)0, (const char)0 };
+  return_value_index_in_strings$1=index_in_strings(params, name);
+  i = return_value_index_in_strings$1 + 1;
+  if(i == 0)
+    return 0;
+
+  if(!(i == 5))
+  {
+    if(!(i == 6))
+      i = i | 128;
+
+  }
+
+  return i;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/stty.c line 251
+static unsigned int * get_ptr_to_tcflag(unsigned int type, struct termios *mode)
+{
+  if(type <= 3u)
+  {
+    if((signed long int)type < 4l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)type < 4l */
+      __VERIFIER_error();
+    static const unsigned char tcflag_offsets[4l] = { (const unsigned char)8ul, (const unsigned char)0ul, (const unsigned char)4ul, (const unsigned char)12ul };
+    return (unsigned int *)((char *)mode + (signed long int)tcflag_offsets[(signed long int)type]);
+  }
+
+  return (unsigned int *)NULL;
+}
+
+// file include/libbb.h line 1348
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height)
+{
+  struct winsize win;
+  signed int err;
+  win.ws_row = (unsigned short int)0;
+  win.ws_col = (unsigned short int)0;
+  signed int return_value_ioctl$1;
+  return_value_ioctl$1=ioctl(fd, (unsigned long int)21523, &win);
+  err = (signed int)(return_value_ioctl$1 != 0 ? (signed int)(1 != 0) : ((signed int)win.ws_row == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)));
+  signed int return_value_wh_helper$2;
+  if(!(height == ((unsigned int *)NULL)))
+  {
+    return_value_wh_helper$2=wh_helper((signed int)win.ws_row, 24, "LINES", &err);
+    *height = (unsigned int)return_value_wh_helper$2;
+  }
+
+  signed int return_value_wh_helper$3;
+  if(!(width == ((unsigned int *)NULL)))
+  {
+    return_value_wh_helper$3=wh_helper((signed int)win.ws_col, 80, "COLUMNS", &err);
+    *width = (unsigned int)return_value_wh_helper$3;
+  }
+
+  return err;
+}
+
+// file libbb/compare_string_array.c line 22
+static signed int index_in_strings(const char *strings, const char *key)
+{
+  signed int idx = 0;
+  signed int tmp_statement_expression$1;
+  while(!((signed int)*strings == 0))
+  {
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    signed int return_value___builtin_strcmp$2;
+    return_value___builtin_strcmp$2=strcmp(strings, key);
+    tmp_statement_expression$1 = return_value___builtin_strcmp$2;
+    if(tmp_statement_expression$1 == 0)
+      return idx;
+
+    unsigned long int return_value_strlen$3;
+    return_value_strlen$3=strlen(strings);
+    strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+    idx = idx + 1;
+  }
+  return -1;
+}
+
+// file libbb/xfuncs.c line 36
+static void ndelay_off(signed int fd)
+{
+  signed int flags;
+  flags=fcntl(fd, 3);
+  if((2048 & flags) == 0)
+    return;
+
+  fcntl(fd, 4, flags & ~2048);
+}
+
+// file coreutils/stty.c line 841
+static void newline(void)
+{
+  if(!(((struct globals *)&bb_common_bufsiz1)->current_col == 0u))
+    wrapf("\n");
+
+}
+
+// file libbb/compare_string_array.c line 76
+static const char * nth_string(const char *strings, signed int n)
+{
+  while(!(n == 0))
+  {
+    n = n - 1;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(strings);
+    strings = strings + (signed long int)(return_value_strlen$1 + (unsigned long int)1);
+  }
+  return strings;
+}
+
+// file coreutils/stty.c line 804
+static void perror_on_device(const char *fmt)
+{
+  bb_perror_msg(fmt, ((struct globals *)&bb_common_bufsiz1)->device_name);
+}
+
+// file coreutils/stty.c line 799
+static void perror_on_device_and_die(const char *fmt)
+{
+  bb_perror_msg_and_die(fmt, ((struct globals *)&bb_common_bufsiz1)->device_name);
+}
+
+// file coreutils/stty.c line 935
+static signed int recover_mode(const char *arg, struct termios *mode)
+{
+  signed int i;
+  signed int n;
+  unsigned int chr;
+  unsigned long int iflag;
+  unsigned long int oflag;
+  unsigned long int cflag;
+  unsigned long int lflag;
+  signed int return_value_sscanf$1;
+  return_value_sscanf$1=sscanf(arg, "%lx:%lx:%lx:%lx%n", &iflag, &oflag, &cflag, &lflag, &n);
+  if(!(return_value_sscanf$1 == 4))
+    return 0;
+
+
+  mode->c_iflag = (unsigned int)iflag;
+
+  mode->c_oflag = (unsigned int)oflag;
+
+  mode->c_cflag = (unsigned int)cflag;
+
+  mode->c_lflag = (unsigned int)lflag;
+  arg = arg + (signed long int)n;
+  i = 0;
+  for( ; i < 32; i = i + 1)
+  {
+    signed int return_value_sscanf$2;
+    return_value_sscanf$2=sscanf(arg, ":%x%n", &chr, &n);
+    if(!(return_value_sscanf$2 == 1))
+      return 0;
+
+
+    mode->c_cc[(signed long int)i] = (unsigned char)chr;
+    arg = arg + (signed long int)n;
+  }
+
+  if(!((signed int)*arg == 0))
+    return 0;
+
+  return 1;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/stty.c line 1062
+static void sane_mode(struct termios *mode)
+{
+  signed int i = 0;
+  for( ; i < 17; i = i + 1)
+  {
+
+    if(2l * (signed long int)i >= 0l)
+      (void)0;
+
+    else
+      /* assertion 2 * (signed long int)i >= 0 */
+      __VERIFIER_error();
+    if((signed long int)i < 17l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)i < 17l */
+      __VERIFIER_error();
+    mode->c_cc[(signed long int)control_info[(signed long int)i].offset] = control_info[(signed long int)i].saneval;
+  }
+  i = 0;
+  for( ; i < 86; i = i + 1)
+  {
+    unsigned int val;
+    unsigned int *bitsp;
+    if(8l * (signed long int)i >= 0l)
+      (void)0;
+
+    else
+      /* assertion 8 * (signed long int)i >= 0 */
+      __VERIFIER_error();
+    if((signed long int)i < 86l)
+      (void)0;
+
+    else
+      /* assertion (signed long int)i < 86l */
+      __VERIFIER_error();
+    bitsp=get_ptr_to_tcflag((unsigned int)mode_info[(signed long int)i].type, mode);
+    if(!(bitsp == ((unsigned int *)NULL)))
+    {
+
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+
+      else
+        /* assertion 8 * (signed long int)i >= 0 */
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+
+      else
+        /* assertion (signed long int)i < 86l */
+        __VERIFIER_error();
+      val = (unsigned int)((unsigned long int)*bitsp & ~((unsigned long int)mode_info[(signed long int)i].mask));
+      if(!((1 & (signed int)mode_info[(signed long int)i].flags) == 0))
+        *bitsp = val | mode_info[(signed long int)i].bits;
+
+      else
+      {
+        if(8l * (signed long int)i >= 0l)
+          (void)0;
+
+        else
+          /* assertion 8 * (signed long int)i >= 0 */
+          __VERIFIER_error();
+        if((signed long int)i < 86l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)i < 86l */
+          __VERIFIER_error();
+        if(!((2 & (signed int)mode_info[(signed long int)i].flags) == 0))
+        {
+
+          *bitsp = val & ~mode_info[(signed long int)i].bits;
+        }
+
+      }
+    }
+
+  }
+}
+
+// file coreutils/stty.c line 1224
+static void set_control_char_or_die(struct control_info *info, const char *arg, struct termios *mode)
+{
+  unsigned char value;
+  _Bool tmp_if_expr$15;
+  if(info == control_info + 15l)
+    tmp_if_expr$15 = 1 != 0;
+
+  else
+    tmp_if_expr$15 = (info == &control_info[(signed long int)16] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  unsigned long int return_value_xatoul_range_sfx$1;
+  _Bool tmp_if_expr$14;
+  signed int tmp_statement_expression$3;
+  _Bool tmp_if_expr$4;
+  signed int tmp_if_expr$7;
+  signed int tmp_statement_expression$5;
+  signed int return_value___builtin_strcmp$6;
+  _Bool tmp_if_expr$13;
+  signed int tmp_statement_expression$8;
+  _Bool tmp_if_expr$9;
+  signed int tmp_if_expr$12;
+  signed int tmp_statement_expression$10;
+  signed int return_value___builtin_strcmp$11;
+  unsigned long int return_value_xatoul_range_sfx$2;
+  if(!(tmp_if_expr$15 == (_Bool)0))
+  {
+    return_value_xatoul_range_sfx$1=xatoul_range_sfx(arg, (unsigned long int)0, (unsigned long int)255, stty_suffixes);
+    value = (unsigned char)return_value_xatoul_range_sfx$1;
+  }
+
+  else
+  {
+
+    if((signed int)*arg == 0)
+      tmp_if_expr$14 = 1 != 0;
+
+    else
+    {
+
+      tmp_if_expr$14 = ((signed int)arg[(signed long int)1] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$14 == (_Bool)0))
+    {
+
+      value = arg[(signed long int)0];
+    }
+
+    else
+    {
+      unsigned long int __s1_len;
+      unsigned long int set_control_char_or_die$$1$$1$$__s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("^-" + 1l) + -((unsigned long int)"^-") == 1ul))
+          goto __CPROVER_DUMP_L13;
+
+        set_control_char_or_die$$1$$1$$__s2_len=strlen("^-");
+        tmp_if_expr$4 = (set_control_char_or_die$$1$$1$$__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L13:
+        ;
+        tmp_if_expr$4 = 0 != 0;
+      }
+      if(!(tmp_if_expr$4 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)arg;
+        signed int __result;
+
+        __result = (signed int)((const char *)"^-")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(set_control_char_or_die$$1$$1$$__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+
+
+            __result = (signed int)((const char *)"^-")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(set_control_char_or_die$$1$$1$$__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+
+
+                __result = (signed int)((const char *)"^-")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(set_control_char_or_die$$1$$1$$__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+
+                    /* assertion (_Bool)0 */
+                    __VERIFIER_error();
+
+                    __result = (signed int)((const char *)"^-")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+
+        tmp_statement_expression$5 = __result;
+        tmp_if_expr$7 = -tmp_statement_expression$5;
+      }
+
+      else
+      {
+        return_value___builtin_strcmp$6=strcmp(arg, "^-");
+        tmp_if_expr$7 = return_value___builtin_strcmp$6;
+      }
+      tmp_statement_expression$3 = tmp_if_expr$7;
+      if(tmp_statement_expression$3 == 0)
+        tmp_if_expr$13 = 1 != 0;
+
+      else
+      {
+        unsigned long int set_control_char_or_die$$1$$2$$__s1_len;
+        unsigned long int __s2_len;
+        if((_Bool)1)
+        {
+          if(!((unsigned long int)("undef" + 1l) + -((unsigned long int)"undef") == 1ul))
+            goto __CPROVER_DUMP_L35;
+
+          __s2_len=strlen("undef");
+          tmp_if_expr$9 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L35:
+          ;
+          tmp_if_expr$9 = 0 != 0;
+        }
+        if(!(tmp_if_expr$9 == (_Bool)0))
+        {
+          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const char *)arg;
+          signed int set_control_char_or_die$$1$$2$$2$$__result;
+
+          set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)0] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)0];
+          if(__s2_len > 0ul)
+          {
+            if(set_control_char_or_die$$1$$2$$2$$__result == 0)
+            {
+
+
+              set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)1] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)1];
+              if(__s2_len > 1ul)
+              {
+                if(set_control_char_or_die$$1$$2$$2$$__result == 0)
+                {
+
+
+                  set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)2] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)2];
+                  if(__s2_len > 2ul)
+                  {
+                    if(set_control_char_or_die$$1$$2$$2$$__result == 0)
+                    {
+
+
+                      set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)3] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)3];
+                    }
+
+                  }
+
+                }
+
+              }
+
+            }
+
+          }
+
+          tmp_statement_expression$10 = set_control_char_or_die$$1$$2$$2$$__result;
+          tmp_if_expr$12 = -tmp_statement_expression$10;
+        }
+
+        else
+        {
+          return_value___builtin_strcmp$11=strcmp(arg, "undef");
+          tmp_if_expr$12 = return_value___builtin_strcmp$11;
+        }
+        tmp_statement_expression$8 = tmp_if_expr$12;
+        tmp_if_expr$13 = (tmp_statement_expression$8 == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$13 == (_Bool)0))
+        value = (unsigned char)0;
+
+      else
+      {
+
+        if((signed int)*arg == 94)
+        {
+
+          value = (unsigned char)((signed int)arg[(signed long int)1] & 31);
+          if((signed int)*(1l + arg) == 63)
+            value = (unsigned char)127;
+
+        }
+
+        else
+        {
+          return_value_xatoul_range_sfx$2=xatoul_range_sfx(arg, (unsigned long int)0, (unsigned long int)255, stty_suffixes);
+          value = (unsigned char)return_value_xatoul_range_sfx$2;
+        }
+      }
+    }
+  }
+
+
+  mode->c_cc[(signed long int)info->offset] = value;
+}
+
+// file coreutils/stty.c line 1090
+static void set_mode(struct mode_info *info, signed int reversed, struct termios *mode)
+{
+  unsigned int *bitsp;
+
+  bitsp=get_ptr_to_tcflag((unsigned int)info->type, mode);
+  if(!(bitsp == ((unsigned int *)NULL)))
+  {
+    unsigned int val;
+
+
+    val = *bitsp & (unsigned int)~((signed int)info->mask);
+    if(!(reversed == 0))
+      *bitsp = val & ~info->bits;
+
+    else
+    {
+
+
+      *bitsp = val | info->bits;
+    }
+    return;
+  }
+
+  _Bool tmp_if_expr$4;
+  if(info == mode_info)
+    tmp_if_expr$4 = 1 != 0;
+
+  else
+    tmp_if_expr$4 = (info == &mode_info[(signed long int)1] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$2;
+  if(!(tmp_if_expr$4 == (_Bool)0))
+  {
+    if(!(reversed == 0))
+    {
+
+      mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+    }
+
+    else
+    {
+
+      mode->c_cflag = mode->c_cflag & (unsigned int)~512 & (unsigned int)~48 | (unsigned int)256 | (unsigned int)32;
+    }
+  }
+
+  else
+    if(info == mode_info + 2l)
+    {
+      if(!(reversed == 0))
+      {
+
+        mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+      }
+
+      else
+      {
+
+        mode->c_cflag = mode->c_cflag & (unsigned int)~48 | (unsigned int)32 | (unsigned int)512 | (unsigned int)256;
+      }
+    }
+
+    else
+      if(info == mode_info + 3l)
+      {
+        if(!(reversed == 0))
+        {
+
+          mode->c_iflag = (mode->c_iflag | (unsigned int)256) & (unsigned int)~64 & (unsigned int)~128;
+
+          mode->c_oflag = (mode->c_oflag | (unsigned int)4) & (unsigned int)~8 & (unsigned int)~32;
+        }
+
+        else
+        {
+
+          mode->c_iflag = mode->c_iflag & (unsigned int)~256;
+
+          mode->c_oflag = mode->c_oflag & (unsigned int)~4;
+        }
+      }
+
+      else
+        if(info == mode_info + 4l)
+        {
+
+          mode->c_cc[(signed long int)2] = (unsigned char)127;
+
+          mode->c_cc[(signed long int)3] = (unsigned char)(117 & 31);
+        }
+
+        else
+          if(info == mode_info + 5l)
+            sane_mode(mode);
+
+          else
+            if(info == mode_info + 10l)
+            {
+              if(!(reversed == 0))
+              {
+
+                mode->c_lflag = mode->c_lflag | (unsigned int)2;
+              }
+
+              else
+              {
+
+                mode->c_lflag = mode->c_lflag & (unsigned int)~2;
+              }
+            }
+
+            else
+              if(info == mode_info + 8l)
+              {
+                if(!(reversed == 0))
+                {
+
+                  mode->c_cflag = mode->c_cflag & (unsigned int)~48 | (unsigned int)32 | (unsigned int)256;
+
+                  mode->c_iflag = mode->c_iflag | (unsigned int)32;
+                }
+
+                else
+                {
+
+                  mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+
+                  mode->c_iflag = mode->c_iflag & (unsigned int)~32;
+                }
+              }
+
+              else
+                if(info == mode_info + 9l)
+                {
+                  if(!(reversed == 0))
+                  {
+
+                    mode->c_cflag = mode->c_cflag & (unsigned int)~48 | (unsigned int)32 | (unsigned int)256;
+
+                    mode->c_iflag = mode->c_iflag | (unsigned int)32;
+
+                    mode->c_oflag = mode->c_oflag | (unsigned int)1;
+                  }
+
+                  else
+                  {
+
+                    mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+
+                    mode->c_iflag = mode->c_iflag & (unsigned int)~32;
+
+                    mode->c_oflag = mode->c_oflag & (unsigned int)~1;
+                  }
+                }
+
+                else
+                {
+                  if(info == mode_info + 7l)
+                    tmp_if_expr$3 = 1 != 0;
+
+                  else
+                    tmp_if_expr$3 = (info == &mode_info[(signed long int)6] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(!(tmp_if_expr$3 == (_Bool)0))
+                  {
+                    if(info == mode_info + 7l && !(reversed == 0))
+                      tmp_if_expr$1 = 1 != 0;
+
+                    else
+                      tmp_if_expr$1 = ((info == &mode_info[(signed long int)6] ? (!(reversed != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) : (signed int)(0 != 0)) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    if(!(tmp_if_expr$1 == (_Bool)0))
+                    {
+
+                      mode->c_iflag = mode->c_iflag | (unsigned int)(2 | 4 | 32 | 256 | 1024);
+
+                      mode->c_oflag = mode->c_oflag | (unsigned int)1;
+
+                      mode->c_lflag = mode->c_lflag | (unsigned int)(1 | 2);
+                    }
+
+                    else
+                    {
+
+                      mode->c_iflag = (unsigned int)0;
+
+                      mode->c_oflag = mode->c_oflag & (unsigned int)~1;
+
+                      mode->c_lflag = mode->c_lflag & (unsigned int)~(1 | 2 | 4);
+
+                      mode->c_cc[(signed long int)6] = (unsigned char)1;
+
+                      mode->c_cc[(signed long int)5] = (unsigned char)0;
+                    }
+                  }
+
+                  else
+                    if(info == mode_info + 13l)
+                    {
+                      if(!(reversed == 0))
+                      {
+
+                        mode->c_iflag = mode->c_iflag | (unsigned int)2048;
+                      }
+
+                      else
+                      {
+
+                        mode->c_iflag = mode->c_iflag & (unsigned int)~2048;
+                      }
+                    }
+
+                    else
+                      if(info == mode_info + 14l)
+                      {
+                        if(!(reversed == 0))
+                        {
+
+                          mode->c_oflag = mode->c_oflag & (unsigned int)~6144 | (unsigned int)6144;
+                        }
+
+                        else
+                        {
+
+                          mode->c_oflag = mode->c_oflag & (unsigned int)~6144 | (unsigned int)0;
+                        }
+                      }
+
+                      else
+                      {
+                        if(info == mode_info + 15l)
+                          tmp_if_expr$2 = 1 != 0;
+
+                        else
+                          tmp_if_expr$2 = (info == &mode_info[(signed long int)16] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                        if(!(tmp_if_expr$2 == (_Bool)0))
+                        {
+                          if(!(reversed == 0))
+                          {
+
+                            mode->c_lflag = mode->c_lflag & (unsigned int)~4;
+
+                            mode->c_iflag = mode->c_iflag & (unsigned int)~512;
+
+                            mode->c_oflag = mode->c_oflag & (unsigned int)~2;
+                          }
+
+                          else
+                          {
+
+                            mode->c_lflag = mode->c_lflag | (unsigned int)4;
+
+                            mode->c_iflag = mode->c_iflag | (unsigned int)512;
+
+                            mode->c_oflag = mode->c_oflag | (unsigned int)2;
+                          }
+                        }
+
+                        else
+                          if(info == mode_info + 11l)
+                          {
+
+                            mode->c_lflag = mode->c_lflag | (unsigned int)(16 | 512 | 2048);
+                          }
+
+                          else
+                            if(info == mode_info + 12l)
+                            {
+
+                              mode->c_cc[(signed long int)0] = (unsigned char)3;
+
+                              mode->c_cc[(signed long int)2] = (unsigned char)127;
+
+                              mode->c_cc[(signed long int)3] = (unsigned char)21;
+
+                              mode->c_lflag = mode->c_lflag | (unsigned int)(16 | 512 | 2048);
+
+                              mode->c_iflag = mode->c_iflag & (unsigned int)~2048;
+                            }
+
+                      }
+                }
+}
+
+// file coreutils/stty.c line 784
+static void set_speed_or_die(signed int type, const char *arg, struct termios *mode)
+{
+  unsigned int baud;
+  unsigned int return_value_xatou$1;
+  return_value_xatou$1=xatou(arg);
+  baud=tty_value_to_baud(return_value_xatou$1);
+  if(!(type == 1))
+    cfsetispeed(mode, baud);
+
+  if(!(type == 0))
+    cfsetospeed(mode, baud);
+
+}
+
+// file coreutils/stty.c line 848
+static void set_window_size(signed int rows, signed int cols)
+{
+  struct winsize win = { .ws_row=(unsigned short int)0, .ws_col=(unsigned short int)0, .ws_xpixel=(unsigned short int)0,
+    .ws_ypixel=(unsigned short int)0 };
+  signed int return_value_ioctl$1;
+  return_value_ioctl$1=ioctl(0, (unsigned long int)21523, &win);
+  if(!(return_value_ioctl$1 == 0))
+  {
+
+    if(*bb_errno != 22)
+      goto bail;
+
+    memset((void *)&win, 0, sizeof(struct winsize) /*8ul*/ );
+  }
+
+  if(rows >= 0)
+    win.ws_row = (unsigned short int)rows;
+
+  if(cols >= 0)
+    win.ws_col = (unsigned short int)cols;
+
+  signed int return_value_ioctl$2;
+  return_value_ioctl$2=ioctl(0, (unsigned long int)21524, (char *)&win);
+  if(!(return_value_ioctl$2 == 0))
+  {
+
+  bail:
+    ;
+    perror_on_device("%s");
+  }
+
+}
+
+// file coreutils/stty.c line 1251
+signed int __main(signed int argc, char **argv)
+{
+  struct termios mode;
+  void (*output_func)(struct termios *, signed int);
+  const char *file_name = (const char *)NULL;
+  signed int display_all = 0;
+  signed int stty_state;
+  signed int k;
+  do
+  {
+    ((struct globals *)&bb_common_bufsiz1)->device_name = bb_msg_standard_input;
+    ((struct globals *)&bb_common_bufsiz1)->max_col = (unsigned int)80;
+  }
+  while((_Bool)0);
+  stty_state = 1 << 4;
+  output_func = do_display;
+  k = 0;
+  do
+  {
+    k = k + 1;
+
+    if(argv[(signed long int)k] == ((char *)NULL))
+      break;
+
+    struct mode_info *mp;
+    struct control_info *stty_main$$1$$2$$cp;
+    const char *stty_main$$1$$2$$arg = argv[(signed long int)k];
+    const char *stty_main$$1$$2$$argnext;
+
+    stty_main$$1$$2$$argnext = argv[(signed long int)(k + 1)];
+    signed int stty_main$$1$$2$$param;
+
+    if((signed int)*stty_main$$1$$2$$arg == 45)
+    {
+      signed int i;
+      mp=find_mode(stty_main$$1$$2$$arg + (signed long int)1);
+      if(!(mp == ((struct mode_info *)NULL)))
+      {
+
+        if((4 & (signed int)mp->flags) == 0)
+          goto invalid_argument;
+
+        stty_state = stty_state & ~(1 << 4);
+        continue;
+      }
+
+      i = 0;
+      do
+      {
+        i = i + 1;
+
+        if((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 0)
+          break;
+
+        if(!((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 97))
+        {
+          if((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 103)
+            goto __CPROVER_DUMP_L16;
+
+          if((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 70)
+            goto __CPROVER_DUMP_L17;
+
+        }
+
+        else
+        {
+          stty_state = stty_state | 1 << 2;
+          output_func = do_display;
+          display_all = 1;
+          continue;
+
+        __CPROVER_DUMP_L16:
+          ;
+          stty_state = stty_state | 1 << 3;
+          output_func = display_recoverable;
+          continue;
+
+        __CPROVER_DUMP_L17:
+          ;
+          if(!(file_name == ((const char *)NULL)))
+            bb_error_msg_and_die("only one device may be specified");
+
+          file_name = &stty_main$$1$$2$$arg[(signed long int)(i + 1)];
+
+          if((signed int)*file_name == 0)
+          {
+            signed int p = k + 1;
+            file_name = stty_main$$1$$2$$argnext;
+            if(file_name == ((const char *)NULL))
+              bb_error_msg_and_die(bb_msg_requires_arg, (const void *)"-F");
+
+            while((_Bool)1)
+            {
+
+              if(argv[(signed long int)p] == ((char *)NULL))
+                break;
+
+
+              argv[(signed long int)p] = argv[(signed long int)(p + 1)];
+              p = p + 1;
+            }
+          }
+
+          break;
+        }
+        goto invalid_argument;
+      }
+      while((_Bool)1);
+
+    end_option:
+      ;
+      continue;
+    }
+
+    mp=find_mode(stty_main$$1$$2$$arg);
+    if(!(mp == ((struct mode_info *)NULL)))
+      stty_state = stty_state & ~(1 << 4);
+
+    else
+    {
+      stty_main$$1$$2$$cp=find_control(stty_main$$1$$2$$arg);
+      if(!(stty_main$$1$$2$$cp == ((struct control_info *)NULL)))
+      {
+        if(stty_main$$1$$2$$argnext == ((const char *)NULL))
+          bb_error_msg_and_die(bb_msg_requires_arg, stty_main$$1$$2$$arg);
+
+        set_control_char_or_die(stty_main$$1$$2$$cp, stty_main$$1$$2$$argnext, &mode);
+        stty_state = stty_state & ~(1 << 4);
+        k = k + 1;
+      }
+
+      else
+      {
+        stty_main$$1$$2$$param=find_param(stty_main$$1$$2$$arg);
+        if(!((128 & stty_main$$1$$2$$param) == 0))
+        {
+          if(stty_main$$1$$2$$argnext == ((const char *)NULL))
+            bb_error_msg_and_die(bb_msg_requires_arg, stty_main$$1$$2$$arg);
+
+          k = k + 1;
+        }
+
+        if(!(stty_main$$1$$2$$param == 129))
+        {
+          if(stty_main$$1$$2$$param == 130)
+            goto __CPROVER_DUMP_L37;
+
+          if(stty_main$$1$$2$$param == 131)
+            goto __CPROVER_DUMP_L37;
+
+          if(stty_main$$1$$2$$param == 132)
+            goto __CPROVER_DUMP_L37;
+
+          if(stty_main$$1$$2$$param == 5 || stty_main$$1$$2$$param == 6)
+            goto __CPROVER_DUMP_L38;
+
+          if(stty_main$$1$$2$$param == 135)
+            goto __CPROVER_DUMP_L39;
+
+          if(stty_main$$1$$2$$param == 136)
+            goto __CPROVER_DUMP_L40;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L37:
+          ;
+          xatoul_range_sfx(stty_main$$1$$2$$argnext, (unsigned long int)1, (unsigned long int)2147483647, stty_suffixes);
+          goto __CPROVER_DUMP_L44;
+
+        __CPROVER_DUMP_L38:
+          ;
+          goto __CPROVER_DUMP_L44;
+
+        __CPROVER_DUMP_L39:
+          ;
+          set_speed_or_die((signed int)0, stty_main$$1$$2$$argnext, &mode);
+          goto __CPROVER_DUMP_L44;
+
+        __CPROVER_DUMP_L40:
+          ;
+          set_speed_or_die((signed int)1, stty_main$$1$$2$$argnext, &mode);
+          goto __CPROVER_DUMP_L44;
+        }
+        signed int return_value_recover_mode$1;
+        return_value_recover_mode$1=recover_mode(stty_main$$1$$2$$arg, &mode);
+        if(!(return_value_recover_mode$1 == 1))
+        {
+          unsigned int return_value_xatou$2;
+          return_value_xatou$2=xatou(stty_main$$1$$2$$arg);
+          unsigned int return_value_tty_value_to_baud$3;
+          return_value_tty_value_to_baud$3=tty_value_to_baud(return_value_xatou$2);
+          if(return_value_tty_value_to_baud$3 == 4294967295u)
+          {
+
+          invalid_argument:
+            ;
+            bb_error_msg_and_die("invalid argument '%s'", stty_main$$1$$2$$arg);
+          }
+
+        }
+
+      __CPROVER_DUMP_L44:
+        ;
+        stty_state = stty_state & ~(1 << 4);
+      }
+    }
+  }
+  while((_Bool)1);
+  if((12 & stty_state) == 12)
+    bb_error_msg_and_die("-a and -g are mutually exclusive");
+
+  if(!((12 & stty_state) == 0))
+  {
+    if((16 & stty_state) == 0)
+      bb_error_msg_and_die("modes may not be set when -a or -g is used");
+
+  }
+
+  if(!(file_name == ((const char *)NULL)))
+  {
+    ((struct globals *)&bb_common_bufsiz1)->device_name = file_name;
+    signed int return_value_xopen_nonblocking$4;
+    return_value_xopen_nonblocking$4=xopen_nonblocking(((struct globals *)&bb_common_bufsiz1)->device_name);
+    xmove_fd(return_value_xopen_nonblocking$4, 0);
+    ndelay_off(0);
+  }
+
+  memset((void *)&mode, 0, sizeof(struct termios) /*60ul*/ );
+  signed int return_value_tcgetattr$5;
+  return_value_tcgetattr$5=tcgetattr(0, &mode);
+  if(!(return_value_tcgetattr$5 == 0))
+    perror_on_device_and_die("%s");
+
+  if(!((28 & stty_state) == 0))
+  {
+    get_terminal_width_height(1, &((struct globals *)&bb_common_bufsiz1)->max_col, (unsigned int *)NULL);
+    output_func(&mode, display_all);
+    return 0;
+  }
+
+  k = 0;
+  unsigned long int return_value_xatoul_sfx$6;
+  unsigned long int return_value_xatoul_sfx$7;
+  unsigned long int return_value_xatoul_sfx$8;
+  do
+  {
+    k = k + 1;
+
+    if(argv[(signed long int)k] == ((char *)NULL))
+      break;
+
+    struct mode_info *stty_main$$1$$7$$mp;
+    struct control_info *cp;
+    const char *arg = argv[(signed long int)k];
+    const char *argnext;
+
+    argnext = argv[(signed long int)(k + 1)];
+    signed int param;
+
+    if((signed int)*arg == 45)
+    {
+      stty_main$$1$$7$$mp=find_mode(arg + (signed long int)1);
+      if(!(stty_main$$1$$7$$mp == ((struct mode_info *)NULL)))
+      {
+        set_mode(stty_main$$1$$7$$mp, 1, &mode);
+        stty_state = stty_state | 1 << 0;
+      }
+
+    }
+
+    else
+    {
+      stty_main$$1$$7$$mp=find_mode(arg);
+      if(!(stty_main$$1$$7$$mp == ((struct mode_info *)NULL)))
+      {
+        set_mode(stty_main$$1$$7$$mp, 0, &mode);
+        stty_state = stty_state | 1 << 0;
+      }
+
+      else
+      {
+        cp=find_control(arg);
+        if(!(cp == ((struct control_info *)NULL)))
+        {
+          k = k + 1;
+          set_control_char_or_die(cp, argnext, &mode);
+          stty_state = stty_state | 1 << 0;
+        }
+
+        else
+        {
+          param=find_param(arg);
+          if(!((128 & param) == 0))
+            k = k + 1;
+
+          if(!(param == 129))
+          {
+            if(param == 131 || param == 132)
+              goto __CPROVER_DUMP_L66;
+
+            if(param == 5)
+              goto __CPROVER_DUMP_L67;
+
+            if(param == 130)
+              goto __CPROVER_DUMP_L68;
+
+            if(param == 6)
+              goto __CPROVER_DUMP_L69;
+
+            if(param == 135)
+              goto __CPROVER_DUMP_L70;
+
+            if(param == 136)
+              goto __CPROVER_DUMP_L71;
+
+          }
+
+          else
+          {
+            return_value_xatoul_sfx$6=xatoul_sfx(argnext, stty_suffixes);
+            mode.c_line = (unsigned char)return_value_xatoul_sfx$6;
+            stty_state = stty_state | 1 << 0;
+            goto __CPROVER_DUMP_L75;
+
+          __CPROVER_DUMP_L66:
+            ;
+            return_value_xatoul_sfx$7=xatoul_sfx(argnext, stty_suffixes);
+            set_window_size(-1, (signed int)return_value_xatoul_sfx$7);
+            goto __CPROVER_DUMP_L75;
+
+          __CPROVER_DUMP_L67:
+            ;
+            display_window_size(0);
+            goto __CPROVER_DUMP_L75;
+
+          __CPROVER_DUMP_L68:
+            ;
+            return_value_xatoul_sfx$8=xatoul_sfx(argnext, stty_suffixes);
+            set_window_size((signed int)return_value_xatoul_sfx$8, -1);
+            goto __CPROVER_DUMP_L75;
+
+          __CPROVER_DUMP_L69:
+            ;
+            display_speed(&mode, 0);
+            goto __CPROVER_DUMP_L75;
+
+          __CPROVER_DUMP_L70:
+            ;
+            set_speed_or_die((signed int)0, argnext, &mode);
+            stty_state = stty_state | 1 << 0 | 1 << 1;
+            goto __CPROVER_DUMP_L75;
+
+          __CPROVER_DUMP_L71:
+            ;
+            set_speed_or_die((signed int)1, argnext, &mode);
+            stty_state = stty_state | 1 << 0 | 1 << 1;
+            goto __CPROVER_DUMP_L75;
+          }
+          signed int return_value_recover_mode$9;
+          return_value_recover_mode$9=recover_mode(arg, &mode);
+          if(return_value_recover_mode$9 == 1)
+            stty_state = stty_state | 1 << 0;
+
+          else
+          {
+            set_speed_or_die((signed int)2, arg, &mode);
+            stty_state = stty_state | 1 << 0 | 1 << 1;
+          }
+        }
+      }
+    }
+
+  __CPROVER_DUMP_L75:
+    ;
+  }
+  while((_Bool)1);
+  if(!((1 & stty_state) == 0))
+  {
+    struct termios new_mode;
+    signed int return_value_tcsetattr$10;
+    return_value_tcsetattr$10=tcsetattr(0, 1, &mode);
+    if(!(return_value_tcsetattr$10 == 0))
+      perror_on_device_and_die("%s");
+
+    memset((void *)&new_mode, 0, sizeof(struct termios) /*60ul*/ );
+    signed int return_value_tcgetattr$11;
+    return_value_tcgetattr$11=tcgetattr(0, &new_mode);
+    if(!(return_value_tcgetattr$11 == 0))
+      perror_on_device_and_die("%s");
+
+    signed int return_value_memcmp$12;
+    return_value_memcmp$12=memcmp((const void *)&mode, (const void *)&new_mode, sizeof(struct termios) /*60ul*/ );
+    if(!(return_value_memcmp$12 == 0))
+      perror_on_device_and_die("%s: cannot perform all requested operations");
+
+  }
+
+  return 0;
+}
+
+// file libbb/speed_table.c line 61
+static unsigned int tty_baud_to_value(unsigned int speed)
+{
+  signed int i = 0;
+  while((_Bool)1)
+  {
+    if(speed == (unsigned int)speeds[(signed long int)i].speed)
+    {
+      if(!((32768u & (unsigned int)speeds[(signed long int)i].value) == 0u))
+        return (unsigned int)(((unsigned long int)speeds[(signed long int)i].value & (unsigned long int)32767u) * (unsigned long int)256);
+
+      return (unsigned int)speeds[(signed long int)i].value;
+    }
+
+    i = i + 1;
+    if(!(i < 21))
+      break;
+
+  }
+  return (unsigned int)0;
+}
+
+// file libbb/speed_table.c line 77
+static unsigned int tty_value_to_baud(unsigned int value)
+{
+  signed int i = 0;
+  do
+  {
+    unsigned int return_value_tty_baud_to_value$1;
+    return_value_tty_baud_to_value$1=tty_baud_to_value((unsigned int)speeds[(signed long int)i].speed);
+    if(value == return_value_tty_baud_to_value$1)
+      return (unsigned int)speeds[(signed long int)i].speed;
+
+    i = i + 1;
+  }
+  while(i < 21);
+  return (unsigned int)-1;
+}
+
+// file libbb/printable.c line 36
+static void visible(unsigned int ch, char *buf, signed int flags)
+{
+  char *tmp_post$1;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  char *tmp_post$4;
+  if((2 & flags) == 0)
+  {
+    if(!(ch == 9u))
+      goto __CPROVER_DUMP_L1;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L1:
+    ;
+    if(ch == 10u)
+    {
+      if(!((1 & flags) == 0))
+      {
+        tmp_post$1 = buf;
+        buf = buf + 1l;
+        *tmp_post$1 = (char)36;
+      }
+
+    }
+
+    else
+    {
+      if(ch >= 128u)
+      {
+        ch = ch - (unsigned int)128;
+        tmp_post$2 = buf;
+        buf = buf + 1l;
+        *tmp_post$2 = (char)77;
+        tmp_post$3 = buf;
+        buf = buf + 1l;
+        *tmp_post$3 = (char)45;
+      }
+
+      if(!(ch < 32u))
+      {
+        if(ch == 127u)
+          goto __CPROVER_DUMP_L5;
+
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L5:
+        ;
+        tmp_post$4 = buf;
+        buf = buf + 1l;
+        *tmp_post$4 = (char)94;
+        ch = ch ^ (unsigned int)64;
+      }
+    }
+  }
+
+raw:
+  ;
+  char *tmp_post$5 = buf;
+  buf = buf + 1l;
+  *tmp_post$5 = (char)ch;
+  *buf = (char)0;
+}
+
+// file libbb/xfuncs.c line 237
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err)
+{
+  if(value == 0)
+  {
+    char *s;
+    s=getenv(env_name);
+    if(!(s == ((char *)NULL)))
+    {
+      value=atoi(s);
+      *err = 0;
+    }
+
+  }
+
+  if(!(value <= 1))
+  {
+    if(value >= 30000)
+      goto __CPROVER_DUMP_L3;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L3:
+    ;
+    value = def_val;
+  }
+  return value;
+}
+
+// file coreutils/stty.c line 812
+static void wrapf(const char *message, ...)
+{
+  char buf[128l];
+  va_list args;
+  unsigned int buflen;
+  va_start(args, message);
+  signed int return_value_vsnprintf$1;
+  return_value_vsnprintf$1=vsnprintf(buf, sizeof(char [128l]) /*128ul*/ , message, args);
+  buflen = (unsigned int)return_value_vsnprintf$1;
+  va_end(args);
+  if(!(buflen == 0u))
+  {
+    if((unsigned long int)buflen >= sizeof(char [128l]) /*128ul*/ )
+      goto __CPROVER_DUMP_L1;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L1:
+    ;
+    return;
+  }
+  if(((struct globals *)&bb_common_bufsiz1)->current_col > 0u)
+  {
+    ((struct globals *)&bb_common_bufsiz1)->current_col = ((struct globals *)&bb_common_bufsiz1)->current_col + 1u;
+    if(!((signed int)buf[0l] == 10))
+    {
+      if(((struct globals *)&bb_common_bufsiz1)->current_col + buflen >= ((struct globals *)&bb_common_bufsiz1)->max_col)
+      {
+        bb_putchar(10);
+        ((struct globals *)&bb_common_bufsiz1)->current_col = (unsigned int)0;
+      }
+
+      else
+        bb_putchar(32);
+    }
+
+  }
+
+  fputs(buf, stdout);
+  ((struct globals *)&bb_common_bufsiz1)->current_col = ((struct globals *)&bb_common_bufsiz1)->current_col + buflen;
+  if((signed long int)(4294967295u + buflen) < 128l)
+    (void)0;
+
+  else
+    /* assertion (signed long int)(buflen + 4294967295u) < 128l */
+    __VERIFIER_error();
+  if((signed int)buf[(signed long int)(4294967295u + buflen)] == 10)
+    ((struct globals *)&bb_common_bufsiz1)->current_col = (unsigned int)0;
+
+}
+
+// file libbb/xatonum_template.c line 116
+static unsigned int xatou(const char *numstr)
+{
+  unsigned int return_value_xatou_sfx$1;
+  return_value_xatou_sfx$1=xatou_sfx(numstr, (struct suffix_mult *)NULL);
+  return return_value_xatou_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 110
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, (unsigned int)0, (unsigned int)2147483647 * 2u + 1u, suffixes);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_range_sfx(const char *str, unsigned long int l, unsigned long int u, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_range_sfx$1;
+  return_value_xatoull_range_sfx$1=xatoull_range_sfx(str, l, u, sfx);
+  return return_value_xatoull_range_sfx$1;
+}
+
+// file include/xatonum.h line 87
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_sfx$1;
+  return_value_xatoull_sfx$1=xatoull_sfx(str, sfx);
+  return return_value_xatoull_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 95
+static unsigned long long int xatoull_range_sfx(const char *numstr, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, lower, upper, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 110
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+
+// file libbb/xfuncs_printf.c line 213
+static void xdup2(signed int from, signed int to)
+{
+  signed int return_value_dup2$1;
+  return_value_dup2$1=dup2(from, to);
+  if(!(return_value_dup2$1 == to))
+    bb_perror_msg_and_die("can't duplicate file descriptor");
+
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file libbb/xfuncs_printf.c line 220
+static void xmove_fd(signed int from, signed int to)
+{
+  if(from == to)
+    return;
+
+  xdup2(from, to);
+  close(from);
+}
+
+// file include/libbb.h line 477
+static signed int xopen(const char *pathname, signed int flags)
+{
+  signed int return_value_xopen3$1;
+  return_value_xopen3$1=xopen3(pathname, flags, 438);
+  return return_value_xopen3$1;
+}
+
+// file libbb/xfuncs_printf.c line 126
+static signed int xopen3(const char *pathname, signed int flags, signed int mode)
+{
+  signed int ret;
+  ret=open(pathname, flags, mode);
+  if(ret < 0)
+    bb_perror_msg_and_die("can't open '%s'", pathname);
+
+  return ret;
+}
+
+// file libbb/xfuncs_printf.c line 165
+static signed int xopen_nonblocking(const char *pathname)
+{
+  signed int return_value_xopen$1;
+  return_value_xopen$1=xopen(pathname, 0 | 2048);
+  return return_value_xopen$1;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/stty_false-no-overflow.i
+++ b/c/busybox-1.22.0/stty_false-no-overflow.i
@@ -1,0 +1,4530 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+struct flock
+  {
+    short int l_type;
+    short int l_whence;
+    __off_t l_start;
+    __off_t l_len;
+    __pid_t l_pid;
+  };
+struct flock64
+  {
+    short int l_type;
+    short int l_whence;
+    __off64_t l_start;
+    __off64_t l_len;
+    __pid_t l_pid;
+  };
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __uid_t uid_t;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __pid_t pid_t;
+typedef __id_t id_t;
+typedef __ssize_t ssize_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef long unsigned int size_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+typedef __sigset_t sigset_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+
+struct iovec
+  {
+    void *iov_base;
+    size_t iov_len;
+  };
+enum __pid_type
+  {
+    F_OWNER_TID = 0,
+    F_OWNER_PID,
+    F_OWNER_PGRP,
+    F_OWNER_GID = F_OWNER_PGRP
+  };
+struct f_owner_ex
+  {
+    enum __pid_type type;
+    __pid_t pid;
+  };
+struct file_handle
+{
+  unsigned int handle_bytes;
+  int handle_type;
+  unsigned char f_handle[0];
+};
+
+extern ssize_t readahead (int __fd, __off64_t __offset, size_t __count)
+    __attribute__ ((__nothrow__ , __leaf__));
+extern int sync_file_range (int __fd, __off64_t __offset, __off64_t __count,
+       unsigned int __flags);
+extern ssize_t vmsplice (int __fdout, const struct iovec *__iov,
+    size_t __count, unsigned int __flags);
+extern ssize_t splice (int __fdin, __off64_t *__offin, int __fdout,
+         __off64_t *__offout, size_t __len,
+         unsigned int __flags);
+extern ssize_t tee (int __fdin, int __fdout, size_t __len,
+      unsigned int __flags);
+extern int fallocate (int __fd, int __mode, __off_t __offset, __off_t __len);
+extern int fallocate64 (int __fd, int __mode, __off64_t __offset,
+   __off64_t __len);
+extern int name_to_handle_at (int __dfd, const char *__name,
+         struct file_handle *__handle, int *__mnt_id,
+         int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern int open_by_handle_at (int __mountdirfd, struct file_handle *__handle,
+         int __flags);
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int fcntl (int __fd, int __cmd, ...);
+extern int open (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int open64 (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int openat (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int openat64 (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int creat (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int creat64 (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int lockf (int __fd, int __cmd, off_t __len);
+extern int lockf64 (int __fd, int __cmd, off64_t __len);
+extern int posix_fadvise (int __fd, off_t __offset, off_t __len,
+     int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fadvise64 (int __fd, off64_t __offset, off64_t __len,
+       int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fallocate (int __fd, off_t __offset, off_t __len);
+extern int posix_fallocate64 (int __fd, off64_t __offset, off64_t __len);
+
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct winsize
+  {
+    unsigned short int ws_row;
+    unsigned short int ws_col;
+    unsigned short int ws_xpixel;
+    unsigned short int ws_ypixel;
+  };
+struct termio
+  {
+    unsigned short int c_iflag;
+    unsigned short int c_oflag;
+    unsigned short int c_cflag;
+    unsigned short int c_lflag;
+    unsigned char c_line;
+    unsigned char c_cc[8];
+};
+extern int ioctl (int __fd, unsigned long int __request, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+typedef unsigned char cc_t;
+typedef unsigned int speed_t;
+typedef unsigned int tcflag_t;
+struct termios
+  {
+    tcflag_t c_iflag;
+    tcflag_t c_oflag;
+    tcflag_t c_cflag;
+    tcflag_t c_lflag;
+    cc_t c_line;
+    cc_t c_cc[32];
+    speed_t c_ispeed;
+    speed_t c_ospeed;
+  };
+extern speed_t cfgetospeed (const struct termios *__termios_p) __attribute__ ((__nothrow__ , __leaf__));
+extern speed_t cfgetispeed (const struct termios *__termios_p) __attribute__ ((__nothrow__ , __leaf__));
+extern int cfsetospeed (struct termios *__termios_p, speed_t __speed) __attribute__ ((__nothrow__ , __leaf__));
+extern int cfsetispeed (struct termios *__termios_p, speed_t __speed) __attribute__ ((__nothrow__ , __leaf__));
+extern int cfsetspeed (struct termios *__termios_p, speed_t __speed) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcgetattr (int __fd, struct termios *__termios_p) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetattr (int __fd, int __optional_actions,
+        const struct termios *__termios_p) __attribute__ ((__nothrow__ , __leaf__));
+extern void cfmakeraw (struct termios *__termios_p) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsendbreak (int __fd, int __duration) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcdrain (int __fd);
+extern int tcflush (int __fd, int __queue_selector) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcflow (int __fd, int __action) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t tcgetsid (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct control_info;
+struct globals;
+struct mode_info;
+struct speed_map;
+struct suffix_mult;
+struct winsize;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static signed int bb_putchar(signed int ch);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void display_recoverable(struct termios *mode, signed int dummy);
+static void display_speed(struct termios *mode, signed int fancy);
+static void display_window_size(signed int fancy);
+static void do_display(struct termios *mode, signed int all);
+static signed int fflush_all(void);
+static struct control_info * find_control(const char *name);
+static struct mode_info * find_mode(const char *name);
+static signed int find_param(const char *name);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int * get_ptr_to_tcflag(unsigned int type, struct termios *mode);
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height);
+static signed int index_in_strings(const char *strings, const char *key);
+static void ndelay_off(signed int fd);
+static void newline(void);
+static const char * nth_string(const char *strings, signed int n);
+static void perror_on_device(const char *fmt);
+static void perror_on_device_and_die(const char *fmt);
+static signed int recover_mode(const char *arg, struct termios *mode);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void sane_mode(struct termios *mode);
+static void set_control_char_or_die(struct control_info *info, const char *arg, struct termios *mode);
+static void set_mode(struct mode_info *info, signed int reversed, struct termios *mode);
+static void set_speed_or_die(signed int type, const char *arg, struct termios *mode);
+static void set_window_size(signed int rows, signed int cols);
+void output_func$object(struct termios *, signed int);
+static unsigned int tty_baud_to_value(unsigned int speed);
+static unsigned int tty_value_to_baud(unsigned int value);
+static void visible(unsigned int ch, char *buf, signed int flags);
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err);
+static void wrapf(const char *message, ...);
+static unsigned int xatou(const char *numstr);
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes);
+static inline unsigned long int xatoul_range_sfx(const char *str, unsigned long int l, unsigned long int u, struct suffix_mult *sfx);
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx);
+static unsigned long long int xatoull_range_sfx(const char *numstr, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes);
+static void xdup2(signed int from, signed int to);
+static void xfunc_die(void);
+static void xmove_fd(signed int from, signed int to);
+static signed int xopen(const char *pathname, signed int flags);
+static signed int xopen3(const char *pathname, signed int flags, signed int mode);
+static signed int xopen_nonblocking(const char *pathname);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct control_info
+{
+  const unsigned char saneval;
+  const unsigned char offset;
+};
+struct globals
+{
+  const char *device_name;
+  unsigned int max_col;
+  unsigned int current_col;
+  char buf[10l];
+};
+struct mode_info
+{
+  const unsigned char type;
+  const unsigned char flags;
+  const unsigned short int mask;
+  const unsigned int bits;
+};
+struct speed_map
+{
+  unsigned short int speed;
+  unsigned short int value;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_name;
+static char bb_common_bufsiz1[8193l];
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_requires_arg[24l] = { (const char)37, (const char)115, (const char)32, (const char)114, (const char)101, (const char)113, (const char)117, (const char)105, (const char)114, (const char)101, (const char)115, (const char)32, (const char)97, (const char)110, (const char)32, (const char)97, (const char)114, (const char)103, (const char)117, (const char)109, (const char)101, (const char)110, (const char)116, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct control_info control_info[17l] = { { .saneval=(const unsigned char)(99 & 31), .offset=(const unsigned char)0 },
+    { .saneval=(const unsigned char)28, .offset=(const unsigned char)1 },
+    { .saneval=(const unsigned char)127, .offset=(const unsigned char)2 },
+    { .saneval=(const unsigned char)(117 & 31), .offset=(const unsigned char)3 },
+    { .saneval=(const unsigned char)(100 & 31), .offset=(const unsigned char)4 },
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)11 },
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)16 },
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)7 },
+    { .saneval=(const unsigned char)(113 & 31), .offset=(const unsigned char)8 },
+    { .saneval=(const unsigned char)(115 & 31), .offset=(const unsigned char)9 },
+    { .saneval=(const unsigned char)(122 & 31), .offset=(const unsigned char)10 },
+    { .saneval=(const unsigned char)(114 & 31), .offset=(const unsigned char)12 },
+    { .saneval=(const unsigned char)(119 & 31), .offset=(const unsigned char)14 },
+    { .saneval=(const unsigned char)(118 & 31), .offset=(const unsigned char)15 },
+    { .saneval=(const unsigned char)(111 & 31), .offset=(const unsigned char)13 },
+    { .saneval=(const unsigned char)1, .offset=(const unsigned char)6 },
+    { .saneval=(const unsigned char)0, .offset=(const unsigned char)5 } };
+static const char control_name[91l] = { (const char)105, (const char)110, (const char)116, (const char)114, (const char)0, (const char)113, (const char)117, (const char)105, (const char)116, (const char)0, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)107, (const char)105, (const char)108, (const char)108, (const char)0, (const char)101, (const char)111, (const char)102, (const char)0, (const char)101, (const char)111, (const char)108, (const char)0, (const char)101, (const char)111, (const char)108, (const char)50, (const char)0, (const char)115, (const char)119, (const char)116, (const char)99, (const char)104, (const char)0, (const char)115, (const char)116, (const char)97, (const char)114, (const char)116, (const char)0, (const char)115, (const char)116, (const char)111, (const char)112, (const char)0, (const char)115, (const char)117, (const char)115, (const char)112, (const char)0, (const char)114, (const char)112, (const char)114, (const char)110, (const char)116, (const char)0, (const char)119, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)108, (const char)110, (const char)101, (const char)120, (const char)116, (const char)0, (const char)102, (const char)108, (const char)117, (const char)115, (const char)104, (const char)0, (const char)109, (const char)105, (const char)110, (const char)0, (const char)116, (const char)105, (const char)109, (const char)101, (const char)0, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static struct mode_info mode_info[86l] = { { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)8, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)4, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)256 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)16 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)32 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)0, .mask=(const unsigned short int)48,
+    .bits=(const unsigned int)48 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)(4 | 8), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 },
+    { .type=(const unsigned char)0, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=2147483648u },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)256 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)4, .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4096 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4096 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8192 },
+    { .type=(const unsigned char)1, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16384 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)256,
+    .bits=(const unsigned int)256 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)256,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)1536 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)1024 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)512 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)1536,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)6144 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)4096 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)2048 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)6144,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)8192,
+    .bits=(const unsigned int)8192 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)8192,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)16384,
+    .bits=(const unsigned int)16384 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)16384,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)2, .mask=(const unsigned short int)32768,
+    .bits=(const unsigned int)32768 },
+    { .type=(const unsigned char)2, .flags=(const unsigned char)1, .mask=(const unsigned short int)32768,
+    .bits=(const unsigned int)0 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32768 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)8 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)16 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)32 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)64 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)128 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)4 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)256 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(2 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)1024 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)512 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(1 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 },
+    { .type=(const unsigned char)3, .flags=(const unsigned char)(8 | 4), .mask=(const unsigned short int)0,
+    .bits=(const unsigned int)2048 } };
+static const char mode_name[502l] = { (const char)101, (const char)118, (const char)101, (const char)110, (const char)112, (const char)0, (const char)112, (const char)97, (const char)114, (const char)105, (const char)116, (const char)121, (const char)0, (const char)111, (const char)100, (const char)100, (const char)112, (const char)0, (const char)110, (const char)108, (const char)0, (const char)101, (const char)107, (const char)0, (const char)115, (const char)97, (const char)110, (const char)101, (const char)0, (const char)99, (const char)111, (const char)111, (const char)107, (const char)101, (const char)100, (const char)0, (const char)114, (const char)97, (const char)119, (const char)0, (const char)112, (const char)97, (const char)115, (const char)115, (const char)56, (const char)0, (const char)108, (const char)105, (const char)116, (const char)111, (const char)117, (const char)116, (const char)0, (const char)99, (const char)98, (const char)114, (const char)101, (const char)97, (const char)107, (const char)0, (const char)99, (const char)114, (const char)116, (const char)0, (const char)100, (const char)101, (const char)99, (const char)0, (const char)100, (const char)101, (const char)99, (const char)99, (const char)116, (const char)108, (const char)113, (const char)0, (const char)116, (const char)97, (const char)98, (const char)115, (const char)0, (const char)108, (const char)99, (const char)97, (const char)115, (const char)101, (const char)0, (const char)76, (const char)67, (const char)65, (const char)83, (const char)69, (const char)0, (const char)112, (const char)97, (const char)114, (const char)101, (const char)110, (const char)98, (const char)0, (const char)112, (const char)97, (const char)114, (const char)111, (const char)100, (const char)100, (const char)0, (const char)99, (const char)115, (const char)53, (const char)0, (const char)99, (const char)115, (const char)54, (const char)0, (const char)99, (const char)115, (const char)55, (const char)0, (const char)99, (const char)115, (const char)56, (const char)0, (const char)104, (const char)117, (const char)112, (const char)99, (const char)108, (const char)0, (const char)104, (const char)117, (const char)112, (const char)0, (const char)99, (const char)115, (const char)116, (const char)111, (const char)112, (const char)98, (const char)0, (const char)99, (const char)114, (const char)101, (const char)97, (const char)100, (const char)0, (const char)99, (const char)108, (const char)111, (const char)99, (const char)97, (const char)108, (const char)0, (const char)99, (const char)114, (const char)116, (const char)115, (const char)99, (const char)116, (const char)115, (const char)0, (const char)105, (const char)103, (const char)110, (const char)98, (const char)114, (const char)107, (const char)0, (const char)98, (const char)114, (const char)107, (const char)105, (const char)110, (const char)116, (const char)0, (const char)105, (const char)103, (const char)110, (const char)112, (const char)97, (const char)114, (const char)0, (const char)112, (const char)97, (const char)114, (const char)109, (const char)114, (const char)107, (const char)0, (const char)105, (const char)110, (const char)112, (const char)99, (const char)107, (const char)0, (const char)105, (const char)115, (const char)116, (const char)114, (const char)105, (const char)112, (const char)0, (const char)105, (const char)110, (const char)108, (const char)99, (const char)114, (const char)0, (const char)105, (const char)103, (const char)110, (const char)99, (const char)114, (const char)0, (const char)105, (const char)99, (const char)114, (const char)110, (const char)108, (const char)0, (const char)105, (const char)120, (const char)111, (const char)110, (const char)0, (const char)105, (const char)120, (const char)111, (const char)102, (const char)102, (const char)0, (const char)116, (const char)97, (const char)110, (const char)100, (const char)101, (const char)109, (const char)0, (const char)105, (const char)117, (const char)99, (const char)108, (const char)99, (const char)0, (const char)105, (const char)120, (const char)97, (const char)110, (const char)121, (const char)0, (const char)105, (const char)109, (const char)97, (const char)120, (const char)98, (const char)101, (const char)108, (const char)0, (const char)105, (const char)117, (const char)116, (const char)102, (const char)56, (const char)0, (const char)111, (const char)112, (const char)111, (const char)115, (const char)116, (const char)0, (const char)111, (const char)108, (const char)99, (const char)117, (const char)99, (const char)0, (const char)111, (const char)99, (const char)114, (const char)110, (const char)108, (const char)0, (const char)111, (const char)110, (const char)108, (const char)99, (const char)114, (const char)0, (const char)111, (const char)110, (const char)111, (const char)99, (const char)114, (const char)0, (const char)111, (const char)110, (const char)108, (const char)114, (const char)101, (const char)116, (const char)0, (const char)111, (const char)102, (const char)105, (const char)108, (const char)108, (const char)0, (const char)111, (const char)102, (const char)100, (const char)101, (const char)108, (const char)0, (const char)110, (const char)108, (const char)49, (const char)0, (const char)110, (const char)108, (const char)48, (const char)0, (const char)99, (const char)114, (const char)51, (const char)0, (const char)99, (const char)114, (const char)50, (const char)0, (const char)99, (const char)114, (const char)49, (const char)0, (const char)99, (const char)114, (const char)48, (const char)0, (const char)116, (const char)97, (const char)98, (const char)51, (const char)0, (const char)116, (const char)97, (const char)98, (const char)50, (const char)0, (const char)116, (const char)97, (const char)98, (const char)49, (const char)0, (const char)116, (const char)97, (const char)98, (const char)48, (const char)0, (const char)98, (const char)115, (const char)49, (const char)0, (const char)98, (const char)115, (const char)48, (const char)0, (const char)118, (const char)116, (const char)49, (const char)0, (const char)118, (const char)116, (const char)48, (const char)0, (const char)102, (const char)102, (const char)49, (const char)0, (const char)102, (const char)102, (const char)48, (const char)0, (const char)105, (const char)115, (const char)105, (const char)103, (const char)0, (const char)105, (const char)99, (const char)97, (const char)110, (const char)111, (const char)110, (const char)0, (const char)105, (const char)101, (const char)120, (const char)116, (const char)101, (const char)110, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)101, (const char)0, (const char)99, (const char)114, (const char)116, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)107, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)110, (const char)108, (const char)0, (const char)110, (const char)111, (const char)102, (const char)108, (const char)115, (const char)104, (const char)0, (const char)120, (const char)99, (const char)97, (const char)115, (const char)101, (const char)0, (const char)116, (const char)111, (const char)115, (const char)116, (const char)111, (const char)112, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)112, (const char)114, (const char)116, (const char)0, (const char)112, (const char)114, (const char)116, (const char)101, (const char)114, (const char)97, (const char)115, (const char)101, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)99, (const char)116, (const char)108, (const char)0, (const char)99, (const char)116, (const char)108, (const char)101, (const char)99, (const char)104, (const char)111, (const char)0, (const char)101, (const char)99, (const char)104, (const char)111, (const char)107, (const char)101, (const char)0, (const char)99, (const char)114, (const char)116, (const char)107, (const char)105, (const char)108, (const char)108, (const char)0, (const char)0 };
+static const char *msg_eol = "\n";
+static struct speed_map speeds[21l] = { { .speed=(unsigned short int)0, .value=(unsigned short int)0 },
+    { .speed=(unsigned short int)1, .value=(unsigned short int)50 },
+    { .speed=(unsigned short int)2, .value=(unsigned short int)75 },
+    { .speed=(unsigned short int)3, .value=(unsigned short int)110 },
+    { .speed=(unsigned short int)4, .value=(unsigned short int)134 },
+    { .speed=(unsigned short int)5, .value=(unsigned short int)150 },
+    { .speed=(unsigned short int)6, .value=(unsigned short int)200 },
+    { .speed=(unsigned short int)7, .value=(unsigned short int)300 },
+    { .speed=(unsigned short int)8, .value=(unsigned short int)600 },
+    { .speed=(unsigned short int)9, .value=(unsigned short int)1200 },
+    { .speed=(unsigned short int)10, .value=(unsigned short int)1800 },
+    { .speed=(unsigned short int)11, .value=(unsigned short int)2400 },
+    { .speed=(unsigned short int)12, .value=(unsigned short int)4800 },
+    { .speed=(unsigned short int)13, .value=(unsigned short int)9600 },
+    { .speed=(unsigned short int)14, .value=(unsigned short int)19200 },
+    { .speed=(unsigned short int)15, .value=(unsigned short int)((unsigned int)(38400 / 256) + 32768u) },
+    { .speed=(unsigned short int)4097, .value=(unsigned short int)((unsigned int)(57600 / 256) + 32768u) },
+    { .speed=(unsigned short int)4098, .value=(unsigned short int)((unsigned int)(115200 / 256) + 32768u) },
+    { .speed=(unsigned short int)4099, .value=(unsigned short int)((unsigned int)(230400 / 256) + 32768u) },
+    { .speed=(unsigned short int)4100, .value=(unsigned short int)((unsigned int)(460800 / 256) + 32768u) },
+    { .speed=(unsigned short int)4103, .value=(unsigned short int)((unsigned int)(921600 / 256) + 32768u) } };
+static struct suffix_mult stty_suffixes[4l] = { { .suffix={ (char)98, (char)0, (char)0, (char)0 }, .mult=(unsigned int)512 },
+    { .suffix={ (char)107, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 },
+    { .suffix={ (char)66, (char)0, (char)0, (char)0 }, .mult=(unsigned int)1024 },
+    { .suffix={ (char)0, (char)0, (char)0, (char)0 }, .mult=(unsigned int)0 } };
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void display_recoverable(struct termios *mode, signed int dummy)
+{
+  signed int i;
+  printf("%lx:%lx:%lx:%lx", (unsigned long int)mode->c_iflag, (unsigned long int)mode->c_oflag, (unsigned long int)mode->c_cflag, (unsigned long int)mode->c_lflag);
+  i = 0;
+  for( ; i < 32; i = i + 1)
+  {
+    printf(":%x", (unsigned int)mode->c_cc[(signed long int)i]);
+  }
+  bb_putchar(10);
+}
+static void display_speed(struct termios *mode, signed int fancy)
+{
+  const char *fmt_str = "%lu %lu\n";
+  unsigned long int ispeed;
+  unsigned long int ospeed;
+  unsigned int return_value_cfgetispeed$1;
+  return_value_cfgetispeed$1=cfgetispeed(mode);
+  ispeed = (unsigned long int)return_value_cfgetispeed$1;
+  unsigned int return_value_cfgetospeed$2;
+  return_value_cfgetospeed$2=cfgetospeed(mode);
+  ospeed = (unsigned long int)return_value_cfgetospeed$2;
+  if(!(ispeed == 0ul))
+  {
+    if(ispeed == ospeed)
+      goto __CPROVER_DUMP_L1;
+  }
+  else
+  {
+  __CPROVER_DUMP_L1:
+    ;
+    ispeed = ospeed;
+    fmt_str = "%lu\n";
+  }
+  if(!(fancy == 0))
+    fmt_str = fmt_str + (signed long int)9;
+  unsigned int return_value_tty_baud_to_value$3;
+  return_value_tty_baud_to_value$3=tty_baud_to_value((unsigned int)ispeed);
+  unsigned int return_value_tty_baud_to_value$4;
+  return_value_tty_baud_to_value$4=tty_baud_to_value((unsigned int)ospeed);
+  wrapf(fmt_str, return_value_tty_baud_to_value$3, return_value_tty_baud_to_value$4);
+}
+static void display_window_size(signed int fancy)
+{
+  const char *fmt_str = "%s";
+  unsigned int width;
+  unsigned int height;
+  signed int return_value_get_terminal_width_height$2;
+  return_value_get_terminal_width_height$2=get_terminal_width_height(0, &width, &height);
+  _Bool tmp_if_expr$1;
+  if(!(return_value_get_terminal_width_height$2 == 0))
+  {
+    if(!(*bb_errno == 22))
+      tmp_if_expr$1 = 1 != 0;
+    else
+    {
+      fmt_str = fmt_str + (signed long int)2;
+      tmp_if_expr$1 = (!(fancy != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      perror_on_device(fmt_str);
+  }
+  else
+    wrapf(fancy != 0 ? "rows %u; columns %u;" : "%u %u\n", height, width);
+}
+static void do_display(struct termios *mode, signed int all)
+{
+  signed int i;
+  unsigned int *bitsp;
+  unsigned long int mask;
+  signed int prev_type = 0;
+  display_speed(mode, 1);
+  if(!(all == 0))
+    display_window_size(1);
+  wrapf("line = %u;\n", mode->c_line);
+  i = 0;
+  for( ; !(i == 15); i = i + 1)
+  {
+    char ch;
+    if(2l * (signed long int)i >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)i < 17l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    ch = mode->c_cc[(signed long int)control_info[(signed long int)i].offset];
+    if((signed int)ch == 0)
+      strcpy(((struct globals *)&bb_common_bufsiz1)->buf, "<undef>");
+    else
+      visible((unsigned int)ch, ((struct globals *)&bb_common_bufsiz1)->buf, 0);
+    const char *return_value_nth_string$1;
+    return_value_nth_string$1=nth_string(control_name, i);
+    wrapf("%s = %s;", return_value_nth_string$1, (const void *)((struct globals *)&bb_common_bufsiz1)->buf);
+  }
+  wrapf("min = %u; time = %u;", mode->c_cc[(signed long int)6], mode->c_cc[(signed long int)5]);
+  newline();
+  i = 0;
+  unsigned int tmp_if_expr$2;
+  _Bool tmp_if_expr$4;
+  const char *return_value_nth_string$3;
+  _Bool tmp_if_expr$6;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$7;
+  for( ; i < 86; i = i + 1)
+  {
+    if(8l * (signed long int)i >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)i < 86l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((8 & (signed int)mode_info[(signed long int)i].flags) == 0)
+    {
+      if(!((signed int)mode_info[(signed long int)i].type == prev_type))
+      {
+        newline();
+        if(8l * (signed long int)i >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        if((signed long int)i < 86l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        prev_type = (signed int)mode_info[(signed long int)i].type;
+      }
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      bitsp=get_ptr_to_tcflag((unsigned int)mode_info[(signed long int)i].type, mode);
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if(!((signed int)mode_info[(signed long int)i].mask == 0))
+        tmp_if_expr$2 = (unsigned int)mode_info[(signed long int)i].mask;
+      else
+      {
+        if(8l * (signed long int)i >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        if((signed long int)i < 86l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        tmp_if_expr$2 = mode_info[(signed long int)i].bits;
+      }
+      mask = (unsigned long int)tmp_if_expr$2;
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((mask & (unsigned long int)*bitsp) == (unsigned long int)mode_info[(signed long int)i].bits)
+      {
+        if(!(all == 0))
+          tmp_if_expr$4 = 1 != 0;
+        else
+        {
+          if(8l * (signed long int)i >= 0l)
+            (void)0;
+          else
+            __VERIFIER_error();
+          if((signed long int)i < 86l)
+            (void)0;
+          else
+            __VERIFIER_error();
+          tmp_if_expr$4 = (((signed int)mode_info[(signed long int)i].flags & 2) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$4 == (_Bool)0))
+        {
+          return_value_nth_string$3=nth_string(mode_name, i);
+          wrapf("-%s" + (signed long int)1, return_value_nth_string$3);
+        }
+      }
+      else
+      {
+        if(!(all == 0))
+        {
+          if(8l * (signed long int)i >= 0l)
+            (void)0;
+          else
+            __VERIFIER_error();
+          if((signed long int)i < 86l)
+            (void)0;
+          else
+            __VERIFIER_error();
+          tmp_if_expr$6 = (((signed int)mode_info[(signed long int)i].flags & 4) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$6 = 0 != 0;
+        if(!(tmp_if_expr$6 == (_Bool)0))
+          tmp_if_expr$8 = 1 != 0;
+        else
+        {
+          if(all == 0)
+          {
+            if(8l * (signed long int)i >= 0l)
+              (void)0;
+            else
+              __VERIFIER_error();
+            if((signed long int)i < 86l)
+              (void)0;
+            else
+              __VERIFIER_error();
+            tmp_if_expr$7 = (((signed int)mode_info[(signed long int)i].flags & (1 | 4)) == (1 | 4) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          else
+            tmp_if_expr$7 = 0 != 0;
+          tmp_if_expr$8 = (tmp_if_expr$7 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$8 == (_Bool)0))
+        {
+          const char *return_value_nth_string$5;
+          return_value_nth_string$5=nth_string(mode_name, i);
+          wrapf("-%s", return_value_nth_string$5);
+        }
+      }
+    }
+  }
+  newline();
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static struct control_info * find_control(const char *name)
+{
+  signed int i;
+  i=index_in_strings(control_name, name);
+  struct control_info *tmp_if_expr$1;
+  if(i >= 0)
+    tmp_if_expr$1 = &control_info[(signed long int)i];
+  else
+    tmp_if_expr$1 = (struct control_info *)((void *)0);
+  return tmp_if_expr$1;
+}
+static struct mode_info * find_mode(const char *name)
+{
+  signed int i;
+  i=index_in_strings(mode_name, name);
+  struct mode_info *tmp_if_expr$1;
+  if(i >= 0)
+    tmp_if_expr$1 = &mode_info[(signed long int)i];
+  else
+    tmp_if_expr$1 = (struct mode_info *)((void *)0);
+  return tmp_if_expr$1;
+}
+static signed int find_param(const char *name)
+{
+  signed int i;
+  signed int return_value_index_in_strings$1;
+  static const char params[49l] = { (const char)108, (const char)105, (const char)110, (const char)101, (const char)0, (const char)114, (const char)111, (const char)119, (const char)115, (const char)0, (const char)99, (const char)111, (const char)108, (const char)115, (const char)0, (const char)99, (const char)111, (const char)108, (const char)117, (const char)109, (const char)110, (const char)115, (const char)0, (const char)115, (const char)105, (const char)122, (const char)101, (const char)0, (const char)115, (const char)112, (const char)101, (const char)101, (const char)100, (const char)0, (const char)105, (const char)115, (const char)112, (const char)101, (const char)101, (const char)100, (const char)0, (const char)111, (const char)115, (const char)112, (const char)101, (const char)101, (const char)100, (const char)0, (const char)0 };
+  return_value_index_in_strings$1=index_in_strings(params, name);
+  i = return_value_index_in_strings$1 + 1;
+  if(i == 0)
+    return 0;
+  if(!(i == 5))
+  {
+    if(!(i == 6))
+      i = i | 128;
+  }
+  return i;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int * get_ptr_to_tcflag(unsigned int type, struct termios *mode)
+{
+  if(type <= 3u)
+  {
+    if((signed long int)type < 4l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    static const unsigned char tcflag_offsets[4l] = { (const unsigned char)8ul, (const unsigned char)0ul, (const unsigned char)4ul, (const unsigned char)12ul };
+    return (unsigned int *)((char *)mode + (signed long int)tcflag_offsets[(signed long int)type]);
+  }
+  return (unsigned int *)((void *)0);
+}
+static signed int get_terminal_width_height(signed int fd, unsigned int *width, unsigned int *height)
+{
+  struct winsize win;
+  signed int err;
+  win.ws_row = (unsigned short int)0;
+  win.ws_col = (unsigned short int)0;
+  signed int return_value_ioctl$1;
+  return_value_ioctl$1=ioctl(fd, (unsigned long int)21523, &win);
+  err = (signed int)(return_value_ioctl$1 != 0 ? (signed int)(1 != 0) : ((signed int)win.ws_row == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)));
+  signed int return_value_wh_helper$2;
+  if(!(height == ((unsigned int *)((void *)0))))
+  {
+    return_value_wh_helper$2=wh_helper((signed int)win.ws_row, 24, "LINES", &err);
+    *height = (unsigned int)return_value_wh_helper$2;
+  }
+  signed int return_value_wh_helper$3;
+  if(!(width == ((unsigned int *)((void *)0))))
+  {
+    return_value_wh_helper$3=wh_helper((signed int)win.ws_col, 80, "COLUMNS", &err);
+    *width = (unsigned int)return_value_wh_helper$3;
+  }
+  return err;
+}
+static signed int index_in_strings(const char *strings, const char *key)
+{
+  signed int idx = 0;
+  signed int tmp_statement_expression$1;
+  while(!((signed int)*strings == 0))
+  {
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    signed int return_value___builtin_strcmp$2;
+    return_value___builtin_strcmp$2=strcmp(strings, key);
+    tmp_statement_expression$1 = return_value___builtin_strcmp$2;
+    if(tmp_statement_expression$1 == 0)
+      return idx;
+    unsigned long int return_value_strlen$3;
+    return_value_strlen$3=strlen(strings);
+    strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+    idx = idx + 1;
+  }
+  return -1;
+}
+static void ndelay_off(signed int fd)
+{
+  signed int flags;
+  flags=fcntl(fd, 3);
+  if((2048 & flags) == 0)
+    return;
+  fcntl(fd, 4, flags & ~2048);
+}
+static void newline(void)
+{
+  if(!(((struct globals *)&bb_common_bufsiz1)->current_col == 0u))
+    wrapf("\n");
+}
+static const char * nth_string(const char *strings, signed int n)
+{
+  while(!(n == 0))
+  {
+    n = n - 1;
+    unsigned long int return_value_strlen$1;
+    return_value_strlen$1=strlen(strings);
+    strings = strings + (signed long int)(return_value_strlen$1 + (unsigned long int)1);
+  }
+  return strings;
+}
+static void perror_on_device(const char *fmt)
+{
+  bb_perror_msg(fmt, ((struct globals *)&bb_common_bufsiz1)->device_name);
+}
+static void perror_on_device_and_die(const char *fmt)
+{
+  bb_perror_msg_and_die(fmt, ((struct globals *)&bb_common_bufsiz1)->device_name);
+}
+static signed int recover_mode(const char *arg, struct termios *mode)
+{
+  signed int i;
+  signed int n;
+  unsigned int chr;
+  unsigned long int iflag;
+  unsigned long int oflag;
+  unsigned long int cflag;
+  unsigned long int lflag;
+  signed int return_value_sscanf$1;
+  return_value_sscanf$1=sscanf(arg, "%lx:%lx:%lx:%lx%n", &iflag, &oflag, &cflag, &lflag, &n);
+  if(!(return_value_sscanf$1 == 4))
+    return 0;
+  mode->c_iflag = (unsigned int)iflag;
+  mode->c_oflag = (unsigned int)oflag;
+  mode->c_cflag = (unsigned int)cflag;
+  mode->c_lflag = (unsigned int)lflag;
+  arg = arg + (signed long int)n;
+  i = 0;
+  for( ; i < 32; i = i + 1)
+  {
+    signed int return_value_sscanf$2;
+    return_value_sscanf$2=sscanf(arg, ":%x%n", &chr, &n);
+    if(!(return_value_sscanf$2 == 1))
+      return 0;
+    mode->c_cc[(signed long int)i] = (unsigned char)chr;
+    arg = arg + (signed long int)n;
+  }
+  if(!((signed int)*arg == 0))
+    return 0;
+  return 1;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void sane_mode(struct termios *mode)
+{
+  signed int i = 0;
+  for( ; i < 17; i = i + 1)
+  {
+    if(2l * (signed long int)i >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)i < 17l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    mode->c_cc[(signed long int)control_info[(signed long int)i].offset] = control_info[(signed long int)i].saneval;
+  }
+  i = 0;
+  for( ; i < 86; i = i + 1)
+  {
+    unsigned int val;
+    unsigned int *bitsp;
+    if(8l * (signed long int)i >= 0l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    if((signed long int)i < 86l)
+      (void)0;
+    else
+      __VERIFIER_error();
+    bitsp=get_ptr_to_tcflag((unsigned int)mode_info[(signed long int)i].type, mode);
+    if(!(bitsp == ((unsigned int *)((void *)0))))
+    {
+      if(8l * (signed long int)i >= 0l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      if((signed long int)i < 86l)
+        (void)0;
+      else
+        __VERIFIER_error();
+      val = (unsigned int)((unsigned long int)*bitsp & ~((unsigned long int)mode_info[(signed long int)i].mask));
+      if(!((1 & (signed int)mode_info[(signed long int)i].flags) == 0))
+        *bitsp = val | mode_info[(signed long int)i].bits;
+      else
+      {
+        if(8l * (signed long int)i >= 0l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        if((signed long int)i < 86l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        if(!((2 & (signed int)mode_info[(signed long int)i].flags) == 0))
+        {
+          *bitsp = val & ~mode_info[(signed long int)i].bits;
+        }
+      }
+    }
+  }
+}
+static void set_control_char_or_die(struct control_info *info, const char *arg, struct termios *mode)
+{
+  unsigned char value;
+  _Bool tmp_if_expr$15;
+  if(info == control_info + 15l)
+    tmp_if_expr$15 = 1 != 0;
+  else
+    tmp_if_expr$15 = (info == &control_info[(signed long int)16] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  unsigned long int return_value_xatoul_range_sfx$1;
+  _Bool tmp_if_expr$14;
+  signed int tmp_statement_expression$3;
+  _Bool tmp_if_expr$4;
+  signed int tmp_if_expr$7;
+  signed int tmp_statement_expression$5;
+  signed int return_value___builtin_strcmp$6;
+  _Bool tmp_if_expr$13;
+  signed int tmp_statement_expression$8;
+  _Bool tmp_if_expr$9;
+  signed int tmp_if_expr$12;
+  signed int tmp_statement_expression$10;
+  signed int return_value___builtin_strcmp$11;
+  unsigned long int return_value_xatoul_range_sfx$2;
+  if(!(tmp_if_expr$15 == (_Bool)0))
+  {
+    return_value_xatoul_range_sfx$1=xatoul_range_sfx(arg, (unsigned long int)0, (unsigned long int)255, stty_suffixes);
+    value = (unsigned char)return_value_xatoul_range_sfx$1;
+  }
+  else
+  {
+    if((signed int)*arg == 0)
+      tmp_if_expr$14 = 1 != 0;
+    else
+    {
+      tmp_if_expr$14 = ((signed int)arg[(signed long int)1] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$14 == (_Bool)0))
+    {
+      value = arg[(signed long int)0];
+    }
+    else
+    {
+      unsigned long int __s1_len;
+      unsigned long int set_control_char_or_die$$1$$1$$__s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("^-" + 1l) + -((unsigned long int)"^-") == 1ul))
+          goto __CPROVER_DUMP_L13;
+        set_control_char_or_die$$1$$1$$__s2_len=strlen("^-");
+        tmp_if_expr$4 = (set_control_char_or_die$$1$$1$$__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      else
+      {
+      __CPROVER_DUMP_L13:
+        ;
+        tmp_if_expr$4 = 0 != 0;
+      }
+      if(!(tmp_if_expr$4 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)arg;
+        signed int __result;
+        __result = (signed int)((const char *)"^-")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(set_control_char_or_die$$1$$1$$__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+            __result = (signed int)((const char *)"^-")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(set_control_char_or_die$$1$$1$$__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"^-")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(set_control_char_or_die$$1$$1$$__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+                    __VERIFIER_error();
+                    __result = (signed int)((const char *)"^-")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+                }
+              }
+            }
+          }
+        }
+        tmp_statement_expression$5 = __result;
+        tmp_if_expr$7 = -tmp_statement_expression$5;
+      }
+      else
+      {
+        return_value___builtin_strcmp$6=strcmp(arg, "^-");
+        tmp_if_expr$7 = return_value___builtin_strcmp$6;
+      }
+      tmp_statement_expression$3 = tmp_if_expr$7;
+      if(tmp_statement_expression$3 == 0)
+        tmp_if_expr$13 = 1 != 0;
+      else
+      {
+        unsigned long int set_control_char_or_die$$1$$2$$__s1_len;
+        unsigned long int __s2_len;
+        if((_Bool)1)
+        {
+          if(!((unsigned long int)("undef" + 1l) + -((unsigned long int)"undef") == 1ul))
+            goto __CPROVER_DUMP_L35;
+          __s2_len=strlen("undef");
+          tmp_if_expr$9 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+        {
+        __CPROVER_DUMP_L35:
+          ;
+          tmp_if_expr$9 = 0 != 0;
+        }
+        if(!(tmp_if_expr$9 == (_Bool)0))
+        {
+          const unsigned char *set_control_char_or_die$$1$$2$$2$$__s2 = (const char *)arg;
+          signed int set_control_char_or_die$$1$$2$$2$$__result;
+          set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)0] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)0];
+          if(__s2_len > 0ul)
+          {
+            if(set_control_char_or_die$$1$$2$$2$$__result == 0)
+            {
+              set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)1] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)1];
+              if(__s2_len > 1ul)
+              {
+                if(set_control_char_or_die$$1$$2$$2$$__result == 0)
+                {
+                  set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)2] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)2];
+                  if(__s2_len > 2ul)
+                  {
+                    if(set_control_char_or_die$$1$$2$$2$$__result == 0)
+                    {
+                      set_control_char_or_die$$1$$2$$2$$__result = (signed int)((const char *)"undef")[(signed long int)3] - (signed int)set_control_char_or_die$$1$$2$$2$$__s2[(signed long int)3];
+                    }
+                  }
+                }
+              }
+            }
+          }
+          tmp_statement_expression$10 = set_control_char_or_die$$1$$2$$2$$__result;
+          tmp_if_expr$12 = -tmp_statement_expression$10;
+        }
+        else
+        {
+          return_value___builtin_strcmp$11=strcmp(arg, "undef");
+          tmp_if_expr$12 = return_value___builtin_strcmp$11;
+        }
+        tmp_statement_expression$8 = tmp_if_expr$12;
+        tmp_if_expr$13 = (tmp_statement_expression$8 == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$13 == (_Bool)0))
+        value = (unsigned char)0;
+      else
+      {
+        if((signed int)*arg == 94)
+        {
+          value = (unsigned char)((signed int)arg[(signed long int)1] & 31);
+          if((signed int)*(1l + arg) == 63)
+            value = (unsigned char)127;
+        }
+        else
+        {
+          return_value_xatoul_range_sfx$2=xatoul_range_sfx(arg, (unsigned long int)0, (unsigned long int)255, stty_suffixes);
+          value = (unsigned char)return_value_xatoul_range_sfx$2;
+        }
+      }
+    }
+  }
+  mode->c_cc[(signed long int)info->offset] = value;
+}
+static void set_mode(struct mode_info *info, signed int reversed, struct termios *mode)
+{
+  unsigned int *bitsp;
+  bitsp=get_ptr_to_tcflag((unsigned int)info->type, mode);
+  if(!(bitsp == ((unsigned int *)((void *)0))))
+  {
+    unsigned int val;
+    val = *bitsp & (unsigned int)~((signed int)info->mask);
+    if(!(reversed == 0))
+      *bitsp = val & ~info->bits;
+    else
+    {
+      *bitsp = val | info->bits;
+    }
+    return;
+  }
+  _Bool tmp_if_expr$4;
+  if(info == mode_info)
+    tmp_if_expr$4 = 1 != 0;
+  else
+    tmp_if_expr$4 = (info == &mode_info[(signed long int)1] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$2;
+  if(!(tmp_if_expr$4 == (_Bool)0))
+  {
+    if(!(reversed == 0))
+    {
+      mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+    }
+    else
+    {
+      mode->c_cflag = mode->c_cflag & (unsigned int)~512 & (unsigned int)~48 | (unsigned int)256 | (unsigned int)32;
+    }
+  }
+  else
+    if(info == mode_info + 2l)
+    {
+      if(!(reversed == 0))
+      {
+        mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+      }
+      else
+      {
+        mode->c_cflag = mode->c_cflag & (unsigned int)~48 | (unsigned int)32 | (unsigned int)512 | (unsigned int)256;
+      }
+    }
+    else
+      if(info == mode_info + 3l)
+      {
+        if(!(reversed == 0))
+        {
+          mode->c_iflag = (mode->c_iflag | (unsigned int)256) & (unsigned int)~64 & (unsigned int)~128;
+          mode->c_oflag = (mode->c_oflag | (unsigned int)4) & (unsigned int)~8 & (unsigned int)~32;
+        }
+        else
+        {
+          mode->c_iflag = mode->c_iflag & (unsigned int)~256;
+          mode->c_oflag = mode->c_oflag & (unsigned int)~4;
+        }
+      }
+      else
+        if(info == mode_info + 4l)
+        {
+          mode->c_cc[(signed long int)2] = (unsigned char)127;
+          mode->c_cc[(signed long int)3] = (unsigned char)(117 & 31);
+        }
+        else
+          if(info == mode_info + 5l)
+            sane_mode(mode);
+          else
+            if(info == mode_info + 10l)
+            {
+              if(!(reversed == 0))
+              {
+                mode->c_lflag = mode->c_lflag | (unsigned int)2;
+              }
+              else
+              {
+                mode->c_lflag = mode->c_lflag & (unsigned int)~2;
+              }
+            }
+            else
+              if(info == mode_info + 8l)
+              {
+                if(!(reversed == 0))
+                {
+                  mode->c_cflag = mode->c_cflag & (unsigned int)~48 | (unsigned int)32 | (unsigned int)256;
+                  mode->c_iflag = mode->c_iflag | (unsigned int)32;
+                }
+                else
+                {
+                  mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+                  mode->c_iflag = mode->c_iflag & (unsigned int)~32;
+                }
+              }
+              else
+                if(info == mode_info + 9l)
+                {
+                  if(!(reversed == 0))
+                  {
+                    mode->c_cflag = mode->c_cflag & (unsigned int)~48 | (unsigned int)32 | (unsigned int)256;
+                    mode->c_iflag = mode->c_iflag | (unsigned int)32;
+                    mode->c_oflag = mode->c_oflag | (unsigned int)1;
+                  }
+                  else
+                  {
+                    mode->c_cflag = mode->c_cflag & (unsigned int)~256 & (unsigned int)~48 | (unsigned int)48;
+                    mode->c_iflag = mode->c_iflag & (unsigned int)~32;
+                    mode->c_oflag = mode->c_oflag & (unsigned int)~1;
+                  }
+                }
+                else
+                {
+                  if(info == mode_info + 7l)
+                    tmp_if_expr$3 = 1 != 0;
+                  else
+                    tmp_if_expr$3 = (info == &mode_info[(signed long int)6] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(!(tmp_if_expr$3 == (_Bool)0))
+                  {
+                    if(info == mode_info + 7l && !(reversed == 0))
+                      tmp_if_expr$1 = 1 != 0;
+                    else
+                      tmp_if_expr$1 = ((info == &mode_info[(signed long int)6] ? (!(reversed != 0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) : (signed int)(0 != 0)) != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    if(!(tmp_if_expr$1 == (_Bool)0))
+                    {
+                      mode->c_iflag = mode->c_iflag | (unsigned int)(2 | 4 | 32 | 256 | 1024);
+                      mode->c_oflag = mode->c_oflag | (unsigned int)1;
+                      mode->c_lflag = mode->c_lflag | (unsigned int)(1 | 2);
+                    }
+                    else
+                    {
+                      mode->c_iflag = (unsigned int)0;
+                      mode->c_oflag = mode->c_oflag & (unsigned int)~1;
+                      mode->c_lflag = mode->c_lflag & (unsigned int)~(1 | 2 | 4);
+                      mode->c_cc[(signed long int)6] = (unsigned char)1;
+                      mode->c_cc[(signed long int)5] = (unsigned char)0;
+                    }
+                  }
+                  else
+                    if(info == mode_info + 13l)
+                    {
+                      if(!(reversed == 0))
+                      {
+                        mode->c_iflag = mode->c_iflag | (unsigned int)2048;
+                      }
+                      else
+                      {
+                        mode->c_iflag = mode->c_iflag & (unsigned int)~2048;
+                      }
+                    }
+                    else
+                      if(info == mode_info + 14l)
+                      {
+                        if(!(reversed == 0))
+                        {
+                          mode->c_oflag = mode->c_oflag & (unsigned int)~6144 | (unsigned int)6144;
+                        }
+                        else
+                        {
+                          mode->c_oflag = mode->c_oflag & (unsigned int)~6144 | (unsigned int)0;
+                        }
+                      }
+                      else
+                      {
+                        if(info == mode_info + 15l)
+                          tmp_if_expr$2 = 1 != 0;
+                        else
+                          tmp_if_expr$2 = (info == &mode_info[(signed long int)16] ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                        if(!(tmp_if_expr$2 == (_Bool)0))
+                        {
+                          if(!(reversed == 0))
+                          {
+                            mode->c_lflag = mode->c_lflag & (unsigned int)~4;
+                            mode->c_iflag = mode->c_iflag & (unsigned int)~512;
+                            mode->c_oflag = mode->c_oflag & (unsigned int)~2;
+                          }
+                          else
+                          {
+                            mode->c_lflag = mode->c_lflag | (unsigned int)4;
+                            mode->c_iflag = mode->c_iflag | (unsigned int)512;
+                            mode->c_oflag = mode->c_oflag | (unsigned int)2;
+                          }
+                        }
+                        else
+                          if(info == mode_info + 11l)
+                          {
+                            mode->c_lflag = mode->c_lflag | (unsigned int)(16 | 512 | 2048);
+                          }
+                          else
+                            if(info == mode_info + 12l)
+                            {
+                              mode->c_cc[(signed long int)0] = (unsigned char)3;
+                              mode->c_cc[(signed long int)2] = (unsigned char)127;
+                              mode->c_cc[(signed long int)3] = (unsigned char)21;
+                              mode->c_lflag = mode->c_lflag | (unsigned int)(16 | 512 | 2048);
+                              mode->c_iflag = mode->c_iflag & (unsigned int)~2048;
+                            }
+                      }
+                }
+}
+static void set_speed_or_die(signed int type, const char *arg, struct termios *mode)
+{
+  unsigned int baud;
+  unsigned int return_value_xatou$1;
+  return_value_xatou$1=xatou(arg);
+  baud=tty_value_to_baud(return_value_xatou$1);
+  if(!(type == 1))
+    cfsetispeed(mode, baud);
+  if(!(type == 0))
+    cfsetospeed(mode, baud);
+}
+static void set_window_size(signed int rows, signed int cols)
+{
+  struct winsize win = { .ws_row=(unsigned short int)0, .ws_col=(unsigned short int)0, .ws_xpixel=(unsigned short int)0,
+    .ws_ypixel=(unsigned short int)0 };
+  signed int return_value_ioctl$1;
+  return_value_ioctl$1=ioctl(0, (unsigned long int)21523, &win);
+  if(!(return_value_ioctl$1 == 0))
+  {
+    if(*bb_errno != 22)
+      goto bail;
+    memset((void *)&win, 0, sizeof(struct winsize) );
+  }
+  if(rows >= 0)
+    win.ws_row = (unsigned short int)rows;
+  if(cols >= 0)
+    win.ws_col = (unsigned short int)cols;
+  signed int return_value_ioctl$2;
+  return_value_ioctl$2=ioctl(0, (unsigned long int)21524, (char *)&win);
+  if(!(return_value_ioctl$2 == 0))
+  {
+  bail:
+    ;
+    perror_on_device("%s");
+  }
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct termios mode;
+  void (*output_func)(struct termios *, signed int);
+  const char *file_name = (const char *)((void *)0);
+  signed int display_all = 0;
+  signed int stty_state;
+  signed int k;
+  do
+  {
+    ((struct globals *)&bb_common_bufsiz1)->device_name = bb_msg_standard_input;
+    ((struct globals *)&bb_common_bufsiz1)->max_col = (unsigned int)80;
+  }
+  while((_Bool)0);
+  stty_state = 1 << 4;
+  output_func = do_display;
+  k = 0;
+  do
+  {
+    k = k + 1;
+    if(argv[(signed long int)k] == ((char *)((void *)0)))
+      break;
+    struct mode_info *mp;
+    struct control_info *stty_main$$1$$2$$cp;
+    const char *stty_main$$1$$2$$arg = argv[(signed long int)k];
+    const char *stty_main$$1$$2$$argnext;
+    stty_main$$1$$2$$argnext = argv[(signed long int)(k + 1)];
+    signed int stty_main$$1$$2$$param;
+    if((signed int)*stty_main$$1$$2$$arg == 45)
+    {
+      signed int i;
+      mp=find_mode(stty_main$$1$$2$$arg + (signed long int)1);
+      if(!(mp == ((struct mode_info *)((void *)0))))
+      {
+        if((4 & (signed int)mp->flags) == 0)
+          goto invalid_argument;
+        stty_state = stty_state & ~(1 << 4);
+        continue;
+      }
+      i = 0;
+      do
+      {
+        i = i + 1;
+        if((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 0)
+          break;
+        if(!((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 97))
+        {
+          if((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 103)
+            goto __CPROVER_DUMP_L16;
+          if((signed int)stty_main$$1$$2$$arg[(signed long int)i] == 70)
+            goto __CPROVER_DUMP_L17;
+        }
+        else
+        {
+          stty_state = stty_state | 1 << 2;
+          output_func = do_display;
+          display_all = 1;
+          continue;
+        __CPROVER_DUMP_L16:
+          ;
+          stty_state = stty_state | 1 << 3;
+          output_func = display_recoverable;
+          continue;
+        __CPROVER_DUMP_L17:
+          ;
+          if(!(file_name == ((const char *)((void *)0))))
+            bb_error_msg_and_die("only one device may be specified");
+          file_name = &stty_main$$1$$2$$arg[(signed long int)(i + 1)];
+          if((signed int)*file_name == 0)
+          {
+            signed int p = k + 1;
+            file_name = stty_main$$1$$2$$argnext;
+            if(file_name == ((const char *)((void *)0)))
+              bb_error_msg_and_die(bb_msg_requires_arg, (const void *)"-F");
+            while((_Bool)1)
+            {
+              if(argv[(signed long int)p] == ((char *)((void *)0)))
+                break;
+              argv[(signed long int)p] = argv[(signed long int)(p + 1)];
+              p = p + 1;
+            }
+          }
+          break;
+        }
+        goto invalid_argument;
+      }
+      while((_Bool)1);
+    end_option:
+      ;
+      continue;
+    }
+    mp=find_mode(stty_main$$1$$2$$arg);
+    if(!(mp == ((struct mode_info *)((void *)0))))
+      stty_state = stty_state & ~(1 << 4);
+    else
+    {
+      stty_main$$1$$2$$cp=find_control(stty_main$$1$$2$$arg);
+      if(!(stty_main$$1$$2$$cp == ((struct control_info *)((void *)0))))
+      {
+        if(stty_main$$1$$2$$argnext == ((const char *)((void *)0)))
+          bb_error_msg_and_die(bb_msg_requires_arg, stty_main$$1$$2$$arg);
+        set_control_char_or_die(stty_main$$1$$2$$cp, stty_main$$1$$2$$argnext, &mode);
+        stty_state = stty_state & ~(1 << 4);
+        k = k + 1;
+      }
+      else
+      {
+        stty_main$$1$$2$$param=find_param(stty_main$$1$$2$$arg);
+        if(!((128 & stty_main$$1$$2$$param) == 0))
+        {
+          if(stty_main$$1$$2$$argnext == ((const char *)((void *)0)))
+            bb_error_msg_and_die(bb_msg_requires_arg, stty_main$$1$$2$$arg);
+          k = k + 1;
+        }
+        if(!(stty_main$$1$$2$$param == 129))
+        {
+          if(stty_main$$1$$2$$param == 130)
+            goto __CPROVER_DUMP_L37;
+          if(stty_main$$1$$2$$param == 131)
+            goto __CPROVER_DUMP_L37;
+          if(stty_main$$1$$2$$param == 132)
+            goto __CPROVER_DUMP_L37;
+          if(stty_main$$1$$2$$param == 5 || stty_main$$1$$2$$param == 6)
+            goto __CPROVER_DUMP_L38;
+          if(stty_main$$1$$2$$param == 135)
+            goto __CPROVER_DUMP_L39;
+          if(stty_main$$1$$2$$param == 136)
+            goto __CPROVER_DUMP_L40;
+        }
+        else
+        {
+        __CPROVER_DUMP_L37:
+          ;
+          xatoul_range_sfx(stty_main$$1$$2$$argnext, (unsigned long int)1, (unsigned long int)2147483647, stty_suffixes);
+          goto __CPROVER_DUMP_L44;
+        __CPROVER_DUMP_L38:
+          ;
+          goto __CPROVER_DUMP_L44;
+        __CPROVER_DUMP_L39:
+          ;
+          set_speed_or_die((signed int)0, stty_main$$1$$2$$argnext, &mode);
+          goto __CPROVER_DUMP_L44;
+        __CPROVER_DUMP_L40:
+          ;
+          set_speed_or_die((signed int)1, stty_main$$1$$2$$argnext, &mode);
+          goto __CPROVER_DUMP_L44;
+        }
+        signed int return_value_recover_mode$1;
+        return_value_recover_mode$1=recover_mode(stty_main$$1$$2$$arg, &mode);
+        if(!(return_value_recover_mode$1 == 1))
+        {
+          unsigned int return_value_xatou$2;
+          return_value_xatou$2=xatou(stty_main$$1$$2$$arg);
+          unsigned int return_value_tty_value_to_baud$3;
+          return_value_tty_value_to_baud$3=tty_value_to_baud(return_value_xatou$2);
+          if(return_value_tty_value_to_baud$3 == 4294967295u)
+          {
+          invalid_argument:
+            ;
+            bb_error_msg_and_die("invalid argument '%s'", stty_main$$1$$2$$arg);
+          }
+        }
+      __CPROVER_DUMP_L44:
+        ;
+        stty_state = stty_state & ~(1 << 4);
+      }
+    }
+  }
+  while((_Bool)1);
+  if((12 & stty_state) == 12)
+    bb_error_msg_and_die("-a and -g are mutually exclusive");
+  if(!((12 & stty_state) == 0))
+  {
+    if((16 & stty_state) == 0)
+      bb_error_msg_and_die("modes may not be set when -a or -g is used");
+  }
+  if(!(file_name == ((const char *)((void *)0))))
+  {
+    ((struct globals *)&bb_common_bufsiz1)->device_name = file_name;
+    signed int return_value_xopen_nonblocking$4;
+    return_value_xopen_nonblocking$4=xopen_nonblocking(((struct globals *)&bb_common_bufsiz1)->device_name);
+    xmove_fd(return_value_xopen_nonblocking$4, 0);
+    ndelay_off(0);
+  }
+  memset((void *)&mode, 0, sizeof(struct termios) );
+  signed int return_value_tcgetattr$5;
+  return_value_tcgetattr$5=tcgetattr(0, &mode);
+  if(!(return_value_tcgetattr$5 == 0))
+    perror_on_device_and_die("%s");
+  if(!((28 & stty_state) == 0))
+  {
+    get_terminal_width_height(1, &((struct globals *)&bb_common_bufsiz1)->max_col, (unsigned int *)((void *)0));
+    output_func(&mode, display_all);
+    return 0;
+  }
+  k = 0;
+  unsigned long int return_value_xatoul_sfx$6;
+  unsigned long int return_value_xatoul_sfx$7;
+  unsigned long int return_value_xatoul_sfx$8;
+  do
+  {
+    k = k + 1;
+    if(argv[(signed long int)k] == ((char *)((void *)0)))
+      break;
+    struct mode_info *stty_main$$1$$7$$mp;
+    struct control_info *cp;
+    const char *arg = argv[(signed long int)k];
+    const char *argnext;
+    argnext = argv[(signed long int)(k + 1)];
+    signed int param;
+    if((signed int)*arg == 45)
+    {
+      stty_main$$1$$7$$mp=find_mode(arg + (signed long int)1);
+      if(!(stty_main$$1$$7$$mp == ((struct mode_info *)((void *)0))))
+      {
+        set_mode(stty_main$$1$$7$$mp, 1, &mode);
+        stty_state = stty_state | 1 << 0;
+      }
+    }
+    else
+    {
+      stty_main$$1$$7$$mp=find_mode(arg);
+      if(!(stty_main$$1$$7$$mp == ((struct mode_info *)((void *)0))))
+      {
+        set_mode(stty_main$$1$$7$$mp, 0, &mode);
+        stty_state = stty_state | 1 << 0;
+      }
+      else
+      {
+        cp=find_control(arg);
+        if(!(cp == ((struct control_info *)((void *)0))))
+        {
+          k = k + 1;
+          set_control_char_or_die(cp, argnext, &mode);
+          stty_state = stty_state | 1 << 0;
+        }
+        else
+        {
+          param=find_param(arg);
+          if(!((128 & param) == 0))
+            k = k + 1;
+          if(!(param == 129))
+          {
+            if(param == 131 || param == 132)
+              goto __CPROVER_DUMP_L66;
+            if(param == 5)
+              goto __CPROVER_DUMP_L67;
+            if(param == 130)
+              goto __CPROVER_DUMP_L68;
+            if(param == 6)
+              goto __CPROVER_DUMP_L69;
+            if(param == 135)
+              goto __CPROVER_DUMP_L70;
+            if(param == 136)
+              goto __CPROVER_DUMP_L71;
+          }
+          else
+          {
+            return_value_xatoul_sfx$6=xatoul_sfx(argnext, stty_suffixes);
+            mode.c_line = (unsigned char)return_value_xatoul_sfx$6;
+            stty_state = stty_state | 1 << 0;
+            goto __CPROVER_DUMP_L75;
+          __CPROVER_DUMP_L66:
+            ;
+            return_value_xatoul_sfx$7=xatoul_sfx(argnext, stty_suffixes);
+            set_window_size(-1, (signed int)return_value_xatoul_sfx$7);
+            goto __CPROVER_DUMP_L75;
+          __CPROVER_DUMP_L67:
+            ;
+            display_window_size(0);
+            goto __CPROVER_DUMP_L75;
+          __CPROVER_DUMP_L68:
+            ;
+            return_value_xatoul_sfx$8=xatoul_sfx(argnext, stty_suffixes);
+            set_window_size((signed int)return_value_xatoul_sfx$8, -1);
+            goto __CPROVER_DUMP_L75;
+          __CPROVER_DUMP_L69:
+            ;
+            display_speed(&mode, 0);
+            goto __CPROVER_DUMP_L75;
+          __CPROVER_DUMP_L70:
+            ;
+            set_speed_or_die((signed int)0, argnext, &mode);
+            stty_state = stty_state | 1 << 0 | 1 << 1;
+            goto __CPROVER_DUMP_L75;
+          __CPROVER_DUMP_L71:
+            ;
+            set_speed_or_die((signed int)1, argnext, &mode);
+            stty_state = stty_state | 1 << 0 | 1 << 1;
+            goto __CPROVER_DUMP_L75;
+          }
+          signed int return_value_recover_mode$9;
+          return_value_recover_mode$9=recover_mode(arg, &mode);
+          if(return_value_recover_mode$9 == 1)
+            stty_state = stty_state | 1 << 0;
+          else
+          {
+            set_speed_or_die((signed int)2, arg, &mode);
+            stty_state = stty_state | 1 << 0 | 1 << 1;
+          }
+        }
+      }
+    }
+  __CPROVER_DUMP_L75:
+    ;
+  }
+  while((_Bool)1);
+  if(!((1 & stty_state) == 0))
+  {
+    struct termios new_mode;
+    signed int return_value_tcsetattr$10;
+    return_value_tcsetattr$10=tcsetattr(0, 1, &mode);
+    if(!(return_value_tcsetattr$10 == 0))
+      perror_on_device_and_die("%s");
+    memset((void *)&new_mode, 0, sizeof(struct termios) );
+    signed int return_value_tcgetattr$11;
+    return_value_tcgetattr$11=tcgetattr(0, &new_mode);
+    if(!(return_value_tcgetattr$11 == 0))
+      perror_on_device_and_die("%s");
+    signed int return_value_memcmp$12;
+    return_value_memcmp$12=memcmp((const void *)&mode, (const void *)&new_mode, sizeof(struct termios) );
+    if(!(return_value_memcmp$12 == 0))
+      perror_on_device_and_die("%s: cannot perform all requested operations");
+  }
+  return 0;
+}
+static unsigned int tty_baud_to_value(unsigned int speed)
+{
+  signed int i = 0;
+  while((_Bool)1)
+  {
+    if(speed == (unsigned int)speeds[(signed long int)i].speed)
+    {
+      if(!((32768u & (unsigned int)speeds[(signed long int)i].value) == 0u))
+        return (unsigned int)(((unsigned long int)speeds[(signed long int)i].value & (unsigned long int)32767u) * (unsigned long int)256);
+      return (unsigned int)speeds[(signed long int)i].value;
+    }
+    i = i + 1;
+    if(!(i < 21))
+      break;
+  }
+  return (unsigned int)0;
+}
+static unsigned int tty_value_to_baud(unsigned int value)
+{
+  signed int i = 0;
+  do
+  {
+    unsigned int return_value_tty_baud_to_value$1;
+    return_value_tty_baud_to_value$1=tty_baud_to_value((unsigned int)speeds[(signed long int)i].speed);
+    if(value == return_value_tty_baud_to_value$1)
+      return (unsigned int)speeds[(signed long int)i].speed;
+    i = i + 1;
+  }
+  while(i < 21);
+  return (unsigned int)-1;
+}
+static void visible(unsigned int ch, char *buf, signed int flags)
+{
+  char *tmp_post$1;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  char *tmp_post$4;
+  if((2 & flags) == 0)
+  {
+    if(!(ch == 9u))
+      goto __CPROVER_DUMP_L1;
+  }
+  else
+  {
+  __CPROVER_DUMP_L1:
+    ;
+    if(ch == 10u)
+    {
+      if(!((1 & flags) == 0))
+      {
+        tmp_post$1 = buf;
+        buf = buf + 1l;
+        *tmp_post$1 = (char)36;
+      }
+    }
+    else
+    {
+      if(ch >= 128u)
+      {
+        ch = ch - (unsigned int)128;
+        tmp_post$2 = buf;
+        buf = buf + 1l;
+        *tmp_post$2 = (char)77;
+        tmp_post$3 = buf;
+        buf = buf + 1l;
+        *tmp_post$3 = (char)45;
+      }
+      if(!(ch < 32u))
+      {
+        if(ch == 127u)
+          goto __CPROVER_DUMP_L5;
+      }
+      else
+      {
+      __CPROVER_DUMP_L5:
+        ;
+        tmp_post$4 = buf;
+        buf = buf + 1l;
+        *tmp_post$4 = (char)94;
+        ch = ch ^ (unsigned int)64;
+      }
+    }
+  }
+raw:
+  ;
+  char *tmp_post$5 = buf;
+  buf = buf + 1l;
+  *tmp_post$5 = (char)ch;
+  *buf = (char)0;
+}
+static signed int wh_helper(signed int value, signed int def_val, const char *env_name, signed int *err)
+{
+  if(value == 0)
+  {
+    char *s;
+    s=getenv(env_name);
+    if(!(s == ((char *)((void *)0))))
+    {
+      value=atoi(s);
+      *err = 0;
+    }
+  }
+  if(!(value <= 1))
+  {
+    if(value >= 30000)
+      goto __CPROVER_DUMP_L3;
+  }
+  else
+  {
+  __CPROVER_DUMP_L3:
+    ;
+    value = def_val;
+  }
+  return value;
+}
+static void wrapf(const char *message, ...)
+{
+  char buf[128l];
+  va_list args;
+  unsigned int buflen;
+  __builtin_va_start(args,message);
+  signed int return_value_vsnprintf$1;
+  return_value_vsnprintf$1=vsnprintf(buf, sizeof(char [128l]) , message, args);
+  buflen = (unsigned int)return_value_vsnprintf$1;
+  __builtin_va_end(args);
+  if(!(buflen == 0u))
+  {
+    if((unsigned long int)buflen >= sizeof(char [128l]) )
+      goto __CPROVER_DUMP_L1;
+  }
+  else
+  {
+  __CPROVER_DUMP_L1:
+    ;
+    return;
+  }
+  if(((struct globals *)&bb_common_bufsiz1)->current_col > 0u)
+  {
+    ((struct globals *)&bb_common_bufsiz1)->current_col = ((struct globals *)&bb_common_bufsiz1)->current_col + 1u;
+    if(!((signed int)buf[0l] == 10))
+    {
+      if(((struct globals *)&bb_common_bufsiz1)->current_col + buflen >= ((struct globals *)&bb_common_bufsiz1)->max_col)
+      {
+        bb_putchar(10);
+        ((struct globals *)&bb_common_bufsiz1)->current_col = (unsigned int)0;
+      }
+      else
+        bb_putchar(32);
+    }
+  }
+  fputs(buf, stdout);
+  ((struct globals *)&bb_common_bufsiz1)->current_col = ((struct globals *)&bb_common_bufsiz1)->current_col + buflen;
+  if((signed long int)(4294967295u + buflen) < 128l)
+    (void)0;
+  else
+    __VERIFIER_error();
+  if((signed int)buf[(signed long int)(4294967295u + buflen)] == 10)
+    ((struct globals *)&bb_common_bufsiz1)->current_col = (unsigned int)0;
+}
+static unsigned int xatou(const char *numstr)
+{
+  unsigned int return_value_xatou_sfx$1;
+  return_value_xatou_sfx$1=xatou_sfx(numstr, (struct suffix_mult *)((void *)0));
+  return return_value_xatou_sfx$1;
+}
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, (unsigned int)0, (unsigned int)2147483647 * 2u + 1u, suffixes);
+  return return_value_xstrtou_range_sfx$1;
+}
+static inline unsigned long int xatoul_range_sfx(const char *str, unsigned long int l, unsigned long int u, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_range_sfx$1;
+  return_value_xatoull_range_sfx$1=xatoull_range_sfx(str, l, u, sfx);
+  return return_value_xatoull_range_sfx$1;
+}
+static inline unsigned long int xatoul_sfx(const char *str, struct suffix_mult *sfx)
+{
+  unsigned long long int return_value_xatoull_sfx$1;
+  return_value_xatoull_sfx$1=xatoull_sfx(str, sfx);
+  return return_value_xatoull_sfx$1;
+}
+static unsigned long long int xatoull_range_sfx(const char *numstr, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, lower, upper, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+static unsigned long long int xatoull_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned long long int return_value_xstrtoull_range_sfx$1;
+  return_value_xstrtoull_range_sfx$1=xstrtoull_range_sfx(numstr, 10, (unsigned long long int)0, (unsigned long int)9223372036854775807ll * 2ull + 1ull, suffixes);
+  return return_value_xstrtoull_range_sfx$1;
+}
+static void xdup2(signed int from, signed int to)
+{
+  signed int return_value_dup2$1;
+  return_value_dup2$1=dup2(from, to);
+  if(!(return_value_dup2$1 == to))
+    bb_perror_msg_and_die("can't duplicate file descriptor");
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void xmove_fd(signed int from, signed int to)
+{
+  if(from == to)
+    return;
+  xdup2(from, to);
+  close(from);
+}
+static signed int xopen(const char *pathname, signed int flags)
+{
+  signed int return_value_xopen3$1;
+  return_value_xopen3$1=xopen3(pathname, flags, 438);
+  return return_value_xopen3$1;
+}
+static signed int xopen3(const char *pathname, signed int flags, signed int mode)
+{
+  signed int ret;
+  ret=open(pathname, flags, mode);
+  if(ret < 0)
+    bb_perror_msg_and_die("can't open '%s'", pathname);
+  return ret;
+}
+static signed int xopen_nonblocking(const char *pathname)
+{
+  signed int return_value_xopen$1;
+  return_value_xopen$1=xopen(pathname, 0 | 2048);
+  return return_value_xopen$1;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static unsigned long long int xstrtoull_range_sfx(const char *numstr, signed int base, unsigned long long int lower, unsigned long long int upper, struct suffix_mult *suffixes)
+{
+  unsigned long long int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=strtoull(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(18446744073709551615ull / (unsigned long int)suffixes->mult >= r))
+                goto range;
+              r = r * (unsigned long long int)suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -530,7 +530,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2745,7 +2745,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/sync_false-no-overflow.c
+++ b/c/busybox-1.22.0/sync_false-no-overflow.c
@@ -1,0 +1,220 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/warn_ignoring_args.c line 12
+static void bb_warn_ignoring_args(char *arg);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/warn_ignoring_args.c line 12
+static void bb_warn_ignoring_args(char *arg)
+{
+  if(!(arg == ((char *)NULL)))
+    bb_error_msg("ignoring all arguments");
+
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/sync.c line 22
+signed int __main(signed int argc, char **argv)
+{
+
+  bb_warn_ignoring_args(argv[(signed long int)1]);
+  sync();
+  return 0;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/sync_false-no-overflow.i
+++ b/c/busybox-1.22.0/sync_false-no-overflow.i
@@ -1,0 +1,2013 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __uid_t uid_t;
+typedef __pid_t pid_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+typedef __sigset_t sigset_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_error_msg(const char *s, ...);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void bb_warn_ignoring_args(char *arg);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void bb_warn_ignoring_args(char *arg)
+{
+  if(!(arg == ((char *)((void *)0))))
+    bb_error_msg("ignoring all arguments");
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  bb_warn_ignoring_args(argv[(signed long int)1]);
+  sync();
+  return 0;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.c
@@ -69,7 +69,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.i
@@ -1778,7 +1778,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/tac_false-no-overflow.c
+++ b/c/busybox-1.22.0/tac_false-no-overflow.c
@@ -1,0 +1,1172 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file coreutils/tac.c line 28
+struct lstring;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file libbb/llist.c line 16
+static void llist_add_to(struct llist_t **old_head, void *data);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 752
+static void xwrite(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct lstring
+{
+  // size
+  signed int size;
+  // buf
+  char buf[1l];
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file libbb/llist.c line 16
+static void llist_add_to(struct llist_t **old_head, void *data)
+{
+  struct llist_t *new_head;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc(sizeof(struct llist_t) /*16ul*/ );
+  new_head = (struct llist_t *)return_value_xmalloc$1;
+  new_head->data = (char *)data;
+  new_head->link = *old_head;
+  *old_head = new_head;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/tac.c line 34
+signed int __main(signed int argc, char **argv)
+{
+  char **name;
+  struct _IO_FILE *f;
+  struct lstring *line = (struct lstring *)NULL;
+  struct llist_t *list = (struct llist_t *)NULL;
+  signed int retval = 0;
+  getopt32(argv, "");
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)"-";
+  }
+
+  name = argv;
+  while((_Bool)1)
+  {
+
+    if(*name == ((char *)NULL))
+      break;
+
+    name = name + 1l;
+  }
+  void *return_value_xrealloc$1;
+  signed int tmp_post$2;
+  do
+  {
+    signed int ch;
+    signed int i;
+    name = name - 1l;
+
+    f=fopen_or_warn_stdin(*name);
+    if(f == ((struct _IO_FILE *)NULL))
+      retval = 1;
+
+    else
+    {
+      i = 0;
+
+      *bb_errno = i;
+      do
+      {
+        ch=getc(f);
+        if(!(ch == -1))
+        {
+          if((127 & i) == 0)
+          {
+            return_value_xrealloc$1=xrealloc((void *)line, (unsigned long int)(i + 127) + sizeof(signed int) /*4ul*/  + (unsigned long int)1);
+            line = (struct lstring *)return_value_xrealloc$1;
+          }
+
+          tmp_post$2 = i;
+          i = i + 1;
+
+          line->buf[(signed long int)tmp_post$2] = (char)ch;
+        }
+
+        if(!(ch == 10))
+        {
+          if(ch == -1)
+          {
+            if(!(i == 0))
+              goto __CPROVER_DUMP_L22;
+
+          }
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L22:
+          ;
+          void *return_value_xrealloc$3;
+          return_value_xrealloc$3=xrealloc((void *)line, (unsigned long int)i + sizeof(signed int) /*4ul*/ );
+          line = (struct lstring *)return_value_xrealloc$3;
+
+          line->size = i;
+          llist_add_to(&list, (void *)line);
+          line = (struct lstring *)NULL;
+          i = 0;
+        }
+      }
+      while(ch != -1);
+
+      if(!(*bb_errno == 0))
+      {
+        if(!(*bb_errno == 2))
+        {
+
+          bb_simple_perror_msg(*name);
+          retval = 1;
+        }
+
+      }
+
+    }
+  }
+  while(!(name == argv));
+  for( ; !(list == ((struct llist_t *)NULL)); list = list->link)
+  {
+
+    line = (struct lstring *)list->data;
+
+    xwrite(1, (const void *)line->buf, (unsigned long int)line->size);
+
+  }
+  return retval;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 752
+static void xwrite(signed int fd, const void *buf, unsigned long int count)
+{
+  if(!(count == 0ul))
+  {
+    signed long int size;
+    size=full_write(fd, buf, count);
+    if(!((unsigned long int)size == count))
+      bb_error_msg_and_die("short write");
+
+  }
+
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/tac_false-no-overflow.i
+++ b/c/busybox-1.22.0/tac_false-no-overflow.i
@@ -1,0 +1,3143 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct lstring;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to(struct llist_t **old_head, void *data);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static void * xrealloc(void *ptr, unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void xwrite(signed int fd, const void *buf, unsigned long int count);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct lstring
+{
+  signed int size;
+  char buf[1l];
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to(struct llist_t **old_head, void *data)
+{
+  struct llist_t *new_head;
+  void *return_value_xmalloc$1;
+  return_value_xmalloc$1=xmalloc(sizeof(struct llist_t) );
+  new_head = (struct llist_t *)return_value_xmalloc$1;
+  new_head->data = (char *)data;
+  new_head->link = *old_head;
+  *old_head = new_head;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  char **name;
+  struct _IO_FILE *f;
+  struct lstring *line = (struct lstring *)((void *)0);
+  struct llist_t *list = (struct llist_t *)((void *)0);
+  signed int retval = 0;
+  getopt32(argv, "");
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)"-";
+  }
+  name = argv;
+  while((_Bool)1)
+  {
+    if(*name == ((char *)((void *)0)))
+      break;
+    name = name + 1l;
+  }
+  void *return_value_xrealloc$1;
+  signed int tmp_post$2;
+  do
+  {
+    signed int ch;
+    signed int i;
+    name = name - 1l;
+    f=fopen_or_warn_stdin(*name);
+    if(f == ((struct _IO_FILE *)((void *)0)))
+      retval = 1;
+    else
+    {
+      i = 0;
+      *bb_errno = i;
+      do
+      {
+        ch=_IO_getc (f);
+        if(!(ch == -1))
+        {
+          if((127 & i) == 0)
+          {
+            return_value_xrealloc$1=xrealloc((void *)line, (unsigned long int)(i + 127) + sizeof(signed int) + (unsigned long int)1);
+            line = (struct lstring *)return_value_xrealloc$1;
+          }
+          tmp_post$2 = i;
+          i = i + 1;
+          line->buf[(signed long int)tmp_post$2] = (char)ch;
+        }
+        if(!(ch == 10))
+        {
+          if(ch == -1)
+          {
+            if(!(i == 0))
+              goto __CPROVER_DUMP_L22;
+          }
+        }
+        else
+        {
+        __CPROVER_DUMP_L22:
+          ;
+          void *return_value_xrealloc$3;
+          return_value_xrealloc$3=xrealloc((void *)line, (unsigned long int)i + sizeof(signed int) );
+          line = (struct lstring *)return_value_xrealloc$3;
+          line->size = i;
+          llist_add_to(&list, (void *)line);
+          line = (struct lstring *)((void *)0);
+          i = 0;
+        }
+      }
+      while(ch != -1);
+      if(!(*bb_errno == 0))
+      {
+        if(!(*bb_errno == 2))
+        {
+          bb_simple_perror_msg(*name);
+          retval = 1;
+        }
+      }
+    }
+  }
+  while(!(name == argv));
+  for( ; !(list == ((struct llist_t *)((void *)0))); list = list->link)
+  {
+    line = (struct lstring *)list->data;
+    xwrite(1, (const void *)line->buf, (unsigned long int)line->size);
+  }
+  return retval;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void xwrite(signed int fd, const void *buf, unsigned long int count)
+{
+  if(!(count == 0ul))
+  {
+    signed long int size;
+    size=full_write(fd, buf, count);
+    if(!((unsigned long int)size == count))
+      bb_error_msg_and_die("short write");
+  }
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.c
@@ -230,7 +230,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.i
@@ -2260,7 +2260,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/tee_false-no-overflow.c
+++ b/c/busybox-1.22.0/tee_false-no-overflow.c
@@ -1,0 +1,1186 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/xfuncs_printf.c line 269
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 710
+static signed long int safe_read(signed int fd, void *buf, unsigned long int count);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/messages.c line 66
+static char bb_common_bufsiz1[8193l];
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/xfuncs_printf.c line 269
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn)
+{
+  signed int return_value_ferror$1;
+  return_value_ferror$1=ferror(fp);
+  if(!(return_value_ferror$1 == 0))
+    bb_error_msg_and_die("%s: I/O error", fn);
+
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 710
+static signed long int safe_read(signed int fd, void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=read(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/tee.c line 28
+signed int __main(signed int argc, char **argv)
+{
+  const char *mode = "w";
+  struct _IO_FILE **files;
+  struct _IO_FILE **fp;
+  char **names;
+  char **np;
+  char retval;
+  signed long int c;
+  unsigned int return_value_getopt32$1;
+  return_value_getopt32$1=getopt32(argv, "ia");
+  retval = (char)return_value_getopt32$1;
+  argc = argc - optind;
+  argv = argv + (signed long int)optind;
+  mode = mode + (signed long int)((signed int)retval & 2);
+  if(!((1 & (signed int)retval) == 0))
+    signal(2, (void (*)(signed int))1);
+
+  retval = (char)0;
+  signal(13, (void (*)(signed int))1);
+  void *return_value_xzalloc$2;
+  return_value_xzalloc$2=xzalloc(sizeof(struct _IO_FILE *) /*8ul*/  * (unsigned long int)(argc + 2));
+  files = (struct _IO_FILE **)return_value_xzalloc$2;
+  fp = files;
+  names = argv - (signed long int)1;
+  np = names;
+
+  files[(signed long int)0] = stdout;
+  goto GOT_NEW_FILE;
+
+__CPROVER_DUMP_L4:
+  ;
+
+  *fp = stdout;
+  _Bool tmp_if_expr$3;
+
+
+  if(!((signed int)*(*argv) == 45))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+
+
+    tmp_if_expr$3 = ((signed int)(*argv)[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  char **tmp_post$4;
+  if(!(tmp_if_expr$3 == (_Bool)0))
+  {
+
+
+    *fp=fopen_or_warn(*argv, mode);
+
+    if(!(*fp == ((struct _IO_FILE *)NULL)))
+      goto __CPROVER_DUMP_L23;
+
+    retval = (char)1;
+    argv = argv + 1l;
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L23:
+    ;
+    tmp_post$4 = argv;
+    argv = argv + 1l;
+
+
+    *np = *tmp_post$4;
+
+  GOT_NEW_FILE:
+    ;
+
+    setbuf(*fp, (char *)NULL);
+    fp = fp + 1l;
+    np = np + 1l;
+  }
+
+  if(!(*argv == ((char *)NULL)))
+    goto __CPROVER_DUMP_L4;
+
+  do
+  {
+    c=safe_read(0, (void *)bb_common_bufsiz1, sizeof(char [8193l]) /*8193ul*/ );
+    if(!(c > 0l))
+      break;
+
+    fp = files;
+    while((_Bool)1)
+    {
+
+      fwrite((const void *)bb_common_bufsiz1, (unsigned long int)1, (unsigned long int)c, *fp);
+      fp = fp + 1l;
+
+      if(*fp == ((struct _IO_FILE *)NULL))
+        break;
+
+    }
+  }
+  while((_Bool)1);
+  if(c < 0l)
+    retval = (char)1;
+
+  np = names;
+  fp = files;
+
+  names[(signed long int)0] = (char *)bb_msg_standard_input;
+
+  files[(signed long int)0] = stdin;
+  struct _IO_FILE **tmp_post$5;
+  char **tmp_post$6;
+  do
+  {
+    tmp_post$5 = fp;
+    fp = fp + 1l;
+    tmp_post$6 = np;
+    np = np + 1l;
+
+
+    die_if_ferror(*tmp_post$5, *tmp_post$6);
+
+  }
+  while(!(*fp == ((struct _IO_FILE *)NULL)));
+  // fflush_stdout_and_exit((signed int)retval); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return (signed int)retval;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/tee_false-no-overflow.i
+++ b/c/busybox-1.22.0/tee_false-no-overflow.i
@@ -1,0 +1,3153 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_read(signed int fd, void *buf, unsigned long int count);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static char bb_common_bufsiz1[8193l];
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn)
+{
+  signed int return_value_ferror$1;
+  return_value_ferror$1=ferror(fp);
+  if(!(return_value_ferror$1 == 0))
+    bb_error_msg_and_die("%s: I/O error", fn);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed long int safe_read(signed int fd, void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=read(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  const char *mode = "w";
+  struct _IO_FILE **files;
+  struct _IO_FILE **fp;
+  char **names;
+  char **np;
+  char retval;
+  signed long int c;
+  unsigned int return_value_getopt32$1;
+  return_value_getopt32$1=getopt32(argv, "ia");
+  retval = (char)return_value_getopt32$1;
+  argc = argc - optind;
+  argv = argv + (signed long int)optind;
+  mode = mode + (signed long int)((signed int)retval & 2);
+  if(!((1 & (signed int)retval) == 0))
+    signal(2, (void (*)(signed int))1);
+  retval = (char)0;
+  signal(13, (void (*)(signed int))1);
+  void *return_value_xzalloc$2;
+  return_value_xzalloc$2=xzalloc(sizeof(struct _IO_FILE *) * (unsigned long int)(argc + 2));
+  files = (struct _IO_FILE **)return_value_xzalloc$2;
+  fp = files;
+  names = argv - (signed long int)1;
+  np = names;
+  files[(signed long int)0] = stdout;
+  goto GOT_NEW_FILE;
+__CPROVER_DUMP_L4:
+  ;
+  *fp = stdout;
+  _Bool tmp_if_expr$3;
+  if(!((signed int)*(*argv) == 45))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    tmp_if_expr$3 = ((signed int)(*argv)[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  char **tmp_post$4;
+  if(!(tmp_if_expr$3 == (_Bool)0))
+  {
+    *fp=fopen_or_warn(*argv, mode);
+    if(!(*fp == ((struct _IO_FILE *)((void *)0))))
+      goto __CPROVER_DUMP_L23;
+    retval = (char)1;
+    argv = argv + 1l;
+  }
+  else
+  {
+  __CPROVER_DUMP_L23:
+    ;
+    tmp_post$4 = argv;
+    argv = argv + 1l;
+    *np = *tmp_post$4;
+  GOT_NEW_FILE:
+    ;
+    setbuf(*fp, (char *)((void *)0));
+    fp = fp + 1l;
+    np = np + 1l;
+  }
+  if(!(*argv == ((char *)((void *)0))))
+    goto __CPROVER_DUMP_L4;
+  do
+  {
+    c=safe_read(0, (void *)bb_common_bufsiz1, sizeof(char [8193l]) );
+    if(!(c > 0l))
+      break;
+    fp = files;
+    while((_Bool)1)
+    {
+      fwrite((const void *)bb_common_bufsiz1, (unsigned long int)1, (unsigned long int)c, *fp);
+      fp = fp + 1l;
+      if(*fp == ((struct _IO_FILE *)((void *)0)))
+        break;
+    }
+  }
+  while((_Bool)1);
+  if(c < 0l)
+    retval = (char)1;
+  np = names;
+  fp = files;
+  names[(signed long int)0] = (char *)bb_msg_standard_input;
+  files[(signed long int)0] = stdin;
+  struct _IO_FILE **tmp_post$5;
+  char **tmp_post$6;
+  do
+  {
+    tmp_post$5 = fp;
+    fp = fp + 1l;
+    tmp_post$6 = np;
+    np = np + 1l;
+    die_if_ferror(*tmp_post$5, *tmp_post$6);
+  }
+  while(!(*fp == ((struct _IO_FILE *)((void *)0))));
+  fflush(stdout);
+  return (signed int)retval;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.c
@@ -243,7 +243,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.i
@@ -2273,7 +2273,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/test-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/test-incomplete_false-no-overflow.c
@@ -1,0 +1,1226 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file coreutils/test.c line 276
+struct operator_t;
+
+// file coreutils/test.c line 377
+struct test_statics;
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file coreutils/test.c line 727
+static signed long int aexpr(signed int n);
+// file include/libbb.h line 386
+static const char * bb_basename(const char *name);
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file coreutils/test.c line 492
+static signed int binop(void);
+// file coreutils/test.c line 473
+static signed int check_operator(const char *s);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file coreutils/test.c line 630
+static signed int filstat(char *nm, signed int mode);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file coreutils/test.c line 420
+static signed long int getn(const char *s);
+// file libbb/compare_string_array.c line 22
+static signed int index_in_strings(const char *strings, const char *key);
+// file coreutils/test.c line 553
+static void initialize_group_array(void);
+// file coreutils/test.c line 576
+static signed int is_a_group_member(unsigned int gid);
+// file coreutils/test.c line 703
+static signed long int nexpr(signed int n);
+// file coreutils/test.c line 746
+static signed long int oexpr(signed int n);
+// file coreutils/test.c line 765
+static signed long int primary(signed int n);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 313
+static char * skip_whitespace(const char *s);
+// file coreutils/test.c line 408
+static void syntax(const char *op, const char *msg);
+// file coreutils/test.c line 599
+static signed int test_eaccess(char *path, signed int mode);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct operator_t
+{
+  // op_num
+  unsigned char op_num;
+  // op_type
+  unsigned char op_type;
+};
+
+struct test_statics
+{
+  // args
+  char **args;
+  // last_operator
+  struct operator_t *last_operator;
+  // group_array
+  unsigned int *group_array;
+  // ngroups
+  signed int ngroups;
+  // leaving
+  struct __jmp_buf_tag leaving[1l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file coreutils/test.c line 280
+static struct operator_t ops_table[40l] = { { .op_num=(unsigned char)1, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)2, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)3, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)4, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)5, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)6, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)7, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)8, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)9, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)14, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)15, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)16, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)12, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)13, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)22, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)23, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)11, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)20, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)21, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)11, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)10, .op_type=(unsigned char)0 }, 
+    { .op_num=(unsigned char)24, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)24, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)25, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)26, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)27, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)28, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)29, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)30, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)31, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)32, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)33, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)17, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)18, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)19, .op_type=(unsigned char)1 }, 
+    { .op_num=(unsigned char)34, .op_type=(unsigned char)2 }, 
+    { .op_num=(unsigned char)35, .op_type=(unsigned char)3 }, 
+    { .op_num=(unsigned char)36, .op_type=(unsigned char)3 }, 
+    { .op_num=(unsigned char)37, .op_type=(unsigned char)4 }, 
+    { .op_num=(unsigned char)38, .op_type=(unsigned char)4 } };
+// file coreutils/test.c line 324
+static const char ops_texts[124l] = { (const char)45, (const char)114, (const char)0, (const char)45, (const char)119, (const char)0, (const char)45, (const char)120, (const char)0, (const char)45, (const char)101, (const char)0, (const char)45, (const char)102, (const char)0, (const char)45, (const char)100, (const char)0, (const char)45, (const char)99, (const char)0, (const char)45, (const char)98, (const char)0, (const char)45, (const char)112, (const char)0, (const char)45, (const char)117, (const char)0, (const char)45, (const char)103, (const char)0, (const char)45, (const char)107, (const char)0, (const char)45, (const char)115, (const char)0, (const char)45, (const char)116, (const char)0, (const char)45, (const char)122, (const char)0, (const char)45, (const char)110, (const char)0, (const char)45, (const char)104, (const char)0, (const char)45, (const char)79, (const char)0, (const char)45, (const char)71, (const char)0, (const char)45, (const char)76, (const char)0, (const char)45, (const char)83, (const char)0, (const char)61, (const char)0, (const char)61, (const char)61, (const char)0, (const char)33, (const char)61, (const char)0, (const char)60, (const char)0, (const char)62, (const char)0, (const char)45, (const char)101, (const char)113, (const char)0, (const char)45, (const char)110, (const char)101, (const char)0, (const char)45, (const char)103, (const char)101, (const char)0, (const char)45, (const char)103, (const char)116, (const char)0, (const char)45, (const char)108, (const char)101, (const char)0, (const char)45, (const char)108, (const char)116, (const char)0, (const char)45, (const char)110, (const char)116, (const char)0, (const char)45, (const char)111, (const char)116, (const char)0, (const char)45, (const char)101, (const char)102, (const char)0, (const char)33, (const char)0, (const char)45, (const char)97, (const char)0, (const char)45, (const char)111, (const char)0, (const char)40, (const char)0, (const char)41, (const char)0, (const char)0 };
+// file coreutils/test.c line 388
+extern struct test_statics * const test_ptr_to_statics;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file coreutils/test.c line 727
+static signed long int aexpr(signed int n)
+{
+  signed long int res;
+  (void)0;
+  res=nexpr(n);
+  (void)0;
+
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+  signed int return_value_check_operator$3;
+
+
+  return_value_check_operator$3=check_operator(*test_ptr_to_statics->args);
+  if(return_value_check_operator$3 == 35)
+  {
+    (void)0;
+
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$1;
+
+
+    return_value_check_operator$1=check_operator(*test_ptr_to_statics->args);
+    signed long int return_value_aexpr$2;
+    return_value_aexpr$2=aexpr(return_value_check_operator$1);
+    res = (signed long int)(return_value_aexpr$2 != 0l ? (res != 0l ? (signed int)(1 != 0) : (signed int)(0 != 0)) : (signed int)(0 != 0));
+    (void)0;
+    return res;
+  }
+
+
+  test_ptr_to_statics->args = test_ptr_to_statics->args - 1l;
+  (void)0;
+  return res;
+}
+
+// file include/libbb.h line 386
+static const char * bb_basename(const char *name)
+{
+  const char *cp;
+  cp=strrchr(name, 47);
+  if(!(cp == ((const char *)NULL)))
+    return cp + (signed long int)1;
+
+  return name;
+}
+
+// file include/libbb.h line 1081
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file coreutils/test.c line 492
+static signed int binop(void)
+{
+  const char *opnd1;
+  const char *opnd2;
+  struct operator_t *op;
+  signed long int val1;
+  signed long int val2;
+
+
+  opnd1 = *test_ptr_to_statics->args;
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+
+
+  check_operator(*test_ptr_to_statics->args);
+
+  op = test_ptr_to_statics->last_operator;
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+
+
+  opnd2 = *test_ptr_to_statics->args;
+  if(opnd2 == ((const char *)NULL))
+  {
+
+    syntax(test_ptr_to_statics->args[(signed long int)-1], "argument expected");
+  }
+
+
+  if(228 + (signed int)(unsigned char)(signed int)op->op_num <= 5)
+  {
+    val1=getn(opnd1);
+    val2=getn(opnd2);
+
+    if((signed int)op->op_num == 28)
+      return (signed int)(val1 == val2);
+
+
+    if((signed int)op->op_num == 29)
+      return (signed int)(val1 != val2);
+
+
+    if((signed int)op->op_num == 30)
+      return (signed int)(val1 >= val2);
+
+
+    if((signed int)op->op_num == 31)
+      return (signed int)(val1 > val2);
+
+
+    if((signed int)op->op_num == 32)
+      return (signed int)(val1 <= val2);
+
+    return (signed int)(val1 < val2);
+  }
+
+
+  signed long int tmp_statement_expression$1;
+  if(234 + (signed int)(unsigned char)(signed int)op->op_num <= 5)
+  {
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    signed int return_value___builtin_strcmp$2;
+    return_value___builtin_strcmp$2=strcmp(opnd1, opnd2);
+    tmp_statement_expression$1 = (signed long int)return_value___builtin_strcmp$2;
+    val1 = tmp_statement_expression$1;
+
+    if((signed int)op->op_num == 24)
+      return (signed int)(val1 == (signed long int)0);
+
+
+    if((signed int)op->op_num == 25)
+      return (signed int)(val1 != (signed long int)0);
+
+
+    if((signed int)op->op_num == 26)
+      return (signed int)(val1 < (signed long int)0);
+
+    return (signed int)(val1 > (signed long int)0);
+  }
+
+  struct stat b1;
+  struct stat b2;
+  signed int return_value_stat$3;
+  return_value_stat$3=stat(opnd1, &b1);
+  _Bool tmp_if_expr$5;
+  signed int return_value_stat$4;
+  if(!(return_value_stat$3 == 0))
+    tmp_if_expr$5 = 1 != 0;
+
+  else
+  {
+    return_value_stat$4=stat(opnd2, &b2);
+    tmp_if_expr$5 = (return_value_stat$4 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$5 == (_Bool)0))
+    return 0;
+
+
+  if((signed int)op->op_num == 17)
+    return (signed int)(b1.st_mtim.tv_sec > b2.st_mtim.tv_sec);
+
+
+  if((signed int)op->op_num == 18)
+    return (signed int)(b1.st_mtim.tv_sec < b2.st_mtim.tv_sec);
+
+  return (signed int)(b1.st_dev == b2.st_dev && b1.st_ino == b2.st_ino);
+}
+
+// file coreutils/test.c line 473
+static signed int check_operator(const char *s)
+{
+  signed int n;
+
+  static struct operator_t no_op = { .op_num=(unsigned char)-1, .op_type=(unsigned char)-1 };
+  test_ptr_to_statics->last_operator = &no_op;
+  if(s == ((const char *)NULL))
+    return (signed int)0;
+
+  n=index_in_strings(ops_texts, s);
+  if(n < 0)
+    return (signed int)39;
+
+
+  test_ptr_to_statics->last_operator = &ops_table[(signed long int)n];
+  if(2l * (signed long int)n >= 0l)
+    (void)0;
+
+  else
+    /* assertion 2 * (signed long int)n >= 0 */
+    __VERIFIER_error();
+  if((signed long int)n < 40l)
+    (void)0;
+
+  else
+    /* assertion (signed long int)n < 40l */
+    __VERIFIER_error();
+  return (signed int)ops_table[(signed long int)n].op_num;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file coreutils/test.c line 630
+static signed int filstat(char *nm, signed int mode)
+{
+  struct stat s;
+  unsigned int i = i;
+  if(mode == 11)
+  {
+    signed int return_value_lstat$1;
+    return_value_lstat$1=lstat(nm, &s);
+    if(return_value_lstat$1 == 0)
+    {
+      i = (unsigned int)40960;
+      goto filetype;
+    }
+
+    return 0;
+  }
+
+  signed int return_value_stat$2;
+  return_value_stat$2=stat(nm, &s);
+  if(!(return_value_stat$2 == 0))
+    return 0;
+
+  if(mode == 4)
+    return 1;
+
+  if(255 + (signed int)(unsigned char)mode <= 2)
+  {
+    if(mode == 1)
+      i = (unsigned int)4;
+
+    if(mode == 2)
+      i = (unsigned int)2;
+
+    if(mode == 3)
+      i = (unsigned int)1;
+
+    signed int return_value_test_eaccess$3;
+    return_value_test_eaccess$3=test_eaccess(nm, (signed int)i);
+    return (signed int)(return_value_test_eaccess$3 == 0);
+  }
+
+  if(251 + (signed int)(unsigned char)mode <= 5)
+  {
+    if(mode == 5)
+      i = (unsigned int)32768;
+
+    if(mode == 6)
+      i = (unsigned int)16384;
+
+    if(mode == 7)
+      i = (unsigned int)8192;
+
+    if(mode == 8)
+      i = (unsigned int)24576;
+
+    if(mode == 9)
+      i = (unsigned int)4096;
+
+    if(mode == 10)
+      i = (unsigned int)49152;
+
+  filetype:
+    ;
+    return (signed int)((s.st_mode & (unsigned int)61440) == i);
+  }
+
+  if(242 + (signed int)(unsigned char)mode <= 2)
+  {
+    if(mode == 14)
+      i = (unsigned int)2048;
+
+    if(mode == 15)
+      i = (unsigned int)1024;
+
+    if(mode == 16)
+      i = (unsigned int)512;
+
+    return (signed int)((s.st_mode & i) != (unsigned int)0);
+  }
+
+  if(mode == 12)
+    return (signed int)(s.st_size > 0l);
+
+  unsigned int return_value_geteuid$4;
+  if(mode == 20)
+  {
+    return_value_geteuid$4=geteuid();
+    return (signed int)(s.st_uid == return_value_geteuid$4);
+  }
+
+  unsigned int return_value_getegid$5;
+  if(mode == 21)
+  {
+    return_value_getegid$5=getegid();
+    return (signed int)(s.st_gid == return_value_getegid$5);
+  }
+
+  return 1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file coreutils/test.c line 420
+static signed long int getn(const char *s)
+{
+  char *p;
+  signed long long int r;
+
+  *bb_errno = 0;
+  r=strtoll(s, &p, 10);
+
+  if(!(*bb_errno == 0))
+    syntax(s, "out of range");
+
+  _Bool tmp_if_expr$2;
+  char *return_value_skip_whitespace$1;
+  if(p == s)
+    tmp_if_expr$2 = 1 != 0;
+
+  else
+  {
+    return_value_skip_whitespace$1=skip_whitespace(p);
+
+    tmp_if_expr$2 = ((signed int)*return_value_skip_whitespace$1 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$2 == (_Bool)0))
+    syntax(s, "bad number");
+
+  return r;
+}
+
+// file libbb/compare_string_array.c line 22
+static signed int index_in_strings(const char *strings, const char *key)
+{
+  signed int idx = 0;
+  signed int tmp_statement_expression$1;
+  while(!((signed int)*strings == 0))
+  {
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    signed int return_value___builtin_strcmp$2;
+    return_value___builtin_strcmp$2=strcmp(strings, key);
+    tmp_statement_expression$1 = return_value___builtin_strcmp$2;
+    if(tmp_statement_expression$1 == 0)
+      return idx;
+
+    unsigned long int return_value_strlen$3;
+    return_value_strlen$3=strlen(strings);
+    strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+    idx = idx + 1;
+  }
+  return -1;
+}
+
+// file coreutils/test.c line 553
+static void initialize_group_array(void)
+{
+  signed int n;
+
+  test_ptr_to_statics->ngroups = 32;
+  while((_Bool)1)
+  {
+
+    n = test_ptr_to_statics->ngroups;
+    void *return_value_xrealloc$1;
+    return_value_xrealloc$1=xrealloc((void *)test_ptr_to_statics->group_array, (unsigned long int)n * sizeof(unsigned int) /*4ul*/ );
+
+    test_ptr_to_statics->group_array = (unsigned int *)return_value_xrealloc$1;
+
+    test_ptr_to_statics->ngroups=getgroups(n, test_ptr_to_statics->group_array);
+
+    if(n >= test_ptr_to_statics->ngroups)
+      break;
+
+  }
+}
+
+// file coreutils/test.c line 576
+static signed int is_a_group_member(unsigned int gid)
+{
+  signed int i;
+  unsigned int return_value_getgid$1;
+  return_value_getgid$1=getgid();
+  _Bool tmp_if_expr$3;
+  unsigned int return_value_getegid$2;
+  if(gid == return_value_getgid$1)
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    return_value_getegid$2=getegid();
+    tmp_if_expr$3 = (gid == return_value_getegid$2 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$3 == (_Bool)0))
+    return 1;
+
+
+  if(test_ptr_to_statics->ngroups == 0)
+    initialize_group_array();
+
+  i = 0;
+  while((_Bool)1)
+  {
+
+    if(i >= test_ptr_to_statics->ngroups)
+      break;
+
+
+    if(gid == test_ptr_to_statics->group_array[(signed long int)i])
+      return 1;
+
+    i = i + 1;
+  }
+  return 0;
+}
+
+// file coreutils/test.c line 703
+static signed long int nexpr(signed int n)
+{
+  signed long int res;
+  (void)0;
+  if(n == 34)
+  {
+
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+
+
+    n=check_operator(*test_ptr_to_statics->args);
+    if(n == 0)
+    {
+
+      test_ptr_to_statics->args = test_ptr_to_statics->args - 1l;
+      (void)0;
+      return (signed long int)1;
+    }
+
+    signed long int return_value_nexpr$1;
+    return_value_nexpr$1=nexpr(n);
+    res = (signed long int)!(return_value_nexpr$1 != 0l);
+    (void)0;
+    return res;
+  }
+
+  res=primary(n);
+  (void)0;
+  return res;
+}
+
+// file coreutils/test.c line 746
+static signed long int oexpr(signed int n)
+{
+  signed long int res;
+  (void)0;
+  res=aexpr(n);
+  (void)0;
+
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+  signed int return_value_check_operator$3;
+
+
+  return_value_check_operator$3=check_operator(*test_ptr_to_statics->args);
+  if(return_value_check_operator$3 == 36)
+  {
+    (void)0;
+
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$1;
+
+
+    return_value_check_operator$1=check_operator(*test_ptr_to_statics->args);
+    signed long int return_value_oexpr$2;
+    return_value_oexpr$2=oexpr(return_value_check_operator$1);
+    res = (signed long int)(return_value_oexpr$2 != 0l ? (signed int)(1 != 0) : (res != 0l ? (signed int)(1 != 0) : (signed int)(0 != 0)));
+    (void)0;
+    return res;
+  }
+
+
+  test_ptr_to_statics->args = test_ptr_to_statics->args - 1l;
+  (void)0;
+  return res;
+}
+
+// file coreutils/test.c line 765
+static signed long int primary(signed int n)
+{
+  signed long int res;
+  struct operator_t *args0_op;
+  (void)0;
+  if(n == 0)
+    syntax((const char *)NULL, "argument expected");
+
+  if(n == 37)
+  {
+
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$1;
+
+
+    return_value_check_operator$1=check_operator(*test_ptr_to_statics->args);
+    res=oexpr(return_value_check_operator$1);
+
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$2;
+
+
+    return_value_check_operator$2=check_operator(*test_ptr_to_statics->args);
+    if(!(return_value_check_operator$2 == 38))
+      syntax((const char *)NULL, "closing paren expected");
+
+    (void)0;
+    return res;
+  }
+
+
+  args0_op = test_ptr_to_statics->last_operator;
+  signed int return_value_check_operator$4;
+
+  return_value_check_operator$4=check_operator(test_ptr_to_statics->args[(signed long int)1]);
+  signed int return_value_binop$3;
+  if(!(return_value_check_operator$4 == 0))
+  {
+
+
+    if(!(*(2l + test_ptr_to_statics->args) == ((char *)NULL)))
+    {
+
+      if((signed int)test_ptr_to_statics->last_operator->op_type == 1)
+      {
+        return_value_binop$3=binop();
+        return (signed long int)return_value_binop$3;
+      }
+
+    }
+
+  }
+
+
+  signed long int return_value_getn$5;
+  signed int return_value_isatty$6;
+  if((signed int)args0_op->op_type == 0)
+  {
+
+
+    if(*(1l + test_ptr_to_statics->args) == ((char *)NULL))
+      goto check_emptiness;
+
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    if(n == 22)
+    {
+
+
+
+      return (signed long int)((signed int)test_ptr_to_statics->args[(signed long int)0][(signed long int)0] == 0);
+    }
+
+    if(n == 23)
+    {
+
+
+
+      return (signed long int)((signed int)test_ptr_to_statics->args[(signed long int)0][(signed long int)0] != 0);
+    }
+
+    if(n == 13)
+    {
+
+
+      return_value_getn$5=getn(*test_ptr_to_statics->args);
+      return_value_isatty$6=isatty((signed int)return_value_getn$5);
+      return (signed long int)return_value_isatty$6;
+    }
+
+    signed int return_value_filstat$7;
+
+
+    return_value_filstat$7=filstat(*test_ptr_to_statics->args, n);
+    return (signed long int)return_value_filstat$7;
+  }
+
+
+
+  if((signed int)test_ptr_to_statics->last_operator->op_type == 1)
+  {
+    signed int return_value_binop$8;
+    return_value_binop$8=binop();
+    return (signed long int)return_value_binop$8;
+  }
+
+check_emptiness:
+  ;
+
+
+
+  return (signed long int)((signed int)test_ptr_to_statics->args[(signed long int)0][(signed long int)0] != 0);
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 313
+static char * skip_whitespace(const char *s)
+{
+  for( ; (_Bool)1; s = s + 1l)
+    if(!((signed int)*s == 32))
+    {
+      if(!(247 + (signed int)(unsigned char)(signed int)*s <= 4))
+        break;
+
+    }
+
+  return (char *)s;
+}
+
+// file coreutils/test.c line 408
+static void syntax(const char *op, const char *msg)
+{
+  _Bool tmp_if_expr$1;
+  if(!(op == ((const char *)NULL)))
+  {
+
+    tmp_if_expr$1 = ((signed int)*op != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+
+  else
+    tmp_if_expr$1 = 0 != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    bb_error_msg("%s: %s", op, msg);
+
+  else
+    bb_error_msg("%s: %s" + (signed long int)4, msg);
+  longjmp(test_ptr_to_statics->leaving, 2);
+}
+
+// file coreutils/test.c line 599
+static signed int test_eaccess(char *path, signed int mode)
+{
+  struct stat st;
+  unsigned int euid;
+  euid=geteuid();
+  signed int return_value_stat$1;
+  return_value_stat$1=stat(path, &st);
+  if(return_value_stat$1 < 0)
+    return -1;
+
+  if(euid == 0u)
+  {
+    if(!(mode == 1))
+      return 0;
+
+    if(!((73u & st.st_mode) == 0u))
+      return 0;
+
+  }
+
+  signed int return_value_is_a_group_member$2;
+  if(st.st_uid == euid)
+    mode = mode << 6;
+
+  else
+  {
+    return_value_is_a_group_member$2=is_a_group_member(st.st_gid);
+    if(!(return_value_is_a_group_member$2 == 0))
+      mode = mode << 3;
+
+  }
+  if(!((st.st_mode & (unsigned int)mode) == 0u))
+    return 0;
+
+  return -1;
+}
+
+// file coreutils/test.c line 825
+signed int __main(signed int argc, char **argv)
+{
+  signed int res;
+  const char *arg0;
+
+  arg0=bb_basename(argv[(signed long int)0]);
+
+  _Bool tmp_if_expr$1;
+  signed int tmp_statement_expression$2;
+  _Bool tmp_if_expr$3;
+  signed int tmp_if_expr$6;
+  signed int tmp_statement_expression$4;
+  signed int return_value___builtin_strcmp$5;
+  if((signed int)*arg0 == 91)
+  {
+    argc = argc - 1;
+
+    if((signed int)*(1l + arg0) == 0)
+    {
+
+
+      if(!((signed int)*argv[(signed long int)argc] == 93))
+        tmp_if_expr$1 = 1 != 0;
+
+      else
+      {
+
+
+        tmp_if_expr$1 = ((signed int)argv[(signed long int)argc][(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$1 == (_Bool)0))
+      {
+        bb_error_msg("missing ]");
+        return 2;
+      }
+
+    }
+
+    else
+    {
+      unsigned long int __s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("]]" + 1l) + -((unsigned long int)"]]") == 1ul))
+          goto __CPROVER_DUMP_L19;
+
+        __s2_len=strlen("]]");
+        tmp_if_expr$3 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L19:
+        ;
+        tmp_if_expr$3 = 0 != 0;
+      }
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        const char *__s2;
+
+        __s2 = (const char *)argv[(signed long int)argc];
+        signed int __result;
+
+        __result = (signed int)((const char *)"]]")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+
+
+            __result = (signed int)((const char *)"]]")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+
+
+                __result = (signed int)((const char *)"]]")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+
+                    /* assertion (_Bool)0 */
+                    __VERIFIER_error();
+
+                    __result = (signed int)((const char *)"]]")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+
+        tmp_statement_expression$4 = __result;
+        tmp_if_expr$6 = -tmp_statement_expression$4;
+      }
+
+      else
+      {
+
+        return_value___builtin_strcmp$5=strcmp(argv[(signed long int)argc], "]]");
+        tmp_if_expr$6 = return_value___builtin_strcmp$5;
+      }
+      tmp_statement_expression$2 = tmp_if_expr$6;
+      if(!(tmp_statement_expression$2 == 0))
+      {
+        bb_error_msg("missing ]]");
+        return 2;
+      }
+
+    }
+    free(argv[(signed long int)argc]);
+    argv[(signed long int)argc] = (char *)NULL;
+  }
+
+  do
+  {
+    void *return_value_xzalloc$7;
+    return_value_xzalloc$7=xzalloc(sizeof(struct test_statics) /*232ul*/ );
+    *((struct test_statics **)&test_ptr_to_statics) = (struct test_statics *)return_value_xzalloc$7;
+  }
+  while((_Bool)0);
+  res=_setjmp(test_ptr_to_statics->leaving);
+  signed int return_value_check_operator$8;
+  signed long int return_value_oexpr$9;
+  if(res == 0)
+  {
+    argv = argv + 1l;
+
+    if(*argv == ((char *)NULL))
+      res = 1;
+
+    else
+    {
+
+      test_ptr_to_statics->args = argv;
+
+
+      return_value_check_operator$8=check_operator(*test_ptr_to_statics->args);
+      return_value_oexpr$9=oexpr(return_value_check_operator$8);
+      res = (signed int)!(return_value_oexpr$9 != 0l);
+
+
+      if(!(*test_ptr_to_statics->args == ((char *)NULL)))
+      {
+        test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+
+
+        if(!(*test_ptr_to_statics->args == ((char *)NULL)))
+        {
+          bb_error_msg("%s: unknown operand", *test_ptr_to_statics->args);
+          res = 2;
+        }
+
+      }
+
+    }
+  }
+
+  do
+  {
+
+  ret:
+    ;
+    free((void *)test_ptr_to_statics);
+  }
+  while((_Bool)0);
+  return res;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/test-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/test-incomplete_false-no-overflow.i
@@ -1,0 +1,3406 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct operator_t;
+struct test_statics;
+static signed long int aexpr(signed int n);
+static const char * bb_basename(const char *name);
+static void bb_error_msg(const char *s, ...);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int binop(void);
+static signed int check_operator(const char *s);
+static signed int fflush_all(void);
+static signed int filstat(char *nm, signed int mode);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int getn(const char *s);
+static signed int index_in_strings(const char *strings, const char *key);
+static void initialize_group_array(void);
+static signed int is_a_group_member(unsigned int gid);
+static signed long int nexpr(signed int n);
+static signed long int oexpr(signed int n);
+static signed long int primary(signed int n);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static char * skip_whitespace(const char *s);
+static void syntax(const char *op, const char *msg);
+static signed int test_eaccess(char *path, signed int mode);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static void * xrealloc(void *ptr, unsigned long int size);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct operator_t
+{
+  unsigned char op_num;
+  unsigned char op_type;
+};
+struct test_statics
+{
+  char **args;
+  struct operator_t *last_operator;
+  unsigned int *group_array;
+  signed int ngroups;
+  struct __jmp_buf_tag leaving[1l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static struct operator_t ops_table[40l] = { { .op_num=(unsigned char)1, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)2, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)3, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)4, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)5, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)6, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)7, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)8, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)9, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)14, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)15, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)16, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)12, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)13, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)22, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)23, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)11, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)20, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)21, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)11, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)10, .op_type=(unsigned char)0 },
+    { .op_num=(unsigned char)24, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)24, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)25, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)26, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)27, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)28, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)29, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)30, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)31, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)32, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)33, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)17, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)18, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)19, .op_type=(unsigned char)1 },
+    { .op_num=(unsigned char)34, .op_type=(unsigned char)2 },
+    { .op_num=(unsigned char)35, .op_type=(unsigned char)3 },
+    { .op_num=(unsigned char)36, .op_type=(unsigned char)3 },
+    { .op_num=(unsigned char)37, .op_type=(unsigned char)4 },
+    { .op_num=(unsigned char)38, .op_type=(unsigned char)4 } };
+static const char ops_texts[124l] = { (const char)45, (const char)114, (const char)0, (const char)45, (const char)119, (const char)0, (const char)45, (const char)120, (const char)0, (const char)45, (const char)101, (const char)0, (const char)45, (const char)102, (const char)0, (const char)45, (const char)100, (const char)0, (const char)45, (const char)99, (const char)0, (const char)45, (const char)98, (const char)0, (const char)45, (const char)112, (const char)0, (const char)45, (const char)117, (const char)0, (const char)45, (const char)103, (const char)0, (const char)45, (const char)107, (const char)0, (const char)45, (const char)115, (const char)0, (const char)45, (const char)116, (const char)0, (const char)45, (const char)122, (const char)0, (const char)45, (const char)110, (const char)0, (const char)45, (const char)104, (const char)0, (const char)45, (const char)79, (const char)0, (const char)45, (const char)71, (const char)0, (const char)45, (const char)76, (const char)0, (const char)45, (const char)83, (const char)0, (const char)61, (const char)0, (const char)61, (const char)61, (const char)0, (const char)33, (const char)61, (const char)0, (const char)60, (const char)0, (const char)62, (const char)0, (const char)45, (const char)101, (const char)113, (const char)0, (const char)45, (const char)110, (const char)101, (const char)0, (const char)45, (const char)103, (const char)101, (const char)0, (const char)45, (const char)103, (const char)116, (const char)0, (const char)45, (const char)108, (const char)101, (const char)0, (const char)45, (const char)108, (const char)116, (const char)0, (const char)45, (const char)110, (const char)116, (const char)0, (const char)45, (const char)111, (const char)116, (const char)0, (const char)45, (const char)101, (const char)102, (const char)0, (const char)33, (const char)0, (const char)45, (const char)97, (const char)0, (const char)45, (const char)111, (const char)0, (const char)40, (const char)0, (const char)41, (const char)0, (const char)0 };
+extern struct test_statics * const test_ptr_to_statics;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static signed long int aexpr(signed int n)
+{
+  signed long int res;
+  (void)0;
+  res=nexpr(n);
+  (void)0;
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+  signed int return_value_check_operator$3;
+  return_value_check_operator$3=check_operator(*test_ptr_to_statics->args);
+  if(return_value_check_operator$3 == 35)
+  {
+    (void)0;
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$1;
+    return_value_check_operator$1=check_operator(*test_ptr_to_statics->args);
+    signed long int return_value_aexpr$2;
+    return_value_aexpr$2=aexpr(return_value_check_operator$1);
+    res = (signed long int)(return_value_aexpr$2 != 0l ? (res != 0l ? (signed int)(1 != 0) : (signed int)(0 != 0)) : (signed int)(0 != 0));
+    (void)0;
+    return res;
+  }
+  test_ptr_to_statics->args = test_ptr_to_statics->args - 1l;
+  (void)0;
+  return res;
+}
+static const char * bb_basename(const char *name)
+{
+  const char *cp;
+  cp=strrchr(name, 47);
+  if(!(cp == ((const char *)((void *)0))))
+    return cp + (signed long int)1;
+  return name;
+}
+static void bb_error_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int binop(void)
+{
+  const char *opnd1;
+  const char *opnd2;
+  struct operator_t *op;
+  signed long int val1;
+  signed long int val2;
+  opnd1 = *test_ptr_to_statics->args;
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+  check_operator(*test_ptr_to_statics->args);
+  op = test_ptr_to_statics->last_operator;
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+  opnd2 = *test_ptr_to_statics->args;
+  if(opnd2 == ((const char *)((void *)0)))
+  {
+    syntax(test_ptr_to_statics->args[(signed long int)-1], "argument expected");
+  }
+  if(228 + (signed int)(unsigned char)(signed int)op->op_num <= 5)
+  {
+    val1=getn(opnd1);
+    val2=getn(opnd2);
+    if((signed int)op->op_num == 28)
+      return (signed int)(val1 == val2);
+    if((signed int)op->op_num == 29)
+      return (signed int)(val1 != val2);
+    if((signed int)op->op_num == 30)
+      return (signed int)(val1 >= val2);
+    if((signed int)op->op_num == 31)
+      return (signed int)(val1 > val2);
+    if((signed int)op->op_num == 32)
+      return (signed int)(val1 <= val2);
+    return (signed int)(val1 < val2);
+  }
+  signed long int tmp_statement_expression$1;
+  if(234 + (signed int)(unsigned char)(signed int)op->op_num <= 5)
+  {
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    signed int return_value___builtin_strcmp$2;
+    return_value___builtin_strcmp$2=strcmp(opnd1, opnd2);
+    tmp_statement_expression$1 = (signed long int)return_value___builtin_strcmp$2;
+    val1 = tmp_statement_expression$1;
+    if((signed int)op->op_num == 24)
+      return (signed int)(val1 == (signed long int)0);
+    if((signed int)op->op_num == 25)
+      return (signed int)(val1 != (signed long int)0);
+    if((signed int)op->op_num == 26)
+      return (signed int)(val1 < (signed long int)0);
+    return (signed int)(val1 > (signed long int)0);
+  }
+  struct stat b1;
+  struct stat b2;
+  signed int return_value_stat$3;
+  return_value_stat$3=stat(opnd1, &b1);
+  _Bool tmp_if_expr$5;
+  signed int return_value_stat$4;
+  if(!(return_value_stat$3 == 0))
+    tmp_if_expr$5 = 1 != 0;
+  else
+  {
+    return_value_stat$4=stat(opnd2, &b2);
+    tmp_if_expr$5 = (return_value_stat$4 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$5 == (_Bool)0))
+    return 0;
+  if((signed int)op->op_num == 17)
+    return (signed int)(b1.st_mtim.tv_sec > b2.st_mtim.tv_sec);
+  if((signed int)op->op_num == 18)
+    return (signed int)(b1.st_mtim.tv_sec < b2.st_mtim.tv_sec);
+  return (signed int)(b1.st_dev == b2.st_dev && b1.st_ino == b2.st_ino);
+}
+static signed int check_operator(const char *s)
+{
+  signed int n;
+  static struct operator_t no_op = { .op_num=(unsigned char)-1, .op_type=(unsigned char)-1 };
+  test_ptr_to_statics->last_operator = &no_op;
+  if(s == ((const char *)((void *)0)))
+    return (signed int)0;
+  n=index_in_strings(ops_texts, s);
+  if(n < 0)
+    return (signed int)39;
+  test_ptr_to_statics->last_operator = &ops_table[(signed long int)n];
+  if(2l * (signed long int)n >= 0l)
+    (void)0;
+  else
+    __VERIFIER_error();
+  if((signed long int)n < 40l)
+    (void)0;
+  else
+    __VERIFIER_error();
+  return (signed int)ops_table[(signed long int)n].op_num;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed int filstat(char *nm, signed int mode)
+{
+  struct stat s;
+  unsigned int i = i;
+  if(mode == 11)
+  {
+    signed int return_value_lstat$1;
+    return_value_lstat$1=lstat(nm, &s);
+    if(return_value_lstat$1 == 0)
+    {
+      i = (unsigned int)40960;
+      goto filetype;
+    }
+    return 0;
+  }
+  signed int return_value_stat$2;
+  return_value_stat$2=stat(nm, &s);
+  if(!(return_value_stat$2 == 0))
+    return 0;
+  if(mode == 4)
+    return 1;
+  if(255 + (signed int)(unsigned char)mode <= 2)
+  {
+    if(mode == 1)
+      i = (unsigned int)4;
+    if(mode == 2)
+      i = (unsigned int)2;
+    if(mode == 3)
+      i = (unsigned int)1;
+    signed int return_value_test_eaccess$3;
+    return_value_test_eaccess$3=test_eaccess(nm, (signed int)i);
+    return (signed int)(return_value_test_eaccess$3 == 0);
+  }
+  if(251 + (signed int)(unsigned char)mode <= 5)
+  {
+    if(mode == 5)
+      i = (unsigned int)32768;
+    if(mode == 6)
+      i = (unsigned int)16384;
+    if(mode == 7)
+      i = (unsigned int)8192;
+    if(mode == 8)
+      i = (unsigned int)24576;
+    if(mode == 9)
+      i = (unsigned int)4096;
+    if(mode == 10)
+      i = (unsigned int)49152;
+  filetype:
+    ;
+    return (signed int)((s.st_mode & (unsigned int)61440) == i);
+  }
+  if(242 + (signed int)(unsigned char)mode <= 2)
+  {
+    if(mode == 14)
+      i = (unsigned int)2048;
+    if(mode == 15)
+      i = (unsigned int)1024;
+    if(mode == 16)
+      i = (unsigned int)512;
+    return (signed int)((s.st_mode & i) != (unsigned int)0);
+  }
+  if(mode == 12)
+    return (signed int)(s.st_size > 0l);
+  unsigned int return_value_geteuid$4;
+  if(mode == 20)
+  {
+    return_value_geteuid$4=geteuid();
+    return (signed int)(s.st_uid == return_value_geteuid$4);
+  }
+  unsigned int return_value_getegid$5;
+  if(mode == 21)
+  {
+    return_value_getegid$5=getegid();
+    return (signed int)(s.st_gid == return_value_getegid$5);
+  }
+  return 1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int getn(const char *s)
+{
+  char *p;
+  signed long long int r;
+  *bb_errno = 0;
+  r=strtoll(s, &p, 10);
+  if(!(*bb_errno == 0))
+    syntax(s, "out of range");
+  _Bool tmp_if_expr$2;
+  char *return_value_skip_whitespace$1;
+  if(p == s)
+    tmp_if_expr$2 = 1 != 0;
+  else
+  {
+    return_value_skip_whitespace$1=skip_whitespace(p);
+    tmp_if_expr$2 = ((signed int)*return_value_skip_whitespace$1 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$2 == (_Bool)0))
+    syntax(s, "bad number");
+  return r;
+}
+static signed int index_in_strings(const char *strings, const char *key)
+{
+  signed int idx = 0;
+  signed int tmp_statement_expression$1;
+  while(!((signed int)*strings == 0))
+  {
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    signed int return_value___builtin_strcmp$2;
+    return_value___builtin_strcmp$2=strcmp(strings, key);
+    tmp_statement_expression$1 = return_value___builtin_strcmp$2;
+    if(tmp_statement_expression$1 == 0)
+      return idx;
+    unsigned long int return_value_strlen$3;
+    return_value_strlen$3=strlen(strings);
+    strings = strings + (signed long int)(return_value_strlen$3 + (unsigned long int)1);
+    idx = idx + 1;
+  }
+  return -1;
+}
+static void initialize_group_array(void)
+{
+  signed int n;
+  test_ptr_to_statics->ngroups = 32;
+  while((_Bool)1)
+  {
+    n = test_ptr_to_statics->ngroups;
+    void *return_value_xrealloc$1;
+    return_value_xrealloc$1=xrealloc((void *)test_ptr_to_statics->group_array, (unsigned long int)n * sizeof(unsigned int) );
+    test_ptr_to_statics->group_array = (unsigned int *)return_value_xrealloc$1;
+    test_ptr_to_statics->ngroups=getgroups(n, test_ptr_to_statics->group_array);
+    if(n >= test_ptr_to_statics->ngroups)
+      break;
+  }
+}
+static signed int is_a_group_member(unsigned int gid)
+{
+  signed int i;
+  unsigned int return_value_getgid$1;
+  return_value_getgid$1=getgid();
+  _Bool tmp_if_expr$3;
+  unsigned int return_value_getegid$2;
+  if(gid == return_value_getgid$1)
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    return_value_getegid$2=getegid();
+    tmp_if_expr$3 = (gid == return_value_getegid$2 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$3 == (_Bool)0))
+    return 1;
+  if(test_ptr_to_statics->ngroups == 0)
+    initialize_group_array();
+  i = 0;
+  while((_Bool)1)
+  {
+    if(i >= test_ptr_to_statics->ngroups)
+      break;
+    if(gid == test_ptr_to_statics->group_array[(signed long int)i])
+      return 1;
+    i = i + 1;
+  }
+  return 0;
+}
+static signed long int nexpr(signed int n)
+{
+  signed long int res;
+  (void)0;
+  if(n == 34)
+  {
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    n=check_operator(*test_ptr_to_statics->args);
+    if(n == 0)
+    {
+      test_ptr_to_statics->args = test_ptr_to_statics->args - 1l;
+      (void)0;
+      return (signed long int)1;
+    }
+    signed long int return_value_nexpr$1;
+    return_value_nexpr$1=nexpr(n);
+    res = (signed long int)!(return_value_nexpr$1 != 0l);
+    (void)0;
+    return res;
+  }
+  res=primary(n);
+  (void)0;
+  return res;
+}
+static signed long int oexpr(signed int n)
+{
+  signed long int res;
+  (void)0;
+  res=aexpr(n);
+  (void)0;
+  test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+  signed int return_value_check_operator$3;
+  return_value_check_operator$3=check_operator(*test_ptr_to_statics->args);
+  if(return_value_check_operator$3 == 36)
+  {
+    (void)0;
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$1;
+    return_value_check_operator$1=check_operator(*test_ptr_to_statics->args);
+    signed long int return_value_oexpr$2;
+    return_value_oexpr$2=oexpr(return_value_check_operator$1);
+    res = (signed long int)(return_value_oexpr$2 != 0l ? (signed int)(1 != 0) : (res != 0l ? (signed int)(1 != 0) : (signed int)(0 != 0)));
+    (void)0;
+    return res;
+  }
+  test_ptr_to_statics->args = test_ptr_to_statics->args - 1l;
+  (void)0;
+  return res;
+}
+static signed long int primary(signed int n)
+{
+  signed long int res;
+  struct operator_t *args0_op;
+  (void)0;
+  if(n == 0)
+    syntax((const char *)((void *)0), "argument expected");
+  if(n == 37)
+  {
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$1;
+    return_value_check_operator$1=check_operator(*test_ptr_to_statics->args);
+    res=oexpr(return_value_check_operator$1);
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    signed int return_value_check_operator$2;
+    return_value_check_operator$2=check_operator(*test_ptr_to_statics->args);
+    if(!(return_value_check_operator$2 == 38))
+      syntax((const char *)((void *)0), "closing paren expected");
+    (void)0;
+    return res;
+  }
+  args0_op = test_ptr_to_statics->last_operator;
+  signed int return_value_check_operator$4;
+  return_value_check_operator$4=check_operator(test_ptr_to_statics->args[(signed long int)1]);
+  signed int return_value_binop$3;
+  if(!(return_value_check_operator$4 == 0))
+  {
+    if(!(*(2l + test_ptr_to_statics->args) == ((char *)((void *)0))))
+    {
+      if((signed int)test_ptr_to_statics->last_operator->op_type == 1)
+      {
+        return_value_binop$3=binop();
+        return (signed long int)return_value_binop$3;
+      }
+    }
+  }
+  signed long int return_value_getn$5;
+  signed int return_value_isatty$6;
+  if((signed int)args0_op->op_type == 0)
+  {
+    if(*(1l + test_ptr_to_statics->args) == ((char *)((void *)0)))
+      goto check_emptiness;
+    test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+    if(n == 22)
+    {
+      return (signed long int)((signed int)test_ptr_to_statics->args[(signed long int)0][(signed long int)0] == 0);
+    }
+    if(n == 23)
+    {
+      return (signed long int)((signed int)test_ptr_to_statics->args[(signed long int)0][(signed long int)0] != 0);
+    }
+    if(n == 13)
+    {
+      return_value_getn$5=getn(*test_ptr_to_statics->args);
+      return_value_isatty$6=isatty((signed int)return_value_getn$5);
+      return (signed long int)return_value_isatty$6;
+    }
+    signed int return_value_filstat$7;
+    return_value_filstat$7=filstat(*test_ptr_to_statics->args, n);
+    return (signed long int)return_value_filstat$7;
+  }
+  if((signed int)test_ptr_to_statics->last_operator->op_type == 1)
+  {
+    signed int return_value_binop$8;
+    return_value_binop$8=binop();
+    return (signed long int)return_value_binop$8;
+  }
+check_emptiness:
+  ;
+  return (signed long int)((signed int)test_ptr_to_statics->args[(signed long int)0][(signed long int)0] != 0);
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static char * skip_whitespace(const char *s)
+{
+  for( ; (_Bool)1; s = s + 1l)
+    if(!((signed int)*s == 32))
+    {
+      if(!(247 + (signed int)(unsigned char)(signed int)*s <= 4))
+        break;
+    }
+  return (char *)s;
+}
+static void syntax(const char *op, const char *msg)
+{
+  _Bool tmp_if_expr$1;
+  if(!(op == ((const char *)((void *)0))))
+  {
+    tmp_if_expr$1 = ((signed int)*op != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  else
+    tmp_if_expr$1 = 0 != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    bb_error_msg("%s: %s", op, msg);
+  else
+    bb_error_msg("%s: %s" + (signed long int)4, msg);
+  longjmp(test_ptr_to_statics->leaving, 2);
+}
+static signed int test_eaccess(char *path, signed int mode)
+{
+  struct stat st;
+  unsigned int euid;
+  euid=geteuid();
+  signed int return_value_stat$1;
+  return_value_stat$1=stat(path, &st);
+  if(return_value_stat$1 < 0)
+    return -1;
+  if(euid == 0u)
+  {
+    if(!(mode == 1))
+      return 0;
+    if(!((73u & st.st_mode) == 0u))
+      return 0;
+  }
+  signed int return_value_is_a_group_member$2;
+  if(st.st_uid == euid)
+    mode = mode << 6;
+  else
+  {
+    return_value_is_a_group_member$2=is_a_group_member(st.st_gid);
+    if(!(return_value_is_a_group_member$2 == 0))
+      mode = mode << 3;
+  }
+  if(!((st.st_mode & (unsigned int)mode) == 0u))
+    return 0;
+  return -1;
+}
+signed int __main(signed int argc, char **argv)
+{
+  signed int res;
+  const char *arg0;
+  arg0=bb_basename(argv[(signed long int)0]);
+  _Bool tmp_if_expr$1;
+  signed int tmp_statement_expression$2;
+  _Bool tmp_if_expr$3;
+  signed int tmp_if_expr$6;
+  signed int tmp_statement_expression$4;
+  signed int return_value___builtin_strcmp$5;
+  if((signed int)*arg0 == 91)
+  {
+    argc = argc - 1;
+    if((signed int)*(1l + arg0) == 0)
+    {
+      if(!((signed int)*argv[(signed long int)argc] == 93))
+        tmp_if_expr$1 = 1 != 0;
+      else
+      {
+        tmp_if_expr$1 = ((signed int)argv[(signed long int)argc][(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$1 == (_Bool)0))
+      {
+        bb_error_msg("missing ]");
+        return 2;
+      }
+    }
+    else
+    {
+      unsigned long int __s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("]]" + 1l) + -((unsigned long int)"]]") == 1ul))
+          goto __CPROVER_DUMP_L19;
+        __s2_len=strlen("]]");
+        tmp_if_expr$3 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      else
+      {
+      __CPROVER_DUMP_L19:
+        ;
+        tmp_if_expr$3 = 0 != 0;
+      }
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        const char *__s2;
+        __s2 = (const char *)argv[(signed long int)argc];
+        signed int __result;
+        __result = (signed int)((const char *)"]]")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+            __result = (signed int)((const char *)"]]")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"]]")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+                    __VERIFIER_error();
+                    __result = (signed int)((const char *)"]]")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+                }
+              }
+            }
+          }
+        }
+        tmp_statement_expression$4 = __result;
+        tmp_if_expr$6 = -tmp_statement_expression$4;
+      }
+      else
+      {
+        return_value___builtin_strcmp$5=strcmp(argv[(signed long int)argc], "]]");
+        tmp_if_expr$6 = return_value___builtin_strcmp$5;
+      }
+      tmp_statement_expression$2 = tmp_if_expr$6;
+      if(!(tmp_statement_expression$2 == 0))
+      {
+        bb_error_msg("missing ]]");
+        return 2;
+      }
+    }
+    free(argv[(signed long int)argc]);
+    argv[(signed long int)argc] = (char *)((void *)0);
+  }
+  do
+  {
+    void *return_value_xzalloc$7;
+    return_value_xzalloc$7=xzalloc(sizeof(struct test_statics) );
+    *((struct test_statics **)&test_ptr_to_statics) = (struct test_statics *)return_value_xzalloc$7;
+  }
+  while((_Bool)0);
+  res=_setjmp(test_ptr_to_statics->leaving);
+  signed int return_value_check_operator$8;
+  signed long int return_value_oexpr$9;
+  if(res == 0)
+  {
+    argv = argv + 1l;
+    if(*argv == ((char *)((void *)0)))
+      res = 1;
+    else
+    {
+      test_ptr_to_statics->args = argv;
+      return_value_check_operator$8=check_operator(*test_ptr_to_statics->args);
+      return_value_oexpr$9=oexpr(return_value_check_operator$8);
+      res = (signed int)!(return_value_oexpr$9 != 0l);
+      if(!(*test_ptr_to_statics->args == ((char *)((void *)0))))
+      {
+        test_ptr_to_statics->args = test_ptr_to_statics->args + 1l;
+        if(!(*test_ptr_to_statics->args == ((char *)((void *)0))))
+        {
+          bb_error_msg("%s: unknown operand", *test_ptr_to_statics->args);
+          res = 2;
+        }
+      }
+    }
+  }
+  do
+  {
+  ret:
+    ;
+    free((void *)test_ptr_to_statics);
+  }
+  while((_Bool)0);
+  return res;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -254,7 +254,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2584,7 +2584,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/touch_false-no-overflow.c
+++ b/c/busybox-1.22.0/touch_false-no-overflow.c
@@ -1,0 +1,1500 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file include/xatonum.h line 135
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base);
+// file libbb/bb_strtonum.c line 73
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/time.c line 11
+static void parse_datestr(const char *date_str, struct tm *ptm);
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file libbb/time.c line 202
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file libbb/xfuncs_printf.c line 242
+static void xclose(signed int fd);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xfuncs_printf.c line 469
+static void xstat(const char *name, struct stat *stat_buf);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 26
+static const char bb_msg_invalid_date[18l] = { (const char)105, (const char)110, (const char)118, (const char)97, (const char)108, (const char)105, (const char)100, (const char)32, (const char)100, (const char)97, (const char)116, (const char)101, (const char)32, (const char)39, (const char)37, (const char)115, (const char)39, (const char)0 };
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file include/xatonum.h line 135
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base)
+{
+  signed long long int return_value_bb_strtoll$1;
+  return_value_bb_strtoll$1=bb_strtoll(arg, endp, base);
+  return return_value_bb_strtoll$1;
+}
+
+// file libbb/bb_strtonum.c line 73
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed long long int)return_value_ret_ERANGE$2;
+  }
+
+  *bb_errno = 0;
+  signed long long int return_value_strtoll$4;
+  return_value_strtoll$4=strtoll(arg, endp, base);
+  v = (unsigned long long int)return_value_strtoll$4;
+  unsigned long long int return_value_handle_errors$5;
+  return_value_handle_errors$5=handle_errors(v, endp);
+  return (signed long long int)return_value_handle_errors$5;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+
+    *bb_errno = 22;
+  }
+
+  return v;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/time.c line 11
+static void parse_datestr(const char *date_str, struct tm *ptm)
+{
+  char end = (char)0;
+  const char *last_colon;
+  last_colon=strrchr(date_str, 58);
+  signed int return_value_sscanf$5;
+  signed int return_value_sscanf$2;
+  _Bool tmp_if_expr$4;
+  signed int return_value_sscanf$3;
+  _Bool tmp_if_expr$1;
+  char *return_value___builtin_strchr$23;
+  _Bool tmp_if_expr$27;
+  signed int return_value_sscanf$24;
+  _Bool tmp_if_expr$26;
+  signed int return_value_sscanf$25;
+  _Bool tmp_if_expr$20;
+  signed int return_value_sscanf$19;
+  _Bool tmp_if_expr$18;
+  signed int return_value_sscanf$17;
+  _Bool tmp_if_expr$16;
+  signed int return_value_sscanf$15;
+  _Bool tmp_if_expr$14;
+  signed int return_value_sscanf$13;
+  _Bool tmp_if_expr$12;
+  signed int return_value_sscanf$11;
+  _Bool tmp_if_expr$10;
+  signed int return_value_sscanf$9;
+  if(!(last_colon == ((const char *)NULL)))
+  {
+    const char *endp;
+    signed int return_value_sscanf$6;
+    return_value_sscanf$6=sscanf(date_str, "%u:%u%c", &ptm->tm_hour, &ptm->tm_min, &end);
+    if(!(return_value_sscanf$6 >= 2))
+    {
+      return_value_sscanf$5=sscanf(date_str, "%u.%u-%u:%u%c", &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+      if(return_value_sscanf$5 >= 4)
+        ptm->tm_mon = ptm->tm_mon - 1;
+
+      else
+      {
+        return_value_sscanf$2=sscanf(date_str, "%u.%u.%u-%u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+        if(return_value_sscanf$2 >= 5)
+          tmp_if_expr$4 = 1 != 0;
+
+        else
+        {
+          return_value_sscanf$3=sscanf(date_str, "%u-%u-%u %u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+          tmp_if_expr$4 = (return_value_sscanf$3 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$4 == (_Bool)0))
+        {
+          ptm->tm_year = ptm->tm_year - 1900;
+          ptm->tm_mon = ptm->tm_mon - 1;
+        }
+
+        else
+        {
+          endp=strptime(date_str, "%b %d %T %Y", ptm);
+          if(!(endp == ((const char *)NULL)))
+            tmp_if_expr$1 = ((signed int)*endp == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+          else
+            tmp_if_expr$1 = 0 != 0;
+          if(!(tmp_if_expr$1 == (_Bool)0))
+            return;
+
+          else
+            bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+        }
+      }
+    }
+
+    if((signed int)end == 58)
+    {
+      signed int return_value_sscanf$7;
+      return_value_sscanf$7=sscanf(last_colon + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+      if(return_value_sscanf$7 == 1)
+        end = (char)0;
+
+    }
+
+  }
+
+  else
+  {
+    return_value___builtin_strchr$23=strchr(date_str, 45);
+    if(!(return_value___builtin_strchr$23 == ((char *)NULL)))
+    {
+      return_value_sscanf$24=sscanf(date_str, "%u-%u-%u %u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &end);
+      if(return_value_sscanf$24 >= 4)
+        tmp_if_expr$26 = 1 != 0;
+
+      else
+      {
+        return_value_sscanf$25=sscanf(date_str, "%u-%u-%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &end);
+        tmp_if_expr$26 = (return_value_sscanf$25 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      tmp_if_expr$27 = (tmp_if_expr$26 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+
+    else
+      tmp_if_expr$27 = 0 != 0;
+    if(!(tmp_if_expr$27 == (_Bool)0))
+    {
+      ptm->tm_year = ptm->tm_year - 1900;
+      ptm->tm_mon = ptm->tm_mon - 1;
+    }
+
+    else
+      if((signed int)*date_str == 64)
+      {
+        signed long int t;
+        t=bb_strtol(date_str + (signed long int)1, (char **)NULL, 10);
+        if(*bb_errno == 0)
+        {
+          struct tm *lt;
+          lt=localtime(&t);
+          if(!(lt == ((struct tm *)NULL)))
+          {
+            *ptm = *lt;
+            return;
+          }
+
+        }
+
+        end = (char)49;
+      }
+
+      else
+      {
+        unsigned int cur_year = (unsigned int)ptm->tm_year;
+        signed int len;
+        char *return_value_strchrnul$8;
+        return_value_strchrnul$8=strchrnul(date_str, 46);
+        len = (signed int)(return_value_strchrnul$8 - date_str);
+        if(len == 2)
+        {
+          return_value_sscanf$19=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)12, &ptm->tm_min, &end);
+          tmp_if_expr$20 = (return_value_sscanf$19 >= 1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+          tmp_if_expr$20 = 0 != 0;
+        if(tmp_if_expr$20 == (_Bool)0)
+        {
+          if(len == 4)
+          {
+            return_value_sscanf$17=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)9, &ptm->tm_hour, &ptm->tm_min, &end);
+            tmp_if_expr$18 = (return_value_sscanf$17 >= 2 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+
+          else
+            tmp_if_expr$18 = 0 != 0;
+          if(tmp_if_expr$18 == (_Bool)0)
+          {
+            if(len == 6)
+            {
+              return_value_sscanf$15=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)6, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+              tmp_if_expr$16 = (return_value_sscanf$15 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+            }
+
+            else
+              tmp_if_expr$16 = 0 != 0;
+            if(tmp_if_expr$16 == (_Bool)0)
+            {
+              if(len == 8)
+              {
+                return_value_sscanf$13=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)3, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                tmp_if_expr$14 = (return_value_sscanf$13 >= 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+              }
+
+              else
+                tmp_if_expr$14 = 0 != 0;
+              if(!(tmp_if_expr$14 == (_Bool)0))
+                ptm->tm_mon = ptm->tm_mon - 1;
+
+              else
+              {
+                if(len == 10)
+                {
+                  return_value_sscanf$11=sscanf(date_str, "%2u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                  tmp_if_expr$12 = (return_value_sscanf$11 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                }
+
+                else
+                  tmp_if_expr$12 = 0 != 0;
+                if(!(tmp_if_expr$12 == (_Bool)0))
+                {
+                  ptm->tm_mon = ptm->tm_mon - 1;
+                  if((signed int)cur_year >= 50)
+                  {
+                    ptm->tm_year = ptm->tm_year + (signed int)((cur_year / (unsigned int)100) * (unsigned int)100);
+                    if(!((unsigned int)ptm->tm_year >= 4294967246u + cur_year))
+                      ptm->tm_year = ptm->tm_year + 100;
+
+                    if(!(50u + cur_year >= (unsigned int)ptm->tm_year))
+                      ptm->tm_year = ptm->tm_year - 100;
+
+                  }
+
+                }
+
+                else
+                {
+                  if(len == 12)
+                  {
+                    return_value_sscanf$9=sscanf(date_str, "%4u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                    tmp_if_expr$10 = (return_value_sscanf$9 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  }
+
+                  else
+                    tmp_if_expr$10 = 0 != 0;
+                  if(!(tmp_if_expr$10 == (_Bool)0))
+                  {
+                    ptm->tm_year = ptm->tm_year - 1900;
+                    ptm->tm_mon = ptm->tm_mon - 1;
+                  }
+
+                  else
+                    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+                }
+              }
+            }
+
+          }
+
+        }
+
+        if((signed int)end == 46)
+        {
+          char *return_value___builtin_strchr$21;
+          return_value___builtin_strchr$21=strchr(date_str, 46);
+          signed int return_value_sscanf$22;
+          return_value_sscanf$22=sscanf(return_value___builtin_strchr$21 + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+          if(return_value_sscanf$22 == 1)
+            end = (char)0;
+
+        }
+
+      }
+  }
+  if(!((signed int)end == 0))
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+
+}
+
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/touch.c line 89
+signed int __main(signed int argc, char **argv)
+{
+  signed int fd;
+  signed int status = 0;
+  signed int opts;
+  char *reference_file = (char *)NULL;
+  char *date_str = (char *)NULL;
+  struct timeval timebuf[2l];
+  timebuf[(signed long int)0].tv_usec = (signed long int)0;
+  timebuf[(signed long int)1].tv_usec = timebuf[(signed long int)0].tv_usec;
+  static const char touch_longopts[49l] = { (const char)110, (const char)111, (const char)45, (const char)99, (const char)114, (const char)101, (const char)97, (const char)116, (const char)101, (const char)0, (const char)0, (const char)99, (const char)114, (const char)101, (const char)102, (const char)101, (const char)114, (const char)101, (const char)110, (const char)99, (const char)101, (const char)0, (const char)1, (const char)114, (const char)100, (const char)97, (const char)116, (const char)101, (const char)0, (const char)1, (const char)100, (const char)110, (const char)111, (const char)45, (const char)100, (const char)101, (const char)114, (const char)101, (const char)102, (const char)101, (const char)114, (const char)101, (const char)110, (const char)99, (const char)101, (const char)0, (const char)0, (const char)104, (const char)0 };
+  applet_long_options = touch_longopts;
+  unsigned int return_value_getopt32$1;
+  return_value_getopt32$1=getopt32(argv, "cr:d:t:hfma", &reference_file, &date_str, &date_str);
+  opts = (signed int)return_value_getopt32$1;
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+    bb_show_usage();
+
+  if(!(reference_file == ((char *)NULL)))
+  {
+    struct stat stbuf;
+    xstat(reference_file, &stbuf);
+    timebuf[(signed long int)0].tv_sec = stbuf.st_mtim.tv_sec;
+    timebuf[(signed long int)1].tv_sec = timebuf[(signed long int)0].tv_sec;
+  }
+
+  if(!(date_str == ((char *)NULL)))
+  {
+    struct tm tm_time;
+    signed long int t;
+    time(&t);
+    localtime_r(&t, &tm_time);
+    parse_datestr(date_str, &tm_time);
+    tm_time.tm_isdst = -1;
+    t=validate_tm_time(date_str, &tm_time);
+    timebuf[(signed long int)0].tv_sec = t;
+    timebuf[(signed long int)1].tv_sec = timebuf[(signed long int)0].tv_sec;
+  }
+
+  struct timeval *tmp_if_expr$2;
+  do
+  {
+    signed int result;
+    if(reference_file == ((char *)NULL))
+    {
+      if(!(date_str == ((char *)NULL)))
+        goto __CPROVER_DUMP_L7;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L7:
+      ;
+      tmp_if_expr$2 = timebuf;
+      goto __CPROVER_DUMP_L9;
+    }
+    tmp_if_expr$2 = (struct timeval *)NULL;
+
+  __CPROVER_DUMP_L9:
+    ;
+    if(!(((16 & opts) != 0 ? lutimes : utimes) == NULL))
+      (void)0;
+
+    else
+      /* assertion !(((16 & opts) != 0 ? lutimes : utimes) == ((signed int (*)(const char *, struct timeval *))((void*)0))) */
+      __VERIFIER_error();
+
+    result=((opts & 16) != 0 ? lutimes : utimes)(*argv, tmp_if_expr$2);
+    if(!(result == 0))
+    {
+
+      if(*bb_errno == 2)
+      {
+        if(!((1 & opts) == 0))
+          goto __CPROVER_DUMP_L25;
+
+
+        fd=open(*argv, 2 | 64, 438);
+        if(!(fd >= 0))
+          goto __CPROVER_DUMP_L22;
+
+        xclose(fd);
+        if(reference_file == ((char *)NULL))
+        {
+          if(!(date_str == ((char *)NULL)))
+            goto __CPROVER_DUMP_L18;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L18:
+          ;
+
+          utimes(*argv, timebuf);
+        }
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L22:
+        ;
+        status = 1;
+
+        bb_simple_perror_msg(*argv);
+      }
+    }
+
+  __CPROVER_DUMP_L25:
+    ;
+    argv = argv + 1l;
+
+  }
+  while(!(*argv == ((char *)NULL)));
+  return status;
+}
+
+// file libbb/time.c line 202
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm)
+{
+  signed long int t;
+  t=mktime(ptm);
+  if(t == -1l)
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+
+  return t;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file libbb/xfuncs_printf.c line 242
+static void xclose(signed int fd)
+{
+  signed int return_value_close$1;
+  return_value_close$1=close(fd);
+  if(!(return_value_close$1 == 0))
+    bb_perror_msg_and_die("close failed");
+
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xfuncs_printf.c line 469
+static void xstat(const char *name, struct stat *stat_buf)
+{
+  signed int return_value_stat$1;
+  return_value_stat$1=stat(name, stat_buf);
+  if(!(return_value_stat$1 == 0))
+    bb_perror_msg_and_die("can't stat '%s'", name);
+
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/touch_false-no-overflow.i
+++ b/c/busybox-1.22.0/touch_false-no-overflow.i
@@ -1,0 +1,3729 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+struct flock
+  {
+    short int l_type;
+    short int l_whence;
+    __off_t l_start;
+    __off_t l_len;
+    __pid_t l_pid;
+  };
+struct flock64
+  {
+    short int l_type;
+    short int l_whence;
+    __off64_t l_start;
+    __off64_t l_len;
+    __pid_t l_pid;
+  };
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __uid_t uid_t;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __pid_t pid_t;
+typedef __id_t id_t;
+typedef __ssize_t ssize_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef long unsigned int size_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+typedef __sigset_t sigset_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+
+struct iovec
+  {
+    void *iov_base;
+    size_t iov_len;
+  };
+enum __pid_type
+  {
+    F_OWNER_TID = 0,
+    F_OWNER_PID,
+    F_OWNER_PGRP,
+    F_OWNER_GID = F_OWNER_PGRP
+  };
+struct f_owner_ex
+  {
+    enum __pid_type type;
+    __pid_t pid;
+  };
+struct file_handle
+{
+  unsigned int handle_bytes;
+  int handle_type;
+  unsigned char f_handle[0];
+};
+
+extern ssize_t readahead (int __fd, __off64_t __offset, size_t __count)
+    __attribute__ ((__nothrow__ , __leaf__));
+extern int sync_file_range (int __fd, __off64_t __offset, __off64_t __count,
+       unsigned int __flags);
+extern ssize_t vmsplice (int __fdout, const struct iovec *__iov,
+    size_t __count, unsigned int __flags);
+extern ssize_t splice (int __fdin, __off64_t *__offin, int __fdout,
+         __off64_t *__offout, size_t __len,
+         unsigned int __flags);
+extern ssize_t tee (int __fdin, int __fdout, size_t __len,
+      unsigned int __flags);
+extern int fallocate (int __fd, int __mode, __off_t __offset, __off_t __len);
+extern int fallocate64 (int __fd, int __mode, __off64_t __offset,
+   __off64_t __len);
+extern int name_to_handle_at (int __dfd, const char *__name,
+         struct file_handle *__handle, int *__mnt_id,
+         int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern int open_by_handle_at (int __mountdirfd, struct file_handle *__handle,
+         int __flags);
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int fcntl (int __fd, int __cmd, ...);
+extern int open (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int open64 (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int openat (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int openat64 (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int creat (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int creat64 (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int lockf (int __fd, int __cmd, off_t __len);
+extern int lockf64 (int __fd, int __cmd, off64_t __len);
+extern int posix_fadvise (int __fd, off_t __offset, off_t __len,
+     int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fadvise64 (int __fd, off64_t __offset, off64_t __len,
+       int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fallocate (int __fd, off_t __offset, off_t __len);
+extern int posix_fallocate64 (int __fd, off64_t __offset, off64_t __len);
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static inline signed int bb_ascii_isalnum(unsigned char a);
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base);
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static void parse_datestr(const char *date_str, struct tm *ptm);
+static unsigned long long int ret_ERANGE(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xclose(signed int fd);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static void xstat(const char *name, struct stat *stat_buf);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_invalid_date[18l] = { (const char)105, (const char)110, (const char)118, (const char)97, (const char)108, (const char)105, (const char)100, (const char)32, (const char)100, (const char)97, (const char)116, (const char)101, (const char)32, (const char)39, (const char)37, (const char)115, (const char)39, (const char)0 };
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline signed long int bb_strtol(const char *arg, char **endp, signed int base)
+{
+  signed long long int return_value_bb_strtoll$1;
+  return_value_bb_strtoll$1=bb_strtoll(arg, endp, base);
+  return return_value_bb_strtoll$1;
+}
+static signed long long int bb_strtoll(const char *arg, char **endp, signed int base)
+{
+  unsigned long long int v;
+  char *endptr;
+  char first;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int tmp_if_expr$1;
+  if(!((signed int)*arg == 45))
+    tmp_if_expr$1 = (signed int)arg[(signed long int)0];
+  else
+    tmp_if_expr$1 = (signed int)arg[(signed long int)1];
+  first = (char)tmp_if_expr$1;
+  signed int return_value_bb_ascii_isalnum$3;
+  return_value_bb_ascii_isalnum$3=bb_ascii_isalnum(first);
+  unsigned long long int return_value_ret_ERANGE$2;
+  if(return_value_bb_ascii_isalnum$3 == 0)
+  {
+    return_value_ret_ERANGE$2=ret_ERANGE();
+    return (signed long long int)return_value_ret_ERANGE$2;
+  }
+  *bb_errno = 0;
+  signed long long int return_value_strtoll$4;
+  return_value_strtoll$4=strtoll(arg, endp, base);
+  v = (unsigned long long int)return_value_strtoll$4;
+  unsigned long long int return_value_handle_errors$5;
+  return_value_handle_errors$5=handle_errors(v, endp);
+  return (signed long long int)return_value_handle_errors$5;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+    *bb_errno = 22;
+  }
+  return v;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static void parse_datestr(const char *date_str, struct tm *ptm)
+{
+  char end = (char)0;
+  const char *last_colon;
+  last_colon=strrchr(date_str, 58);
+  signed int return_value_sscanf$5;
+  signed int return_value_sscanf$2;
+  _Bool tmp_if_expr$4;
+  signed int return_value_sscanf$3;
+  _Bool tmp_if_expr$1;
+  char *return_value___builtin_strchr$23;
+  _Bool tmp_if_expr$27;
+  signed int return_value_sscanf$24;
+  _Bool tmp_if_expr$26;
+  signed int return_value_sscanf$25;
+  _Bool tmp_if_expr$20;
+  signed int return_value_sscanf$19;
+  _Bool tmp_if_expr$18;
+  signed int return_value_sscanf$17;
+  _Bool tmp_if_expr$16;
+  signed int return_value_sscanf$15;
+  _Bool tmp_if_expr$14;
+  signed int return_value_sscanf$13;
+  _Bool tmp_if_expr$12;
+  signed int return_value_sscanf$11;
+  _Bool tmp_if_expr$10;
+  signed int return_value_sscanf$9;
+  if(!(last_colon == ((const char *)((void *)0))))
+  {
+    const char *endp;
+    signed int return_value_sscanf$6;
+    return_value_sscanf$6=sscanf(date_str, "%u:%u%c", &ptm->tm_hour, &ptm->tm_min, &end);
+    if(!(return_value_sscanf$6 >= 2))
+    {
+      return_value_sscanf$5=sscanf(date_str, "%u.%u-%u:%u%c", &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+      if(return_value_sscanf$5 >= 4)
+        ptm->tm_mon = ptm->tm_mon - 1;
+      else
+      {
+        return_value_sscanf$2=sscanf(date_str, "%u.%u.%u-%u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+        if(return_value_sscanf$2 >= 5)
+          tmp_if_expr$4 = 1 != 0;
+        else
+        {
+          return_value_sscanf$3=sscanf(date_str, "%u-%u-%u %u:%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+          tmp_if_expr$4 = (return_value_sscanf$3 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        if(!(tmp_if_expr$4 == (_Bool)0))
+        {
+          ptm->tm_year = ptm->tm_year - 1900;
+          ptm->tm_mon = ptm->tm_mon - 1;
+        }
+        else
+        {
+          endp=strptime(date_str, "%b %d %T %Y", ptm);
+          if(!(endp == ((const char *)((void *)0))))
+            tmp_if_expr$1 = ((signed int)*endp == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          else
+            tmp_if_expr$1 = 0 != 0;
+          if(!(tmp_if_expr$1 == (_Bool)0))
+            return;
+          else
+            bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+        }
+      }
+    }
+    if((signed int)end == 58)
+    {
+      signed int return_value_sscanf$7;
+      return_value_sscanf$7=sscanf(last_colon + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+      if(return_value_sscanf$7 == 1)
+        end = (char)0;
+    }
+  }
+  else
+  {
+    return_value___builtin_strchr$23=strchr(date_str, 45);
+    if(!(return_value___builtin_strchr$23 == ((char *)((void *)0))))
+    {
+      return_value_sscanf$24=sscanf(date_str, "%u-%u-%u %u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &end);
+      if(return_value_sscanf$24 >= 4)
+        tmp_if_expr$26 = 1 != 0;
+      else
+      {
+        return_value_sscanf$25=sscanf(date_str, "%u-%u-%u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &end);
+        tmp_if_expr$26 = (return_value_sscanf$25 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      tmp_if_expr$27 = (tmp_if_expr$26 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    else
+      tmp_if_expr$27 = 0 != 0;
+    if(!(tmp_if_expr$27 == (_Bool)0))
+    {
+      ptm->tm_year = ptm->tm_year - 1900;
+      ptm->tm_mon = ptm->tm_mon - 1;
+    }
+    else
+      if((signed int)*date_str == 64)
+      {
+        signed long int t;
+        t=bb_strtol(date_str + (signed long int)1, (char **)((void *)0), 10);
+        if(*bb_errno == 0)
+        {
+          struct tm *lt;
+          lt=localtime(&t);
+          if(!(lt == ((struct tm *)((void *)0))))
+          {
+            *ptm = *lt;
+            return;
+          }
+        }
+        end = (char)49;
+      }
+      else
+      {
+        unsigned int cur_year = (unsigned int)ptm->tm_year;
+        signed int len;
+        char *return_value_strchrnul$8;
+        return_value_strchrnul$8=strchrnul(date_str, 46);
+        len = (signed int)(return_value_strchrnul$8 - date_str);
+        if(len == 2)
+        {
+          return_value_sscanf$19=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)12, &ptm->tm_min, &end);
+          tmp_if_expr$20 = (return_value_sscanf$19 >= 1 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+          tmp_if_expr$20 = 0 != 0;
+        if(tmp_if_expr$20 == (_Bool)0)
+        {
+          if(len == 4)
+          {
+            return_value_sscanf$17=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)9, &ptm->tm_hour, &ptm->tm_min, &end);
+            tmp_if_expr$18 = (return_value_sscanf$17 >= 2 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+          }
+          else
+            tmp_if_expr$18 = 0 != 0;
+          if(tmp_if_expr$18 == (_Bool)0)
+          {
+            if(len == 6)
+            {
+              return_value_sscanf$15=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)6, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+              tmp_if_expr$16 = (return_value_sscanf$15 >= 3 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+            }
+            else
+              tmp_if_expr$16 = 0 != 0;
+            if(tmp_if_expr$16 == (_Bool)0)
+            {
+              if(len == 8)
+              {
+                return_value_sscanf$13=sscanf(date_str, "%2u%2u%2u%2u%2u%c" + (signed long int)3, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                tmp_if_expr$14 = (return_value_sscanf$13 >= 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+              }
+              else
+                tmp_if_expr$14 = 0 != 0;
+              if(!(tmp_if_expr$14 == (_Bool)0))
+                ptm->tm_mon = ptm->tm_mon - 1;
+              else
+              {
+                if(len == 10)
+                {
+                  return_value_sscanf$11=sscanf(date_str, "%2u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                  tmp_if_expr$12 = (return_value_sscanf$11 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                }
+                else
+                  tmp_if_expr$12 = 0 != 0;
+                if(!(tmp_if_expr$12 == (_Bool)0))
+                {
+                  ptm->tm_mon = ptm->tm_mon - 1;
+                  if((signed int)cur_year >= 50)
+                  {
+                    ptm->tm_year = ptm->tm_year + (signed int)((cur_year / (unsigned int)100) * (unsigned int)100);
+                    if(!((unsigned int)ptm->tm_year >= 4294967246u + cur_year))
+                      ptm->tm_year = ptm->tm_year + 100;
+                    if(!(50u + cur_year >= (unsigned int)ptm->tm_year))
+                      ptm->tm_year = ptm->tm_year - 100;
+                  }
+                }
+                else
+                {
+                  if(len == 12)
+                  {
+                    return_value_sscanf$9=sscanf(date_str, "%4u%2u%2u%2u%2u%c", &ptm->tm_year, &ptm->tm_mon, &ptm->tm_mday, &ptm->tm_hour, &ptm->tm_min, &end);
+                    tmp_if_expr$10 = (return_value_sscanf$9 >= 5 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  }
+                  else
+                    tmp_if_expr$10 = 0 != 0;
+                  if(!(tmp_if_expr$10 == (_Bool)0))
+                  {
+                    ptm->tm_year = ptm->tm_year - 1900;
+                    ptm->tm_mon = ptm->tm_mon - 1;
+                  }
+                  else
+                    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+                }
+              }
+            }
+          }
+        }
+        if((signed int)end == 46)
+        {
+          char *return_value___builtin_strchr$21;
+          return_value___builtin_strchr$21=strchr(date_str, 46);
+          signed int return_value_sscanf$22;
+          return_value_sscanf$22=sscanf(return_value___builtin_strchr$21 + (signed long int)1, "%u%c", &ptm->tm_sec, &end);
+          if(return_value_sscanf$22 == 1)
+            end = (char)0;
+        }
+      }
+  }
+  if(!((signed int)end == 0))
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+}
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  signed int fd;
+  signed int status = 0;
+  signed int opts;
+  char *reference_file = (char *)((void *)0);
+  char *date_str = (char *)((void *)0);
+  struct timeval timebuf[2l];
+  timebuf[(signed long int)0].tv_usec = (signed long int)0;
+  timebuf[(signed long int)1].tv_usec = timebuf[(signed long int)0].tv_usec;
+  static const char touch_longopts[49l] = { (const char)110, (const char)111, (const char)45, (const char)99, (const char)114, (const char)101, (const char)97, (const char)116, (const char)101, (const char)0, (const char)0, (const char)99, (const char)114, (const char)101, (const char)102, (const char)101, (const char)114, (const char)101, (const char)110, (const char)99, (const char)101, (const char)0, (const char)1, (const char)114, (const char)100, (const char)97, (const char)116, (const char)101, (const char)0, (const char)1, (const char)100, (const char)110, (const char)111, (const char)45, (const char)100, (const char)101, (const char)114, (const char)101, (const char)102, (const char)101, (const char)114, (const char)101, (const char)110, (const char)99, (const char)101, (const char)0, (const char)0, (const char)104, (const char)0 };
+  applet_long_options = touch_longopts;
+  unsigned int return_value_getopt32$1;
+  return_value_getopt32$1=getopt32(argv, "cr:d:t:hfma", &reference_file, &date_str, &date_str);
+  opts = (signed int)return_value_getopt32$1;
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+    bb_show_usage();
+  if(!(reference_file == ((char *)((void *)0))))
+  {
+    struct stat stbuf;
+    xstat(reference_file, &stbuf);
+    timebuf[(signed long int)0].tv_sec = stbuf.st_mtim.tv_sec;
+    timebuf[(signed long int)1].tv_sec = timebuf[(signed long int)0].tv_sec;
+  }
+  if(!(date_str == ((char *)((void *)0))))
+  {
+    struct tm tm_time;
+    signed long int t;
+    time(&t);
+    localtime_r(&t, &tm_time);
+    parse_datestr(date_str, &tm_time);
+    tm_time.tm_isdst = -1;
+    t=validate_tm_time(date_str, &tm_time);
+    timebuf[(signed long int)0].tv_sec = t;
+    timebuf[(signed long int)1].tv_sec = timebuf[(signed long int)0].tv_sec;
+  }
+  struct timeval *tmp_if_expr$2;
+  do
+  {
+    signed int result;
+    if(reference_file == ((char *)((void *)0)))
+    {
+      if(!(date_str == ((char *)((void *)0))))
+        goto __CPROVER_DUMP_L7;
+    }
+    else
+    {
+    __CPROVER_DUMP_L7:
+      ;
+      tmp_if_expr$2 = timebuf;
+      goto __CPROVER_DUMP_L9;
+    }
+    tmp_if_expr$2 = (struct timeval *)((void *)0);
+  __CPROVER_DUMP_L9:
+    ;
+    if(!(((16 & opts) != 0 ? lutimes : utimes) == ((void *)0)))
+      (void)0;
+    else
+      __VERIFIER_error();
+    result=((opts & 16) != 0 ? lutimes : utimes)(*argv, tmp_if_expr$2);
+    if(!(result == 0))
+    {
+      if(*bb_errno == 2)
+      {
+        if(!((1 & opts) == 0))
+          goto __CPROVER_DUMP_L25;
+        fd=open(*argv, 2 | 64, 438);
+        if(!(fd >= 0))
+          goto __CPROVER_DUMP_L22;
+        xclose(fd);
+        if(reference_file == ((char *)((void *)0)))
+        {
+          if(!(date_str == ((char *)((void *)0))))
+            goto __CPROVER_DUMP_L18;
+        }
+        else
+        {
+        __CPROVER_DUMP_L18:
+          ;
+          utimes(*argv, timebuf);
+        }
+      }
+      else
+      {
+      __CPROVER_DUMP_L22:
+        ;
+        status = 1;
+        bb_simple_perror_msg(*argv);
+      }
+    }
+  __CPROVER_DUMP_L25:
+    ;
+    argv = argv + 1l;
+  }
+  while(!(*argv == ((char *)((void *)0))));
+  return status;
+}
+static signed long int validate_tm_time(const char *date_str, struct tm *ptm)
+{
+  signed long int t;
+  t=mktime(ptm);
+  if(t == -1l)
+    bb_error_msg_and_die(bb_msg_invalid_date, date_str);
+  return t;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xclose(signed int fd)
+{
+  signed int return_value_close$1;
+  return_value_close$1=close(fd);
+  if(!(return_value_close$1 == 0))
+    bb_perror_msg_and_die("close failed");
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static void xstat(const char *name, struct stat *stat_buf)
+{
+  signed int return_value_stat$1;
+  return_value_stat$1=stat(name, stat_buf);
+  if(!(return_value_stat$1 == 0))
+    bb_perror_msg_and_die("can't stat '%s'", name);
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -307,7 +307,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2629,7 +2629,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/uname_false-no-overflow.c
+++ b/c/busybox-1.22.0/uname_false-no-overflow.c
@@ -1,0 +1,1063 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file coreutils/uname.c line 71
+struct anonymous;
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct anonymous
+{
+  // name
+  struct utsname name;
+  // processor
+  char processor[(signed long int)sizeof(char [65l]) /*65l*/ ];
+  // platform
+  char platform[(signed long int)sizeof(char [65l]) /*65l*/ ];
+  // os
+  char os[(signed long int)sizeof(char [10l]) /*10l*/ ];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file coreutils/uname.c line 78
+static const char options[10l] = { (const char)115, (const char)110, (const char)114, (const char)118, (const char)109, (const char)112, (const char)105, (const char)111, (const char)97, (const char)0 };
+// file coreutils/uname.c line 79
+static const unsigned short int utsname_offset[8l] = { (const unsigned short int)0ul, (const unsigned short int)65ul, (const unsigned short int)130ul, (const unsigned short int)195ul, (const unsigned short int)260ul, (const unsigned short int)390ul, (const unsigned short int)455ul, (const unsigned short int)520ul };
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/uname.c line 91
+signed int __main(signed int argc, char **argv)
+{
+  struct anonymous uname_info;
+  const char *unknown_str = "unknown";
+  const char *fmt;
+  const unsigned short int *delta;
+  unsigned int toprint;
+  static const char uname_longopts[137l] = { (const char)97, (const char)108, (const char)108, (const char)0, (const char)0, (const char)97, (const char)107, (const char)101, (const char)114, (const char)110, (const char)101, (const char)108, (const char)45, (const char)110, (const char)97, (const char)109, (const char)101, (const char)0, (const char)0, (const char)115, (const char)110, (const char)111, (const char)100, (const char)101, (const char)110, (const char)97, (const char)109, (const char)101, (const char)0, (const char)0, (const char)110, (const char)107, (const char)101, (const char)114, (const char)110, (const char)101, (const char)108, (const char)45, (const char)114, (const char)101, (const char)108, (const char)101, (const char)97, (const char)115, (const char)101, (const char)0, (const char)0, (const char)114, (const char)114, (const char)101, (const char)108, (const char)101, (const char)97, (const char)115, (const char)101, (const char)0, (const char)0, (const char)114, (const char)107, (const char)101, (const char)114, (const char)110, (const char)101, (const char)108, (const char)45, (const char)118, (const char)101, (const char)114, (const char)115, (const char)105, (const char)111, (const char)110, (const char)0, (const char)0, (const char)118, (const char)109, (const char)97, (const char)99, (const char)104, (const char)105, (const char)110, (const char)101, (const char)0, (const char)0, (const char)109, (const char)112, (const char)114, (const char)111, (const char)99, (const char)101, (const char)115, (const char)115, (const char)111, (const char)114, (const char)0, (const char)0, (const char)112, (const char)104, (const char)97, (const char)114, (const char)100, (const char)119, (const char)97, (const char)114, (const char)101, (const char)45, (const char)112, (const char)108, (const char)97, (const char)116, (const char)102, (const char)111, (const char)114, (const char)109, (const char)0, (const char)0, (const char)105, (const char)111, (const char)112, (const char)101, (const char)114, (const char)97, (const char)116, (const char)105, (const char)110, (const char)103, (const char)45, (const char)115, (const char)121, (const char)115, (const char)116, (const char)101, (const char)109, (const char)0, (const char)0, (const char)111, (const char)0 };
+  applet_long_options = uname_longopts;
+  toprint=getopt32(argv, options);
+
+  if(!(argv[(signed long int)optind] == ((char *)NULL)))
+    bb_show_usage();
+
+  if(!((256u & toprint) == 0u))
+  {
+    toprint = (unsigned int)((1 << 8) - 1);
+    unknown_str = "";
+  }
+
+  if(toprint == 0u)
+    toprint = (unsigned int)1;
+
+  uname(&uname_info.name);
+  strcpy(uname_info.processor, unknown_str);
+  strcpy(uname_info.platform, unknown_str);
+  strcpy(uname_info.os, "GNU/Linux");
+  delta = utsname_offset;
+  fmt = " %s" + (signed long int)1;
+  while((_Bool)1)
+  {
+    if(!((1u & toprint) == 0u))
+    {
+      const char *p = (char *)&uname_info + (signed long int)*delta;
+      if(!((signed int)*p == 0))
+      {
+        printf(fmt, p);
+        fmt = " %s";
+      }
+
+    }
+
+    delta = delta + 1l;
+    toprint = toprint >> 1;
+    if(toprint == 0u)
+      break;
+
+  }
+  bb_putchar(10);
+  // fflush_stdout_and_exit(0); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return 0;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/uname_false-no-overflow.i
+++ b/c/busybox-1.22.0/uname_false-no-overflow.i
@@ -1,0 +1,3074 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct utsname
+  {
+    char sysname[65];
+    char nodename[65];
+    char release[65];
+    char version[65];
+    char machine[65];
+    char domainname[65];
+  };
+extern int uname (struct utsname *__name) __attribute__ ((__nothrow__ , __leaf__));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct anonymous;
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static signed int bb_putchar(signed int ch);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct anonymous
+{
+  struct utsname name;
+  char processor[(signed long int)sizeof(char [65l]) ];
+  char platform[(signed long int)sizeof(char [65l]) ];
+  char os[(signed long int)sizeof(char [10l]) ];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static const char options[10l] = { (const char)115, (const char)110, (const char)114, (const char)118, (const char)109, (const char)112, (const char)105, (const char)111, (const char)97, (const char)0 };
+static const unsigned short int utsname_offset[8l] = { (const unsigned short int)0ul, (const unsigned short int)65ul, (const unsigned short int)130ul, (const unsigned short int)195ul, (const unsigned short int)260ul, (const unsigned short int)390ul, (const unsigned short int)455ul, (const unsigned short int)520ul };
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct anonymous uname_info;
+  const char *unknown_str = "unknown";
+  const char *fmt;
+  const unsigned short int *delta;
+  unsigned int toprint;
+  static const char uname_longopts[137l] = { (const char)97, (const char)108, (const char)108, (const char)0, (const char)0, (const char)97, (const char)107, (const char)101, (const char)114, (const char)110, (const char)101, (const char)108, (const char)45, (const char)110, (const char)97, (const char)109, (const char)101, (const char)0, (const char)0, (const char)115, (const char)110, (const char)111, (const char)100, (const char)101, (const char)110, (const char)97, (const char)109, (const char)101, (const char)0, (const char)0, (const char)110, (const char)107, (const char)101, (const char)114, (const char)110, (const char)101, (const char)108, (const char)45, (const char)114, (const char)101, (const char)108, (const char)101, (const char)97, (const char)115, (const char)101, (const char)0, (const char)0, (const char)114, (const char)114, (const char)101, (const char)108, (const char)101, (const char)97, (const char)115, (const char)101, (const char)0, (const char)0, (const char)114, (const char)107, (const char)101, (const char)114, (const char)110, (const char)101, (const char)108, (const char)45, (const char)118, (const char)101, (const char)114, (const char)115, (const char)105, (const char)111, (const char)110, (const char)0, (const char)0, (const char)118, (const char)109, (const char)97, (const char)99, (const char)104, (const char)105, (const char)110, (const char)101, (const char)0, (const char)0, (const char)109, (const char)112, (const char)114, (const char)111, (const char)99, (const char)101, (const char)115, (const char)115, (const char)111, (const char)114, (const char)0, (const char)0, (const char)112, (const char)104, (const char)97, (const char)114, (const char)100, (const char)119, (const char)97, (const char)114, (const char)101, (const char)45, (const char)112, (const char)108, (const char)97, (const char)116, (const char)102, (const char)111, (const char)114, (const char)109, (const char)0, (const char)0, (const char)105, (const char)111, (const char)112, (const char)101, (const char)114, (const char)97, (const char)116, (const char)105, (const char)110, (const char)103, (const char)45, (const char)115, (const char)121, (const char)115, (const char)116, (const char)101, (const char)109, (const char)0, (const char)0, (const char)111, (const char)0 };
+  applet_long_options = uname_longopts;
+  toprint=getopt32(argv, options);
+  if(!(argv[(signed long int)optind] == ((char *)((void *)0))))
+    bb_show_usage();
+  if(!((256u & toprint) == 0u))
+  {
+    toprint = (unsigned int)((1 << 8) - 1);
+    unknown_str = "";
+  }
+  if(toprint == 0u)
+    toprint = (unsigned int)1;
+  uname(&uname_info.name);
+  strcpy(uname_info.processor, unknown_str);
+  strcpy(uname_info.platform, unknown_str);
+  strcpy(uname_info.os, "GNU/Linux");
+  delta = utsname_offset;
+  fmt = " %s" + (signed long int)1;
+  while((_Bool)1)
+  {
+    if(!((1u & toprint) == 0u))
+    {
+      const char *p = (char *)&uname_info + (signed long int)*delta;
+      if(!((signed int)*p == 0))
+      {
+        printf(fmt, p);
+        fmt = " %s";
+      }
+    }
+    delta = delta + 1l;
+    toprint = toprint >> 1;
+    if(toprint == 0u)
+      break;
+  }
+  bb_putchar(10);
+  fflush(stdout);
+  return 0;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.c
@@ -234,7 +234,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.i
@@ -2275,7 +2275,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/uniq_false-no-overflow.c
+++ b/c/busybox-1.22.0/uniq_false-no-overflow.c
@@ -1,0 +1,1295 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/xfuncs_printf.c line 269
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file libbb/skip_whitespace.c line 26
+static char * skip_non_whitespace(const char *s);
+// file include/libbb.h line 313
+static char * skip_whitespace(const char *s);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file libbb/xfuncs_printf.c line 213
+static void xdup2(signed int from, signed int to);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/get_line_from_file.c line 53
+static char * xmalloc_fgetline(struct _IO_FILE *file);
+// file libbb/xfuncs_printf.c line 220
+static void xmove_fd(signed int from, signed int to);
+// file include/libbb.h line 477
+static signed int xopen(const char *pathname, signed int flags);
+// file libbb/xfuncs_printf.c line 126
+static signed int xopen3(const char *pathname, signed int flags, signed int mode);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)NULL;
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=getc(file);
+    if(ch == -1)
+      break;
+
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+
+    if(!(end == ((signed int *)NULL)))
+    {
+      if(ch == 10)
+        break;
+
+    }
+
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)NULL)))
+    *end = (signed int)idx;
+
+  if(!(linebuf == ((char *)NULL)))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+
+  return linebuf;
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/xfuncs_printf.c line 269
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn)
+{
+  signed int return_value_ferror$1;
+  return_value_ferror$1=ferror(fp);
+  if(!(return_value_ferror$1 == 0))
+    bb_error_msg_and_die("%s: I/O error", fn);
+
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file libbb/skip_whitespace.c line 26
+static char * skip_non_whitespace(const char *s)
+{
+  for( ; !((signed int)*s == 0); s = s + 1l)
+  {
+    if((signed int)*s == 32)
+      break;
+
+    if(!(247 + (signed int)(unsigned char)(signed int)*s > 4))
+      break;
+
+  }
+  return (char *)s;
+}
+
+// file include/libbb.h line 313
+static char * skip_whitespace(const char *s)
+{
+  for( ; (_Bool)1; s = s + 1l)
+    if(!((signed int)*s == 32))
+    {
+      if(!(247 + (signed int)(unsigned char)(signed int)*s <= 4))
+        break;
+
+    }
+
+  return (char *)s;
+}
+
+// file coreutils/uniq.c line 33
+signed int __main(signed int argc, char **argv)
+{
+  const char *input_filename;
+  unsigned int skip_fields;
+  unsigned int skip_chars;
+  unsigned int max_chars;
+  unsigned int opt;
+  char *cur_line;
+  const char *cur_compare;
+  skip_chars = (unsigned int)0;
+  skip_fields = skip_chars;
+  max_chars = (unsigned int)2147483647;
+  opt_complementary = "f+:s+:w+";
+  opt=getopt32(argv, "cduf:s:w:", &skip_fields, &skip_chars, &max_chars);
+  argv = argv + (signed long int)optind;
+
+  input_filename = argv[(signed long int)0];
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$3;
+  if(!(input_filename == ((const char *)NULL)))
+  {
+    const char *output;
+
+    if(!((signed int)*input_filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+    {
+
+      tmp_if_expr$1 = ((signed int)input_filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+    {
+      close(0);
+      xopen(input_filename, 0);
+    }
+
+
+    output = argv[(signed long int)1];
+    if(!(output == ((const char *)NULL)))
+    {
+
+      if(!(*(2l + argv) == ((char *)NULL)))
+        bb_show_usage();
+
+
+      if(!((signed int)*output == 45))
+        tmp_if_expr$3 = 1 != 0;
+
+      else
+      {
+
+        tmp_if_expr$3 = ((signed int)output[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        signed int return_value_xopen$2;
+        return_value_xopen$2=xopen(output, 1 | 64 | 512);
+        xmove_fd(return_value_xopen$2, 1);
+      }
+
+    }
+
+  }
+
+  cur_line = (char *)NULL;
+  cur_compare = cur_line;
+  _Bool tmp_if_expr$5;
+  signed int return_value_strncmp$4;
+  do
+  {
+    unsigned int i;
+    unsigned long int dups;
+    char *old_line;
+    const char *old_compare;
+    old_line = cur_line;
+    old_compare = cur_compare;
+    dups = (unsigned long int)0;
+    do
+    {
+      cur_line=xmalloc_fgetline(stdin);
+      if(cur_line == ((char *)NULL))
+        break;
+
+      cur_compare = cur_line;
+      i = skip_fields;
+      for( ; !(i == 0u); i = i - 1u)
+      {
+        cur_compare=skip_whitespace(cur_compare);
+        cur_compare=skip_non_whitespace(cur_compare);
+      }
+      i = skip_chars;
+      while((_Bool)1)
+      {
+
+        if(i == 0u || (signed int)*cur_compare == 0)
+          break;
+
+        cur_compare = cur_compare + 1l;
+        i = i - 1u;
+      }
+      if(old_line == ((char *)NULL))
+        tmp_if_expr$5 = 1 != 0;
+
+      else
+      {
+        return_value_strncmp$4=strncmp(old_compare, cur_compare, (unsigned long int)max_chars);
+        tmp_if_expr$5 = (return_value_strncmp$4 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(tmp_if_expr$5 != (_Bool)0)
+        break;
+
+      free((void *)cur_line);
+      dups = dups + 1ul;
+    }
+    while((_Bool)1);
+    if(!(old_line == ((char *)NULL)))
+    {
+      if((opt & (unsigned int)(2 << (signed int)!(dups == 0ul))) == 0u)
+      {
+        if(!((1u & opt) == 0u))
+          printf("%7lu ", dups + (unsigned long int)1);
+
+        printf("%s\n", old_line);
+      }
+
+      free((void *)old_line);
+    }
+
+  }
+  while(!(cur_line == ((char *)NULL)));
+  die_if_ferror(stdin, input_filename);
+  // fflush_stdout_and_exit(0); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return 0;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file libbb/xfuncs_printf.c line 213
+static void xdup2(signed int from, signed int to)
+{
+  signed int return_value_dup2$1;
+  return_value_dup2$1=dup2(from, to);
+  if(!(return_value_dup2$1 == to))
+    bb_perror_msg_and_die("can't duplicate file descriptor");
+
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/get_line_from_file.c line 53
+static char * xmalloc_fgetline(struct _IO_FILE *file)
+{
+  signed int i;
+  char *c;
+  c=bb_get_chunk_from_file(file, &i);
+  if(!(i == 0))
+  {
+    i = i - 1;
+    if((signed int)c[(signed long int)i] == 10)
+      c[(signed long int)i] = (char)0;
+
+  }
+
+  return c;
+}
+
+// file libbb/xfuncs_printf.c line 220
+static void xmove_fd(signed int from, signed int to)
+{
+  if(from == to)
+    return;
+
+  xdup2(from, to);
+  close(from);
+}
+
+// file include/libbb.h line 477
+static signed int xopen(const char *pathname, signed int flags)
+{
+  signed int return_value_xopen3$1;
+  return_value_xopen3$1=xopen3(pathname, flags, 438);
+  return return_value_xopen3$1;
+}
+
+// file libbb/xfuncs_printf.c line 126
+static signed int xopen3(const char *pathname, signed int flags, signed int mode)
+{
+  signed int ret;
+  ret=open(pathname, flags, mode);
+  if(ret < 0)
+    bb_perror_msg_and_die("can't open '%s'", pathname);
+
+  return ret;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/uniq_false-no-overflow.i
+++ b/c/busybox-1.22.0/uniq_false-no-overflow.i
@@ -1,0 +1,3355 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+struct flock
+  {
+    short int l_type;
+    short int l_whence;
+    __off_t l_start;
+    __off_t l_len;
+    __pid_t l_pid;
+  };
+struct flock64
+  {
+    short int l_type;
+    short int l_whence;
+    __off64_t l_start;
+    __off64_t l_len;
+    __pid_t l_pid;
+  };
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __uid_t uid_t;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __pid_t pid_t;
+typedef __id_t id_t;
+typedef __ssize_t ssize_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef long unsigned int size_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+typedef __sigset_t sigset_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+
+struct iovec
+  {
+    void *iov_base;
+    size_t iov_len;
+  };
+enum __pid_type
+  {
+    F_OWNER_TID = 0,
+    F_OWNER_PID,
+    F_OWNER_PGRP,
+    F_OWNER_GID = F_OWNER_PGRP
+  };
+struct f_owner_ex
+  {
+    enum __pid_type type;
+    __pid_t pid;
+  };
+struct file_handle
+{
+  unsigned int handle_bytes;
+  int handle_type;
+  unsigned char f_handle[0];
+};
+
+extern ssize_t readahead (int __fd, __off64_t __offset, size_t __count)
+    __attribute__ ((__nothrow__ , __leaf__));
+extern int sync_file_range (int __fd, __off64_t __offset, __off64_t __count,
+       unsigned int __flags);
+extern ssize_t vmsplice (int __fdout, const struct iovec *__iov,
+    size_t __count, unsigned int __flags);
+extern ssize_t splice (int __fdin, __off64_t *__offin, int __fdout,
+         __off64_t *__offout, size_t __len,
+         unsigned int __flags);
+extern ssize_t tee (int __fdin, int __fdout, size_t __len,
+      unsigned int __flags);
+extern int fallocate (int __fd, int __mode, __off_t __offset, __off_t __len);
+extern int fallocate64 (int __fd, int __mode, __off64_t __offset,
+   __off64_t __len);
+extern int name_to_handle_at (int __dfd, const char *__name,
+         struct file_handle *__handle, int *__mnt_id,
+         int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern int open_by_handle_at (int __mountdirfd, struct file_handle *__handle,
+         int __flags);
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int fcntl (int __fd, int __cmd, ...);
+extern int open (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int open64 (const char *__file, int __oflag, ...) __attribute__ ((__nonnull__ (1)));
+extern int openat (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int openat64 (int __fd, const char *__file, int __oflag, ...)
+     __attribute__ ((__nonnull__ (2)));
+extern int creat (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int creat64 (const char *__file, mode_t __mode) __attribute__ ((__nonnull__ (1)));
+extern int lockf (int __fd, int __cmd, off_t __len);
+extern int lockf64 (int __fd, int __cmd, off64_t __len);
+extern int posix_fadvise (int __fd, off_t __offset, off_t __len,
+     int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fadvise64 (int __fd, off64_t __offset, off64_t __len,
+       int __advise) __attribute__ ((__nothrow__ , __leaf__));
+extern int posix_fallocate (int __fd, off_t __offset, off_t __len);
+extern int posix_fallocate64 (int __fd, off64_t __offset, off64_t __len);
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static char * skip_non_whitespace(const char *s);
+static char * skip_whitespace(const char *s);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xdup2(signed int from, signed int to);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_fgetline(struct _IO_FILE *file);
+static void xmove_fd(signed int from, signed int to);
+static signed int xopen(const char *pathname, signed int flags);
+static signed int xopen3(const char *pathname, signed int flags, signed int mode);
+static void * xrealloc(void *ptr, unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)((void *)0);
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=_IO_getc (file);
+    if(ch == -1)
+      break;
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+    if(!(end == ((signed int *)((void *)0))))
+    {
+      if(ch == 10)
+        break;
+    }
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)((void *)0))))
+    *end = (signed int)idx;
+  if(!(linebuf == ((char *)((void *)0))))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+  return linebuf;
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static void die_if_ferror(struct _IO_FILE *fp, const char *fn)
+{
+  signed int return_value_ferror$1;
+  return_value_ferror$1=ferror(fp);
+  if(!(return_value_ferror$1 == 0))
+    bb_error_msg_and_die("%s: I/O error", fn);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static char * skip_non_whitespace(const char *s)
+{
+  for( ; !((signed int)*s == 0); s = s + 1l)
+  {
+    if((signed int)*s == 32)
+      break;
+    if(!(247 + (signed int)(unsigned char)(signed int)*s > 4))
+      break;
+  }
+  return (char *)s;
+}
+static char * skip_whitespace(const char *s)
+{
+  for( ; (_Bool)1; s = s + 1l)
+    if(!((signed int)*s == 32))
+    {
+      if(!(247 + (signed int)(unsigned char)(signed int)*s <= 4))
+        break;
+    }
+  return (char *)s;
+}
+signed int __main(signed int argc, char **argv)
+{
+  const char *input_filename;
+  unsigned int skip_fields;
+  unsigned int skip_chars;
+  unsigned int max_chars;
+  unsigned int opt;
+  char *cur_line;
+  const char *cur_compare;
+  skip_chars = (unsigned int)0;
+  skip_fields = skip_chars;
+  max_chars = (unsigned int)2147483647;
+  opt_complementary = "f+:s+:w+";
+  opt=getopt32(argv, "cduf:s:w:", &skip_fields, &skip_chars, &max_chars);
+  argv = argv + (signed long int)optind;
+  input_filename = argv[(signed long int)0];
+  _Bool tmp_if_expr$1;
+  _Bool tmp_if_expr$3;
+  if(!(input_filename == ((const char *)((void *)0))))
+  {
+    const char *output;
+    if(!((signed int)*input_filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+    {
+      tmp_if_expr$1 = ((signed int)input_filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$1 == (_Bool)0))
+    {
+      close(0);
+      xopen(input_filename, 0);
+    }
+    output = argv[(signed long int)1];
+    if(!(output == ((const char *)((void *)0))))
+    {
+      if(!(*(2l + argv) == ((char *)((void *)0))))
+        bb_show_usage();
+      if(!((signed int)*output == 45))
+        tmp_if_expr$3 = 1 != 0;
+      else
+      {
+        tmp_if_expr$3 = ((signed int)output[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        signed int return_value_xopen$2;
+        return_value_xopen$2=xopen(output, 1 | 64 | 512);
+        xmove_fd(return_value_xopen$2, 1);
+      }
+    }
+  }
+  cur_line = (char *)((void *)0);
+  cur_compare = cur_line;
+  _Bool tmp_if_expr$5;
+  signed int return_value_strncmp$4;
+  do
+  {
+    unsigned int i;
+    unsigned long int dups;
+    char *old_line;
+    const char *old_compare;
+    old_line = cur_line;
+    old_compare = cur_compare;
+    dups = (unsigned long int)0;
+    do
+    {
+      cur_line=xmalloc_fgetline(stdin);
+      if(cur_line == ((char *)((void *)0)))
+        break;
+      cur_compare = cur_line;
+      i = skip_fields;
+      for( ; !(i == 0u); i = i - 1u)
+      {
+        cur_compare=skip_whitespace(cur_compare);
+        cur_compare=skip_non_whitespace(cur_compare);
+      }
+      i = skip_chars;
+      while((_Bool)1)
+      {
+        if(i == 0u || (signed int)*cur_compare == 0)
+          break;
+        cur_compare = cur_compare + 1l;
+        i = i - 1u;
+      }
+      if(old_line == ((char *)((void *)0)))
+        tmp_if_expr$5 = 1 != 0;
+      else
+      {
+        return_value_strncmp$4=strncmp(old_compare, cur_compare, (unsigned long int)max_chars);
+        tmp_if_expr$5 = (return_value_strncmp$4 != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(tmp_if_expr$5 != (_Bool)0)
+        break;
+      free((void *)cur_line);
+      dups = dups + 1ul;
+    }
+    while((_Bool)1);
+    if(!(old_line == ((char *)((void *)0))))
+    {
+      if((opt & (unsigned int)(2 << (signed int)!(dups == 0ul))) == 0u)
+      {
+        if(!((1u & opt) == 0u))
+          printf("%7lu ", dups + (unsigned long int)1);
+        printf("%s\n", old_line);
+      }
+      free((void *)old_line);
+    }
+  }
+  while(!(cur_line == ((char *)((void *)0))));
+  die_if_ferror(stdin, input_filename);
+  fflush(stdout);
+  return 0;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xdup2(signed int from, signed int to)
+{
+  signed int return_value_dup2$1;
+  return_value_dup2$1=dup2(from, to);
+  if(!(return_value_dup2$1 == to))
+    bb_perror_msg_and_die("can't duplicate file descriptor");
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_fgetline(struct _IO_FILE *file)
+{
+  signed int i;
+  char *c;
+  c=bb_get_chunk_from_file(file, &i);
+  if(!(i == 0))
+  {
+    i = i - 1;
+    if((signed int)c[(signed long int)i] == 10)
+      c[(signed long int)i] = (char)0;
+  }
+  return c;
+}
+static void xmove_fd(signed int from, signed int to)
+{
+  if(from == to)
+    return;
+  xdup2(from, to);
+  close(from);
+}
+static signed int xopen(const char *pathname, signed int flags)
+{
+  signed int return_value_xopen3$1;
+  return_value_xopen3$1=xopen3(pathname, flags, 438);
+  return return_value_xopen3$1;
+}
+static signed int xopen3(const char *pathname, signed int flags, signed int mode)
+{
+  signed int ret;
+  ret=open(pathname, flags, mode);
+  if(ret < 0)
+    bb_perror_msg_and_die("can't open '%s'", pathname);
+  return ret;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.c
@@ -274,7 +274,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.i
@@ -2409,7 +2409,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/usleep_false-no-overflow.c
+++ b/c/busybox-1.22.0/usleep_false-no-overflow.c
@@ -1,0 +1,384 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file libbb/xatonum_template.c line 116
+static unsigned int xatou(const char *numstr);
+// file libbb/xatonum_template.c line 110
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/usleep.c line 26
+signed int __main(signed int argc, char **argv)
+{
+
+  if(*(1l + argv) == ((char *)NULL))
+    return 1;
+
+  unsigned int return_value_xatou$1;
+
+  return_value_xatou$1=xatou(argv[(signed long int)1]);
+  usleep(return_value_xatou$1);
+  return 0;
+}
+
+// file libbb/xatonum_template.c line 116
+static unsigned int xatou(const char *numstr)
+{
+  unsigned int return_value_xatou_sfx$1;
+  return_value_xatou_sfx$1=xatou_sfx(numstr, (struct suffix_mult *)NULL);
+  return return_value_xatou_sfx$1;
+}
+
+// file libbb/xatonum_template.c line 110
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, (unsigned int)0, (unsigned int)2147483647 * 2u + 1u, suffixes);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/usleep_false-no-overflow.i
+++ b/c/busybox-1.22.0/usleep_false-no-overflow.i
@@ -1,0 +1,2583 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static unsigned int xatou(const char *numstr);
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes);
+static void xfunc_die(void);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  if(*(1l + argv) == ((char *)((void *)0)))
+    return 1;
+  unsigned int return_value_xatou$1;
+  return_value_xatou$1=xatou(argv[(signed long int)1]);
+  usleep(return_value_xatou$1);
+  return 0;
+}
+static unsigned int xatou(const char *numstr)
+{
+  unsigned int return_value_xatou_sfx$1;
+  return_value_xatou_sfx$1=xatou_sfx(numstr, (struct suffix_mult *)((void *)0));
+  return return_value_xatou_sfx$1;
+}
+static unsigned int xatou_sfx(const char *numstr, struct suffix_mult *suffixes)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, (unsigned int)0, (unsigned int)2147483647 * 2u + 1u, suffixes);
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.c
@@ -125,7 +125,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.i
@@ -2261,7 +2261,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/uudecode_false-no-overflow.c
+++ b/c/busybox-1.22.0/uudecode_false-no-overflow.c
@@ -1,0 +1,1860 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a);
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/bb_strtonum.c line 127
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/uuencode.c line 82
+static const char * decode_base64(char **pp_dst, const char *src);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/uuencode.c line 162
+static void read_base64(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags);
+// file coreutils/uudecode.c line 28
+static void read_stduu(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags);
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// 
+void decode_fn_ptr$object(struct _IO_FILE *, struct _IO_FILE *, signed int);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 788
+static struct _IO_FILE * xfopen(const char *path, const char *mode);
+// file libbb/wfopen.c line 37
+static struct _IO_FILE * xfopen_for_write(const char *path);
+// file libbb/wfopen_input.c line 29
+static struct _IO_FILE * xfopen_stdin(const char *filename);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/get_line_from_file.c line 53
+static char * xmalloc_fgetline(struct _IO_FILE *file);
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/uuencode.c line 13
+static const char bb_uuenc_tbl_base64[66l] = { (const char)65, (const char)66, (const char)67, (const char)68, (const char)69, (const char)70, (const char)71, (const char)72, (const char)73, (const char)74, (const char)75, (const char)76, (const char)77, (const char)78, (const char)79, (const char)80, (const char)81, (const char)82, (const char)83, (const char)84, (const char)85, (const char)86, (const char)87, (const char)88, (const char)89, (const char)90, (const char)97, (const char)98, (const char)99, (const char)100, (const char)101, (const char)102, (const char)103, (const char)104, (const char)105, (const char)106, (const char)107, (const char)108, (const char)109, (const char)110, (const char)111, (const char)112, (const char)113, (const char)114, (const char)115, (const char)116, (const char)117, (const char)118, (const char)119, (const char)120, (const char)121, (const char)122, (const char)48, (const char)49, (const char)50, (const char)51, (const char)52, (const char)53, (const char)54, (const char)55, (const char)56, (const char)57, (const char)43, (const char)47, (const char)61, (const char)0 };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1887
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/get_line_from_file.c line 14
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)NULL;
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=getc(file);
+    if(ch == -1)
+      break;
+
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+
+    if(!(end == ((signed int *)NULL)))
+    {
+      if(ch == 10)
+        break;
+
+    }
+
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)NULL)))
+    *end = (signed int)idx;
+
+  if(!(linebuf == ((char *)NULL)))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+
+  return linebuf;
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/bb_strtonum.c line 127
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base)
+{
+  unsigned long int v;
+  char *endptr;
+  if(endp == ((char **)NULL))
+    endp = &endptr;
+
+  *endp = (char *)arg;
+  signed int return_value_bb_ascii_isalnum$2;
+  return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(arg[(signed long int)0]);
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(return_value_bb_ascii_isalnum$2 == 0)
+  {
+    return_value_ret_ERANGE$1=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$1;
+  }
+
+  *bb_errno = 0;
+  v=strtoul(arg, endp, base);
+  unsigned long long int return_value_ret_ERANGE$3;
+  if(v > 4294967295ul)
+  {
+    return_value_ret_ERANGE$3=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$3;
+  }
+
+  unsigned long long int return_value_handle_errors$4;
+  return_value_handle_errors$4=handle_errors(v, endp);
+  return (unsigned int)return_value_handle_errors$4;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/uuencode.c line 82
+static const char * decode_base64(char **pp_dst, const char *src)
+{
+  char *dst = *pp_dst;
+  const char *src_tail;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  char *tmp_post$4;
+  while((_Bool)1)
+  {
+    unsigned char six_bit[4l];
+    signed int count = 0;
+    src_tail = src;
+    while(count < 4)
+    {
+      char *table_ptr;
+      signed int ch;
+      do
+      {
+        ch = (signed int)*src;
+        if(ch == 0)
+        {
+          if(count == 0)
+            src_tail = src;
+
+          goto ret;
+        }
+
+        src = src + 1l;
+        char *return_value___builtin_strchr$1;
+        return_value___builtin_strchr$1=strchr(bb_uuenc_tbl_base64, ch);
+        table_ptr = return_value___builtin_strchr$1;
+      }
+      while(table_ptr == ((char *)NULL));
+      ch = (signed int)(table_ptr - bb_uuenc_tbl_base64);
+      if(ch == 64)
+        break;
+
+      six_bit[(signed long int)count] = (unsigned char)ch;
+      count = count + 1;
+    }
+    if(count > 1)
+    {
+      tmp_post$2 = dst;
+      dst = dst + 1l;
+      *tmp_post$2 = (char)((signed int)six_bit[(signed long int)0] << 2 | (signed int)six_bit[(signed long int)1] >> 4);
+    }
+
+    if(count > 2)
+    {
+      tmp_post$3 = dst;
+      dst = dst + 1l;
+      *tmp_post$3 = (char)((signed int)six_bit[(signed long int)1] << 4 | (signed int)six_bit[(signed long int)2] >> 2);
+    }
+
+    if(count > 3)
+    {
+      tmp_post$4 = dst;
+      dst = dst + 1l;
+      *tmp_post$4 = (char)((signed int)six_bit[(signed long int)2] << 6 | (signed int)six_bit[(signed long int)3]);
+    }
+
+  }
+
+ret:
+  ;
+  *pp_dst = dst;
+  return src_tail;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file libbb/bb_strtonum.c line 39
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+
+    *bb_errno = 22;
+  }
+
+  return v;
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/uuencode.c line 162
+static void read_base64(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags)
+{
+  char in_buf[66l];
+  char out_buf[50l];
+  char *out_tail;
+  const char *in_tail;
+  signed int term_seen = 0;
+  signed int in_count = 0;
+  signed int tmp_post$1;
+  signed int tmp_statement_expression$2;
+  _Bool tmp_if_expr$3;
+  signed int tmp_if_expr$6;
+  signed int tmp_statement_expression$4;
+  signed int return_value___builtin_strcmp$5;
+  while((_Bool)1)
+  {
+    while(in_count < 64)
+    {
+      signed int ch;
+      ch=getc(src_stream);
+      if(ch == (signed int)(signed char)flags)
+      {
+        if(in_count == 0)
+          return;
+
+        term_seen = 1;
+        break;
+      }
+
+      if(ch == -1)
+      {
+        term_seen = 1;
+        break;
+      }
+
+      if(ch <= 32)
+        break;
+
+      tmp_post$1 = in_count;
+      in_count = in_count + 1;
+      in_buf[(signed long int)tmp_post$1] = (char)ch;
+    }
+    in_buf[(signed long int)in_count] = (char)0;
+    if(!((256 & flags) == 0))
+    {
+      unsigned long int __s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("====" + 1l) + -((unsigned long int)"====") == 1ul))
+          goto __CPROVER_DUMP_L8;
+
+        __s2_len=strlen("====");
+        tmp_if_expr$3 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L8:
+        ;
+        tmp_if_expr$3 = 0 != 0;
+      }
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)in_buf;
+        signed int __result = (signed int)((const char *)"====")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+            __result = (signed int)((const char *)"====")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"====")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                    __result = (signed int)((const char *)"====")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+
+        tmp_statement_expression$4 = __result;
+        tmp_if_expr$6 = -tmp_statement_expression$4;
+      }
+
+      else
+      {
+        return_value___builtin_strcmp$5=strcmp(in_buf, "====");
+        tmp_if_expr$6 = return_value___builtin_strcmp$5;
+      }
+      tmp_statement_expression$2 = tmp_if_expr$6;
+      if(tmp_statement_expression$2 == 0)
+        return;
+
+    }
+
+    out_tail = out_buf;
+    in_tail=decode_base64(&out_tail, in_buf);
+    fwrite((const void *)out_buf, (unsigned long int)(out_tail - out_buf), (unsigned long int)1, dst_stream);
+    if(!(term_seen == 0))
+    {
+      if((signed int)*in_tail == 0)
+        return;
+
+      bb_error_msg_and_die("truncated base64 input");
+    }
+
+    unsigned long int return_value_strlen$7;
+    return_value_strlen$7=strlen(in_tail);
+    in_count = (signed int)return_value_strlen$7;
+    memmove((void *)in_buf, (const void *)in_tail, (unsigned long int)in_count);
+  }
+}
+
+// file coreutils/uudecode.c line 28
+static void read_stduu(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags)
+{
+  char *line;
+  signed int tmp_statement_expression$1;
+  _Bool tmp_if_expr$2;
+  signed int tmp_if_expr$5;
+  signed int tmp_statement_expression$3;
+  signed int return_value___builtin_strcmp$4;
+  char *tmp_post$6;
+  char *tmp_post$7;
+  char *tmp_post$8;
+  do
+  {
+    line=xmalloc_fgetline(src_stream);
+    if(line == ((char *)NULL))
+      break;
+
+    signed int encoded_len;
+    signed int str_len;
+    char *line_ptr;
+    char *dst;
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    if((_Bool)1)
+    {
+      if(!((unsigned long int)("end" + 1l) + -((unsigned long int)"end") == 1ul))
+        goto __CPROVER_DUMP_L2;
+
+      __s2_len=strlen("end");
+      tmp_if_expr$2 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L2:
+      ;
+      tmp_if_expr$2 = 0 != 0;
+    }
+    if(!(tmp_if_expr$2 == (_Bool)0))
+    {
+      const char *__s2 = (const char *)line;
+      signed int __result;
+
+      __result = (signed int)((const char *)"end")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+      if(__s2_len > 0ul)
+      {
+        if(__result == 0)
+        {
+
+
+          __result = (signed int)((const char *)"end")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+          if(__s2_len > 1ul)
+          {
+            if(__result == 0)
+            {
+
+
+              __result = (signed int)((const char *)"end")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+              if(__s2_len > 2ul)
+              {
+                if(__result == 0)
+                {
+
+
+                  __result = (signed int)((const char *)"end")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+
+      }
+
+      tmp_statement_expression$3 = __result;
+      tmp_if_expr$5 = -tmp_statement_expression$3;
+    }
+
+    else
+    {
+      return_value___builtin_strcmp$4=strcmp(line, "end");
+      tmp_if_expr$5 = return_value___builtin_strcmp$4;
+    }
+    tmp_statement_expression$1 = tmp_if_expr$5;
+    if(tmp_statement_expression$1 == 0)
+      return;
+
+    line_ptr = line;
+    while((_Bool)1)
+    {
+
+      if((signed int)*line_ptr == 0)
+        break;
+
+      *line_ptr = (char)((signed int)*line_ptr - 32 & 63);
+      line_ptr = line_ptr + 1l;
+    }
+    str_len = (signed int)(line_ptr - line);
+
+    encoded_len = ((signed int)line[(signed long int)0] * 4) / 3;
+    if(encoded_len >= str_len)
+      break;
+
+    if(encoded_len <= 0)
+      free((void *)line);
+
+    else
+    {
+      if(encoded_len > 60)
+        bb_error_msg_and_die("line too long");
+
+      dst = line;
+      line_ptr = line + (signed long int)1;
+      do
+      {
+        tmp_post$6 = dst;
+        dst = dst + 1l;
+
+
+
+        *tmp_post$6 = (char)((signed int)line_ptr[(signed long int)0] << 2 | (signed int)line_ptr[(signed long int)1] >> 4);
+        encoded_len = encoded_len - 1;
+        if(encoded_len == 0)
+          break;
+
+        tmp_post$7 = dst;
+        dst = dst + 1l;
+
+
+
+        *tmp_post$7 = (char)((signed int)line_ptr[(signed long int)1] << 4 | (signed int)line_ptr[(signed long int)2] >> 2);
+        encoded_len = encoded_len - 1;
+        if(encoded_len == 0)
+          break;
+
+        tmp_post$8 = dst;
+        dst = dst + 1l;
+
+
+
+        *tmp_post$8 = (char)((signed int)line_ptr[(signed long int)2] << 6 | (signed int)line_ptr[(signed long int)3]);
+        line_ptr = line_ptr + (signed long int)4;
+        encoded_len = encoded_len - 2;
+      }
+      while(encoded_len > 0);
+      fwrite((const void *)line, (unsigned long int)1, (unsigned long int)(dst - line), dst_stream);
+      free((void *)line);
+    }
+  }
+  while((_Bool)1);
+  bb_error_msg_and_die("short file");
+}
+
+// file libbb/bb_strtonum.c line 33
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/uudecode.c line 92
+signed int __main(signed int argc, char **argv)
+{
+  struct _IO_FILE *src_stream;
+  char *outname = (char *)NULL;
+  char *line;
+  opt_complementary = "?1";
+  getopt32(argv, "o:", &outname);
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)"-";
+  }
+
+
+  src_stream=xfopen_stdin(argv[(signed long int)0]);
+  signed int tmp_if_expr$16;
+  signed int tmp_statement_expression$10;
+  _Bool tmp_if_expr$11;
+  signed int tmp_if_expr$14;
+  signed int tmp_statement_expression$12;
+  signed int return_value___builtin_strcmp$13;
+  signed int return_value_strncmp$15;
+  unsigned long int return_value_strlen$1;
+  signed int tmp_if_expr$8;
+  signed int tmp_statement_expression$2;
+  _Bool tmp_if_expr$3;
+  signed int tmp_if_expr$6;
+  signed int tmp_statement_expression$4;
+  signed int return_value___builtin_strcmp$5;
+  signed int return_value_strncmp$7;
+  _Bool tmp_if_expr$20;
+  do
+  {
+    line=xmalloc_fgetline(src_stream);
+    if(line == ((char *)NULL))
+      break;
+
+    void (*decode_fn_ptr)(struct _IO_FILE *, struct _IO_FILE *, signed int);
+    char *line_ptr;
+    struct _IO_FILE *dst_stream;
+    signed int mode;
+    unsigned long int return_value_strlen$9;
+    return_value_strlen$9=strlen("begin-base64 ");
+    if(return_value_strlen$9 < 13ul)
+    {
+      unsigned long int uudecode_main$$1$$1$$1$$__s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("begin-base64 " + 1l) + -((unsigned long int)"begin-base64 ") == 1ul))
+          goto __CPROVER_DUMP_L9;
+
+        __s2_len=strlen("begin-base64 ");
+        tmp_if_expr$11 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+
+      else
+      {
+
+      __CPROVER_DUMP_L9:
+        ;
+        tmp_if_expr$11 = 0 != 0;
+      }
+      if(!(tmp_if_expr$11 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)line;
+        signed int __result;
+
+        __result = (signed int)((const char *)"begin-base64 ")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+
+
+            __result = (signed int)((const char *)"begin-base64 ")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+
+
+                __result = (signed int)((const char *)"begin-base64 ")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+
+
+                    __result = (signed int)((const char *)"begin-base64 ")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+
+        tmp_statement_expression$12 = __result;
+        tmp_if_expr$14 = -tmp_statement_expression$12;
+      }
+
+      else
+      {
+        return_value___builtin_strcmp$13=strcmp(line, "begin-base64 ");
+        tmp_if_expr$14 = return_value___builtin_strcmp$13;
+      }
+      tmp_statement_expression$10 = tmp_if_expr$14;
+      tmp_if_expr$16 = tmp_statement_expression$10;
+    }
+
+    else
+    {
+      return_value_strncmp$15=strncmp(line, "begin-base64 ", (unsigned long int)13);
+      tmp_if_expr$16 = return_value_strncmp$15;
+    }
+    if(tmp_if_expr$16 == 0)
+    {
+      line_ptr = line + (signed long int)13;
+      decode_fn_ptr = read_base64;
+    }
+
+    else
+    {
+      return_value_strlen$1=strlen("begin ");
+      if(return_value_strlen$1 < 6ul)
+      {
+        unsigned long int __s1_len;
+        unsigned long int uudecode_main$$1$$1$$3$$__s2_len;
+        if((_Bool)1)
+        {
+          if(!((unsigned long int)("begin " + 1l) + -((unsigned long int)"begin ") == 1ul))
+            goto __CPROVER_DUMP_L31;
+
+          uudecode_main$$1$$1$$3$$__s2_len=strlen("begin ");
+          tmp_if_expr$3 = (uudecode_main$$1$$1$$3$$__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L31:
+          ;
+          tmp_if_expr$3 = 0 != 0;
+        }
+        if(!(tmp_if_expr$3 == (_Bool)0))
+        {
+          const unsigned char *uudecode_main$$1$$1$$3$$2$$__s2 = (const char *)line;
+          signed int uudecode_main$$1$$1$$3$$2$$__result;
+
+          uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)0] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)0];
+          if(uudecode_main$$1$$1$$3$$__s2_len > 0ul)
+          {
+            if(uudecode_main$$1$$1$$3$$2$$__result == 0)
+            {
+
+
+              uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)1] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)1];
+              if(uudecode_main$$1$$1$$3$$__s2_len > 1ul)
+              {
+                if(uudecode_main$$1$$1$$3$$2$$__result == 0)
+                {
+
+
+                  uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)2] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)2];
+                  if(uudecode_main$$1$$1$$3$$__s2_len > 2ul)
+                  {
+                    if(uudecode_main$$1$$1$$3$$2$$__result == 0)
+                    {
+
+
+                      uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)3] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)3];
+                    }
+
+                  }
+
+                }
+
+              }
+
+            }
+
+          }
+
+          tmp_statement_expression$4 = uudecode_main$$1$$1$$3$$2$$__result;
+          tmp_if_expr$6 = -tmp_statement_expression$4;
+        }
+
+        else
+        {
+          return_value___builtin_strcmp$5=strcmp(line, "begin ");
+          tmp_if_expr$6 = return_value___builtin_strcmp$5;
+        }
+        tmp_statement_expression$2 = tmp_if_expr$6;
+        tmp_if_expr$8 = tmp_statement_expression$2;
+      }
+
+      else
+      {
+        return_value_strncmp$7=strncmp(line, "begin ", (unsigned long int)6);
+        tmp_if_expr$8 = return_value_strncmp$7;
+      }
+      if(tmp_if_expr$8 == 0)
+      {
+        line_ptr = line + (signed long int)6;
+        decode_fn_ptr = read_stduu;
+      }
+
+      else
+      {
+        free((void *)line);
+        continue;
+      }
+    }
+    unsigned int return_value_bb_strtou$17;
+    return_value_bb_strtou$17=bb_strtou(line_ptr, (char **)NULL, 8);
+    mode = (signed int)return_value_bb_strtou$17;
+    if(outname == ((char *)NULL))
+    {
+      char *return_value___builtin_strchr$18;
+      return_value___builtin_strchr$18=strchr(line_ptr, 32);
+      outname = return_value___builtin_strchr$18;
+      if(outname == ((char *)NULL))
+        break;
+
+      outname = outname + 1l;
+
+      if((signed int)*outname == 0)
+        break;
+
+    }
+
+    dst_stream = stdout;
+
+    if(!((signed int)*outname == 45))
+      tmp_if_expr$20 = 1 != 0;
+
+    else
+    {
+
+      tmp_if_expr$20 = ((signed int)outname[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$20 == (_Bool)0))
+    {
+      dst_stream=xfopen_for_write(outname);
+      signed int return_value_fileno$19;
+      return_value_fileno$19=fileno(dst_stream);
+      fchmod(return_value_fileno$19, (unsigned int)(mode & (256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3)));
+    }
+
+    free((void *)line);
+    decode_fn_ptr(src_stream, dst_stream, 256 + 128);
+    return 0;
+  }
+  while((_Bool)1);
+  bb_error_msg_and_die("no 'begin' line");
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 788
+static struct _IO_FILE * xfopen(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_perror_msg_and_die("can't open '%s'", path);
+
+  return fp;
+}
+
+// file libbb/wfopen.c line 37
+static struct _IO_FILE * xfopen_for_write(const char *path)
+{
+  struct _IO_FILE *return_value_xfopen$1;
+  return_value_xfopen$1=xfopen(path, "w");
+  return return_value_xfopen$1;
+}
+
+// file libbb/wfopen_input.c line 29
+static struct _IO_FILE * xfopen_stdin(const char *filename)
+{
+  struct _IO_FILE *fp;
+  fp=fopen_or_warn_stdin(filename);
+  if(!(fp == ((struct _IO_FILE *)NULL)))
+    return fp;
+
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/get_line_from_file.c line 53
+static char * xmalloc_fgetline(struct _IO_FILE *file)
+{
+  signed int i;
+  char *c;
+  c=bb_get_chunk_from_file(file, &i);
+  if(!(i == 0))
+  {
+    i = i - 1;
+    if((signed int)c[(signed long int)i] == 10)
+      c[(signed long int)i] = (char)0;
+
+  }
+
+  return c;
+}
+
+// file include/libbb.h line 697
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/uudecode_false-no-overflow.i
+++ b/c/busybox-1.22.0/uudecode_false-no-overflow.i
@@ -1,0 +1,3800 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static inline signed int bb_ascii_isalnum(unsigned char a);
+static void bb_error_msg_and_die(const char *s, ...);
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static const char * decode_base64(char **pp_dst, const char *src);
+static signed int fflush_all(void);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static unsigned long long int handle_errors(unsigned long long int v, char **endp);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static void read_base64(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags);
+static void read_stduu(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags);
+static unsigned long long int ret_ERANGE(void);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+void decode_fn_ptr$object(struct _IO_FILE *, struct _IO_FILE *, signed int);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static struct _IO_FILE * xfopen(const char *path, const char *mode);
+static struct _IO_FILE * xfopen_for_write(const char *path);
+static struct _IO_FILE * xfopen_stdin(const char *filename);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static char * xmalloc_fgetline(struct _IO_FILE *file);
+static void * xrealloc(void *ptr, unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static const char bb_uuenc_tbl_base64[66l] = { (const char)65, (const char)66, (const char)67, (const char)68, (const char)69, (const char)70, (const char)71, (const char)72, (const char)73, (const char)74, (const char)75, (const char)76, (const char)77, (const char)78, (const char)79, (const char)80, (const char)81, (const char)82, (const char)83, (const char)84, (const char)85, (const char)86, (const char)87, (const char)88, (const char)89, (const char)90, (const char)97, (const char)98, (const char)99, (const char)100, (const char)101, (const char)102, (const char)103, (const char)104, (const char)105, (const char)106, (const char)107, (const char)108, (const char)109, (const char)110, (const char)111, (const char)112, (const char)113, (const char)114, (const char)115, (const char)116, (const char)117, (const char)118, (const char)119, (const char)120, (const char)121, (const char)122, (const char)48, (const char)49, (const char)50, (const char)51, (const char)52, (const char)53, (const char)54, (const char)55, (const char)56, (const char)57, (const char)43, (const char)47, (const char)61, (const char)0 };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static inline signed int bb_ascii_isalnum(unsigned char a)
+{
+  unsigned char b = (unsigned char)((signed int)a - 48);
+  if((signed int)b <= 9)
+    return (signed int)((signed int)b <= 9);
+  b = (unsigned char)(((signed int)a | 32) - 97);
+  return (signed int)((signed int)b <= 122 - 97);
+}
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static char * bb_get_chunk_from_file(struct _IO_FILE *file, signed int *end)
+{
+  signed int ch;
+  unsigned int idx = (unsigned int)0;
+  char *linebuf = (char *)((void *)0);
+  void *return_value_xrealloc$1;
+  unsigned int tmp_post$2;
+  do
+  {
+    ch=_IO_getc (file);
+    if(ch == -1)
+      break;
+    if((255u & idx) == 0u)
+    {
+      return_value_xrealloc$1=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)256));
+      linebuf = (char *)return_value_xrealloc$1;
+    }
+    tmp_post$2 = idx;
+    idx = idx + 1u;
+    linebuf[(signed long int)tmp_post$2] = (char)ch;
+    if(ch == 0)
+      break;
+    if(!(end == ((signed int *)((void *)0))))
+    {
+      if(ch == 10)
+        break;
+    }
+  }
+  while((_Bool)1);
+  if(!(end == ((signed int *)((void *)0))))
+    *end = (signed int)idx;
+  if(!(linebuf == ((char *)((void *)0))))
+  {
+    void *return_value_xrealloc$3;
+    return_value_xrealloc$3=xrealloc((void *)linebuf, (unsigned long int)(idx + (unsigned int)1));
+    linebuf = (char *)return_value_xrealloc$3;
+    linebuf[(signed long int)idx] = (char)0;
+  }
+  return linebuf;
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static unsigned int bb_strtou(const char *arg, char **endp, signed int base)
+{
+  unsigned long int v;
+  char *endptr;
+  if(endp == ((char **)((void *)0)))
+    endp = &endptr;
+  *endp = (char *)arg;
+  signed int return_value_bb_ascii_isalnum$2;
+  return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(arg[(signed long int)0]);
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(return_value_bb_ascii_isalnum$2 == 0)
+  {
+    return_value_ret_ERANGE$1=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$1;
+  }
+  *bb_errno = 0;
+  v=strtoul(arg, endp, base);
+  unsigned long long int return_value_ret_ERANGE$3;
+  if(v > 4294967295ul)
+  {
+    return_value_ret_ERANGE$3=ret_ERANGE();
+    return (unsigned int)return_value_ret_ERANGE$3;
+  }
+  unsigned long long int return_value_handle_errors$4;
+  return_value_handle_errors$4=handle_errors(v, endp);
+  return (unsigned int)return_value_handle_errors$4;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static const char * decode_base64(char **pp_dst, const char *src)
+{
+  char *dst = *pp_dst;
+  const char *src_tail;
+  char *tmp_post$2;
+  char *tmp_post$3;
+  char *tmp_post$4;
+  while((_Bool)1)
+  {
+    unsigned char six_bit[4l];
+    signed int count = 0;
+    src_tail = src;
+    while(count < 4)
+    {
+      char *table_ptr;
+      signed int ch;
+      do
+      {
+        ch = (signed int)*src;
+        if(ch == 0)
+        {
+          if(count == 0)
+            src_tail = src;
+          goto ret;
+        }
+        src = src + 1l;
+        char *return_value___builtin_strchr$1;
+        return_value___builtin_strchr$1=strchr(bb_uuenc_tbl_base64, ch);
+        table_ptr = return_value___builtin_strchr$1;
+      }
+      while(table_ptr == ((char *)((void *)0)));
+      ch = (signed int)(table_ptr - bb_uuenc_tbl_base64);
+      if(ch == 64)
+        break;
+      six_bit[(signed long int)count] = (unsigned char)ch;
+      count = count + 1;
+    }
+    if(count > 1)
+    {
+      tmp_post$2 = dst;
+      dst = dst + 1l;
+      *tmp_post$2 = (char)((signed int)six_bit[(signed long int)0] << 2 | (signed int)six_bit[(signed long int)1] >> 4);
+    }
+    if(count > 2)
+    {
+      tmp_post$3 = dst;
+      dst = dst + 1l;
+      *tmp_post$3 = (char)((signed int)six_bit[(signed long int)1] << 4 | (signed int)six_bit[(signed long int)2] >> 2);
+    }
+    if(count > 3)
+    {
+      tmp_post$4 = dst;
+      dst = dst + 1l;
+      *tmp_post$4 = (char)((signed int)six_bit[(signed long int)2] << 6 | (signed int)six_bit[(signed long int)3]);
+    }
+  }
+ret:
+  ;
+  *pp_dst = dst;
+  return src_tail;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static unsigned long long int handle_errors(unsigned long long int v, char **endp)
+{
+  char next_ch = *(*endp);
+  _Bool tmp_if_expr$3;
+  unsigned long long int return_value_ret_ERANGE$1;
+  if(!((signed int)next_ch == 0))
+  {
+    signed int return_value_bb_ascii_isalnum$2;
+    return_value_bb_ascii_isalnum$2=bb_ascii_isalnum(next_ch);
+    if(!(return_value_bb_ascii_isalnum$2 == 0))
+      tmp_if_expr$3 = 1 != 0;
+    else
+      tmp_if_expr$3 = (*bb_errno != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$3 == (_Bool)0))
+    {
+      return_value_ret_ERANGE$1=ret_ERANGE();
+      return return_value_ret_ERANGE$1;
+    }
+    *bb_errno = 22;
+  }
+  return v;
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static void read_base64(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags)
+{
+  char in_buf[66l];
+  char out_buf[50l];
+  char *out_tail;
+  const char *in_tail;
+  signed int term_seen = 0;
+  signed int in_count = 0;
+  signed int tmp_post$1;
+  signed int tmp_statement_expression$2;
+  _Bool tmp_if_expr$3;
+  signed int tmp_if_expr$6;
+  signed int tmp_statement_expression$4;
+  signed int return_value___builtin_strcmp$5;
+  while((_Bool)1)
+  {
+    while(in_count < 64)
+    {
+      signed int ch;
+      ch=_IO_getc (src_stream);
+      if(ch == (signed int)(signed char)flags)
+      {
+        if(in_count == 0)
+          return;
+        term_seen = 1;
+        break;
+      }
+      if(ch == -1)
+      {
+        term_seen = 1;
+        break;
+      }
+      if(ch <= 32)
+        break;
+      tmp_post$1 = in_count;
+      in_count = in_count + 1;
+      in_buf[(signed long int)tmp_post$1] = (char)ch;
+    }
+    in_buf[(signed long int)in_count] = (char)0;
+    if(!((256 & flags) == 0))
+    {
+      unsigned long int __s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("====" + 1l) + -((unsigned long int)"====") == 1ul))
+          goto __CPROVER_DUMP_L8;
+        __s2_len=strlen("====");
+        tmp_if_expr$3 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      else
+      {
+      __CPROVER_DUMP_L8:
+        ;
+        tmp_if_expr$3 = 0 != 0;
+      }
+      if(!(tmp_if_expr$3 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)in_buf;
+        signed int __result = (signed int)((const char *)"====")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+            __result = (signed int)((const char *)"====")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"====")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                    __result = (signed int)((const char *)"====")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                }
+              }
+            }
+          }
+        }
+        tmp_statement_expression$4 = __result;
+        tmp_if_expr$6 = -tmp_statement_expression$4;
+      }
+      else
+      {
+        return_value___builtin_strcmp$5=strcmp(in_buf, "====");
+        tmp_if_expr$6 = return_value___builtin_strcmp$5;
+      }
+      tmp_statement_expression$2 = tmp_if_expr$6;
+      if(tmp_statement_expression$2 == 0)
+        return;
+    }
+    out_tail = out_buf;
+    in_tail=decode_base64(&out_tail, in_buf);
+    fwrite((const void *)out_buf, (unsigned long int)(out_tail - out_buf), (unsigned long int)1, dst_stream);
+    if(!(term_seen == 0))
+    {
+      if((signed int)*in_tail == 0)
+        return;
+      bb_error_msg_and_die("truncated base64 input");
+    }
+    unsigned long int return_value_strlen$7;
+    return_value_strlen$7=strlen(in_tail);
+    in_count = (signed int)return_value_strlen$7;
+    memmove((void *)in_buf, (const void *)in_tail, (unsigned long int)in_count);
+  }
+}
+static void read_stduu(struct _IO_FILE *src_stream, struct _IO_FILE *dst_stream, signed int flags)
+{
+  char *line;
+  signed int tmp_statement_expression$1;
+  _Bool tmp_if_expr$2;
+  signed int tmp_if_expr$5;
+  signed int tmp_statement_expression$3;
+  signed int return_value___builtin_strcmp$4;
+  char *tmp_post$6;
+  char *tmp_post$7;
+  char *tmp_post$8;
+  do
+  {
+    line=xmalloc_fgetline(src_stream);
+    if(line == ((char *)((void *)0)))
+      break;
+    signed int encoded_len;
+    signed int str_len;
+    char *line_ptr;
+    char *dst;
+    unsigned long int __s1_len;
+    unsigned long int __s2_len;
+    if((_Bool)1)
+    {
+      if(!((unsigned long int)("end" + 1l) + -((unsigned long int)"end") == 1ul))
+        goto __CPROVER_DUMP_L2;
+      __s2_len=strlen("end");
+      tmp_if_expr$2 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    else
+    {
+    __CPROVER_DUMP_L2:
+      ;
+      tmp_if_expr$2 = 0 != 0;
+    }
+    if(!(tmp_if_expr$2 == (_Bool)0))
+    {
+      const char *__s2 = (const char *)line;
+      signed int __result;
+      __result = (signed int)((const char *)"end")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+      if(__s2_len > 0ul)
+      {
+        if(__result == 0)
+        {
+          __result = (signed int)((const char *)"end")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+          if(__s2_len > 1ul)
+          {
+            if(__result == 0)
+            {
+              __result = (signed int)((const char *)"end")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+              if(__s2_len > 2ul)
+              {
+                if(__result == 0)
+                {
+                  __result = (signed int)((const char *)"end")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                }
+              }
+            }
+          }
+        }
+      }
+      tmp_statement_expression$3 = __result;
+      tmp_if_expr$5 = -tmp_statement_expression$3;
+    }
+    else
+    {
+      return_value___builtin_strcmp$4=strcmp(line, "end");
+      tmp_if_expr$5 = return_value___builtin_strcmp$4;
+    }
+    tmp_statement_expression$1 = tmp_if_expr$5;
+    if(tmp_statement_expression$1 == 0)
+      return;
+    line_ptr = line;
+    while((_Bool)1)
+    {
+      if((signed int)*line_ptr == 0)
+        break;
+      *line_ptr = (char)((signed int)*line_ptr - 32 & 63);
+      line_ptr = line_ptr + 1l;
+    }
+    str_len = (signed int)(line_ptr - line);
+    encoded_len = ((signed int)line[(signed long int)0] * 4) / 3;
+    if(encoded_len >= str_len)
+      break;
+    if(encoded_len <= 0)
+      free((void *)line);
+    else
+    {
+      if(encoded_len > 60)
+        bb_error_msg_and_die("line too long");
+      dst = line;
+      line_ptr = line + (signed long int)1;
+      do
+      {
+        tmp_post$6 = dst;
+        dst = dst + 1l;
+        *tmp_post$6 = (char)((signed int)line_ptr[(signed long int)0] << 2 | (signed int)line_ptr[(signed long int)1] >> 4);
+        encoded_len = encoded_len - 1;
+        if(encoded_len == 0)
+          break;
+        tmp_post$7 = dst;
+        dst = dst + 1l;
+        *tmp_post$7 = (char)((signed int)line_ptr[(signed long int)1] << 4 | (signed int)line_ptr[(signed long int)2] >> 2);
+        encoded_len = encoded_len - 1;
+        if(encoded_len == 0)
+          break;
+        tmp_post$8 = dst;
+        dst = dst + 1l;
+        *tmp_post$8 = (char)((signed int)line_ptr[(signed long int)2] << 6 | (signed int)line_ptr[(signed long int)3]);
+        line_ptr = line_ptr + (signed long int)4;
+        encoded_len = encoded_len - 2;
+      }
+      while(encoded_len > 0);
+      fwrite((const void *)line, (unsigned long int)1, (unsigned long int)(dst - line), dst_stream);
+      free((void *)line);
+    }
+  }
+  while((_Bool)1);
+  bb_error_msg_and_die("short file");
+}
+static unsigned long long int ret_ERANGE(void)
+{
+  *bb_errno = 34;
+  return (unsigned long int)9223372036854775807ll * 2ull + 1ull;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct _IO_FILE *src_stream;
+  char *outname = (char *)((void *)0);
+  char *line;
+  opt_complementary = "?1";
+  getopt32(argv, "o:", &outname);
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)"-";
+  }
+  src_stream=xfopen_stdin(argv[(signed long int)0]);
+  signed int tmp_if_expr$16;
+  signed int tmp_statement_expression$10;
+  _Bool tmp_if_expr$11;
+  signed int tmp_if_expr$14;
+  signed int tmp_statement_expression$12;
+  signed int return_value___builtin_strcmp$13;
+  signed int return_value_strncmp$15;
+  unsigned long int return_value_strlen$1;
+  signed int tmp_if_expr$8;
+  signed int tmp_statement_expression$2;
+  _Bool tmp_if_expr$3;
+  signed int tmp_if_expr$6;
+  signed int tmp_statement_expression$4;
+  signed int return_value___builtin_strcmp$5;
+  signed int return_value_strncmp$7;
+  _Bool tmp_if_expr$20;
+  do
+  {
+    line=xmalloc_fgetline(src_stream);
+    if(line == ((char *)((void *)0)))
+      break;
+    void (*decode_fn_ptr)(struct _IO_FILE *, struct _IO_FILE *, signed int);
+    char *line_ptr;
+    struct _IO_FILE *dst_stream;
+    signed int mode;
+    unsigned long int return_value_strlen$9;
+    return_value_strlen$9=strlen("begin-base64 ");
+    if(return_value_strlen$9 < 13ul)
+    {
+      unsigned long int uudecode_main$$1$$1$$1$$__s1_len;
+      unsigned long int __s2_len;
+      if((_Bool)1)
+      {
+        if(!((unsigned long int)("begin-base64 " + 1l) + -((unsigned long int)"begin-base64 ") == 1ul))
+          goto __CPROVER_DUMP_L9;
+        __s2_len=strlen("begin-base64 ");
+        tmp_if_expr$11 = (__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      else
+      {
+      __CPROVER_DUMP_L9:
+        ;
+        tmp_if_expr$11 = 0 != 0;
+      }
+      if(!(tmp_if_expr$11 == (_Bool)0))
+      {
+        const char *__s2 = (const char *)line;
+        signed int __result;
+        __result = (signed int)((const char *)"begin-base64 ")[(signed long int)0] - (signed int)__s2[(signed long int)0];
+        if(__s2_len > 0ul)
+        {
+          if(__result == 0)
+          {
+            __result = (signed int)((const char *)"begin-base64 ")[(signed long int)1] - (signed int)__s2[(signed long int)1];
+            if(__s2_len > 1ul)
+            {
+              if(__result == 0)
+              {
+                __result = (signed int)((const char *)"begin-base64 ")[(signed long int)2] - (signed int)__s2[(signed long int)2];
+                if(__s2_len > 2ul)
+                {
+                  if(__result == 0)
+                  {
+                    __result = (signed int)((const char *)"begin-base64 ")[(signed long int)3] - (signed int)__s2[(signed long int)3];
+                  }
+                }
+              }
+            }
+          }
+        }
+        tmp_statement_expression$12 = __result;
+        tmp_if_expr$14 = -tmp_statement_expression$12;
+      }
+      else
+      {
+        return_value___builtin_strcmp$13=strcmp(line, "begin-base64 ");
+        tmp_if_expr$14 = return_value___builtin_strcmp$13;
+      }
+      tmp_statement_expression$10 = tmp_if_expr$14;
+      tmp_if_expr$16 = tmp_statement_expression$10;
+    }
+    else
+    {
+      return_value_strncmp$15=strncmp(line, "begin-base64 ", (unsigned long int)13);
+      tmp_if_expr$16 = return_value_strncmp$15;
+    }
+    if(tmp_if_expr$16 == 0)
+    {
+      line_ptr = line + (signed long int)13;
+      decode_fn_ptr = read_base64;
+    }
+    else
+    {
+      return_value_strlen$1=strlen("begin ");
+      if(return_value_strlen$1 < 6ul)
+      {
+        unsigned long int __s1_len;
+        unsigned long int uudecode_main$$1$$1$$3$$__s2_len;
+        if((_Bool)1)
+        {
+          if(!((unsigned long int)("begin " + 1l) + -((unsigned long int)"begin ") == 1ul))
+            goto __CPROVER_DUMP_L31;
+          uudecode_main$$1$$1$$3$$__s2_len=strlen("begin ");
+          tmp_if_expr$3 = (uudecode_main$$1$$1$$3$$__s2_len < (unsigned long int)4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+        }
+        else
+        {
+        __CPROVER_DUMP_L31:
+          ;
+          tmp_if_expr$3 = 0 != 0;
+        }
+        if(!(tmp_if_expr$3 == (_Bool)0))
+        {
+          const unsigned char *uudecode_main$$1$$1$$3$$2$$__s2 = (const char *)line;
+          signed int uudecode_main$$1$$1$$3$$2$$__result;
+          uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)0] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)0];
+          if(uudecode_main$$1$$1$$3$$__s2_len > 0ul)
+          {
+            if(uudecode_main$$1$$1$$3$$2$$__result == 0)
+            {
+              uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)1] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)1];
+              if(uudecode_main$$1$$1$$3$$__s2_len > 1ul)
+              {
+                if(uudecode_main$$1$$1$$3$$2$$__result == 0)
+                {
+                  uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)2] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)2];
+                  if(uudecode_main$$1$$1$$3$$__s2_len > 2ul)
+                  {
+                    if(uudecode_main$$1$$1$$3$$2$$__result == 0)
+                    {
+                      uudecode_main$$1$$1$$3$$2$$__result = (signed int)((const char *)"begin ")[(signed long int)3] - (signed int)uudecode_main$$1$$1$$3$$2$$__s2[(signed long int)3];
+                    }
+                  }
+                }
+              }
+            }
+          }
+          tmp_statement_expression$4 = uudecode_main$$1$$1$$3$$2$$__result;
+          tmp_if_expr$6 = -tmp_statement_expression$4;
+        }
+        else
+        {
+          return_value___builtin_strcmp$5=strcmp(line, "begin ");
+          tmp_if_expr$6 = return_value___builtin_strcmp$5;
+        }
+        tmp_statement_expression$2 = tmp_if_expr$6;
+        tmp_if_expr$8 = tmp_statement_expression$2;
+      }
+      else
+      {
+        return_value_strncmp$7=strncmp(line, "begin ", (unsigned long int)6);
+        tmp_if_expr$8 = return_value_strncmp$7;
+      }
+      if(tmp_if_expr$8 == 0)
+      {
+        line_ptr = line + (signed long int)6;
+        decode_fn_ptr = read_stduu;
+      }
+      else
+      {
+        free((void *)line);
+        continue;
+      }
+    }
+    unsigned int return_value_bb_strtou$17;
+    return_value_bb_strtou$17=bb_strtou(line_ptr, (char **)((void *)0), 8);
+    mode = (signed int)return_value_bb_strtou$17;
+    if(outname == ((char *)((void *)0)))
+    {
+      char *return_value___builtin_strchr$18;
+      return_value___builtin_strchr$18=strchr(line_ptr, 32);
+      outname = return_value___builtin_strchr$18;
+      if(outname == ((char *)((void *)0)))
+        break;
+      outname = outname + 1l;
+      if((signed int)*outname == 0)
+        break;
+    }
+    dst_stream = stdout;
+    if(!((signed int)*outname == 45))
+      tmp_if_expr$20 = 1 != 0;
+    else
+    {
+      tmp_if_expr$20 = ((signed int)outname[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    if(!(tmp_if_expr$20 == (_Bool)0))
+    {
+      dst_stream=xfopen_for_write(outname);
+      signed int return_value_fileno$19;
+      return_value_fileno$19=fileno(dst_stream);
+      fchmod(return_value_fileno$19, (unsigned int)(mode & (256 | 128 | 64 | (256 | 128 | 64) >> 3 | ((256 | 128 | 64) >> 3) >> 3)));
+    }
+    free((void *)line);
+    decode_fn_ptr(src_stream, dst_stream, 256 + 128);
+    return 0;
+  }
+  while((_Bool)1);
+  bb_error_msg_and_die("no 'begin' line");
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static struct _IO_FILE * xfopen(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_perror_msg_and_die("can't open '%s'", path);
+  return fp;
+}
+static struct _IO_FILE * xfopen_for_write(const char *path)
+{
+  struct _IO_FILE *return_value_xfopen$1;
+  return_value_xfopen$1=xfopen(path, "w");
+  return return_value_xfopen$1;
+}
+static struct _IO_FILE * xfopen_stdin(const char *filename)
+{
+  struct _IO_FILE *fp;
+  fp=fopen_or_warn_stdin(filename);
+  if(!(fp == ((struct _IO_FILE *)((void *)0))))
+    return fp;
+  abort();
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static char * xmalloc_fgetline(struct _IO_FILE *file)
+{
+  signed int i;
+  char *c;
+  c=bb_get_chunk_from_file(file, &i);
+  if(!(i == 0))
+  {
+    i = i - 1;
+    if((signed int)c[(signed long int)i] == 10)
+      c[(signed long int)i] = (char)0;
+  }
+  return c;
+}
+static void * xrealloc(void *ptr, unsigned long int size)
+{
+  ptr=realloc(ptr, size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.c
@@ -357,7 +357,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.i
@@ -2464,7 +2464,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/wc_false-no-overflow.c
+++ b/c/busybox-1.22.0/wc_false-no-overflow.c
@@ -1,0 +1,1303 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...);
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval);
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file include/unicode.h line 83
+static void init_unicode(void);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/messages.c line 33
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/messages.c line 34
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/unicode.c line 14
+static unsigned char unicode_status;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 1083
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+}
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1084
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file libbb/fclose_nonstdin.c line 17
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+
+  return r;
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 786
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort(); // xfunc_die() invokes exit() and would thus leak memory
+  }
+
+  exit(retval);
+}
+
+// file include/libbb.h line 790
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)NULL))
+    bb_simple_perror_msg(path);
+
+  return fp;
+}
+
+// file include/libbb.h line 793
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+
+  }
+
+  return fp;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file include/unicode.h line 83
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)NULL))
+      s=getenv("LC_CTYPE");
+
+    if(s == ((char *)NULL))
+      s=getenv("LANG");
+
+    reinit_unicode(s);
+  }
+
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file libbb/unicode.c line 69
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)NULL))
+    tmp_if_expr$4 = 1 != 0;
+
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)NULL)))
+      tmp_if_expr$3 = 1 != 0;
+
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)NULL ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+
+  unicode_status = (unsigned char)2;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/wc.c line 92
+signed int __main(signed int argc, char **argv)
+{
+  const char *arg;
+  const char *start_fmt = " %9u" + (signed long int)1;
+  const char *fname_fmt = " %s\n";
+  unsigned int *pcounts;
+  unsigned int counts[5l];
+  unsigned int totals[5l];
+  signed int num_files;
+  signed char status = (signed char)0;
+  unsigned int print_type;
+  init_unicode();
+  print_type=getopt32(argv, "lwmcL");
+  if(print_type == 0u)
+    print_type = (unsigned int)(1 << 0 | 1 << 1 | 1 << 3);
+
+  argv = argv + (signed long int)optind;
+
+  if(*argv == ((char *)NULL))
+  {
+    argv = argv - 1l;
+
+    *argv = (char *)bb_msg_standard_input;
+    fname_fmt = "\n";
+  }
+
+
+  if(*(1l + argv) == ((char *)NULL))
+  {
+    if((4294967295u + print_type & print_type) == 0u)
+      start_fmt = "%u";
+
+  }
+
+  memset((void *)totals, 0, sizeof(unsigned int [5l]) /*20ul*/ );
+  pcounts = counts;
+  num_files = 0;
+  char **tmp_post$1;
+  do
+  {
+    tmp_post$1 = argv;
+    argv = argv + 1l;
+
+    arg = *tmp_post$1;
+    if(arg == ((const char *)NULL))
+      break;
+
+    struct _IO_FILE *fp;
+    const char *s;
+    unsigned int u;
+    unsigned int linepos;
+    signed char in_word;
+    num_files = num_files + 1;
+    fp=fopen_or_warn_stdin(arg);
+    if(fp == ((struct _IO_FILE *)NULL))
+      status = (signed char)1;
+
+    else
+    {
+      memset((void *)counts, 0, sizeof(unsigned int [5l]) /*20ul*/ );
+      linepos = (unsigned int)0;
+      in_word = (signed char)0;
+      while((_Bool)1)
+      {
+        signed int c;
+        c=getc(fp);
+        if(c == -1)
+        {
+          signed int return_value_ferror$2;
+          return_value_ferror$2=ferror(fp);
+          if(!(return_value_ferror$2 == 0))
+          {
+            bb_simple_perror_msg(arg);
+            status = (signed char)1;
+          }
+
+          goto DO_EOF;
+        }
+
+        counts[(signed long int)3] = counts[(signed long int)3] + 1u;
+        if((signed int)unicode_status == 2)
+        {
+          if((192 & c) != 128)
+            goto __CPROVER_DUMP_L17;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L17:
+          ;
+          counts[(signed long int)2] = counts[(signed long int)2] + 1u;
+        }
+        if(4294967264u + (unsigned int)c <= 94u)
+        {
+          linepos = linepos + 1u;
+          if(!(c == 32))
+          {
+            in_word = (signed char)1;
+            continue;
+          }
+
+        }
+
+        else
+          if(4294967287u + (unsigned int)c <= 4u)
+          {
+            if(c == 9)
+              linepos = (linepos | (unsigned int)7) + (unsigned int)1;
+
+            else
+            {
+
+            DO_EOF:
+              ;
+              if(!(counts[4l] >= linepos))
+                counts[(signed long int)4] = linepos;
+
+              if(c == 10)
+                counts[(signed long int)0] = counts[(signed long int)0] + 1u;
+
+              if(!(c == 11))
+                linepos = (unsigned int)0;
+
+            }
+          }
+
+          else
+            continue;
+        counts[(signed long int)1] = counts[(signed long int)1] + (unsigned int)in_word;
+        in_word = (signed char)0;
+        if(c == -1)
+          break;
+
+      }
+      fclose_if_not_stdin(fp);
+      if(!(totals[4l] >= counts[4l]))
+        totals[(signed long int)4] = counts[(signed long int)4];
+
+      totals[(signed long int)4] = totals[(signed long int)4] - counts[(signed long int)4];
+
+    OUTPUT:
+      ;
+      s = start_fmt;
+      u = (unsigned int)0;
+      while((_Bool)1)
+      {
+        if(!((print_type & (unsigned int)(1 << u)) == 0u))
+        {
+          printf(s, pcounts[(signed long int)u]);
+          s = " %9u";
+        }
+
+        if((signed long int)u < 5l)
+          (void)0;
+
+        else
+          /* assertion (signed long int)u < 5l */
+          __VERIFIER_error();
+        totals[(signed long int)u] = totals[(signed long int)u] + pcounts[(signed long int)u];
+        u = u + 1u;
+        if(!(u < 5u))
+          break;
+
+      }
+      printf(fname_fmt, arg);
+    }
+  }
+  while((_Bool)1);
+  if(num_files > 1)
+  {
+    num_files = 0;
+    arg = "total";
+    pcounts = totals;
+    argv = argv - 1l;
+    goto OUTPUT;
+  }
+
+  // fflush_stdout_and_exit((signed int)status); -- invokes exit() and would thus leak memory
+  fflush(stdout);
+  return (signed int)status;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/wc_false-no-overflow.i
+++ b/c/busybox-1.22.0/wc_false-no-overflow.i
@@ -1,0 +1,3255 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static void bb_perror_msg(const char *s, ...);
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_show_usage(void);
+static void bb_simple_perror_msg(const char *s);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fclose_if_not_stdin(struct _IO_FILE *f);
+static signed int fflush_all(void);
+static void fflush_stdout_and_exit(signed int retval);
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode);
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void init_unicode(void);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static void reinit_unicode(const char *LANG);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static const char bb_msg_standard_input[15l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)105, (const char)110, (const char)112, (const char)117, (const char)116, (const char)0 };
+static const char bb_msg_standard_output[16l] = { (const char)115, (const char)116, (const char)97, (const char)110, (const char)100, (const char)97, (const char)114, (const char)100, (const char)32, (const char)111, (const char)117, (const char)116, (const char)112, (const char)117, (const char)116, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char unicode_status;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_msg(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+}
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_simple_perror_msg(const char *s)
+{
+  bb_perror_msg("%s", s);
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fclose_if_not_stdin(struct _IO_FILE *f)
+{
+  signed int r;
+  r=ferror(f);
+  if(!(r == 0))
+    *bb_errno = 5;
+  signed int return_value_fclose$1;
+  if(!(f == stdin))
+  {
+    return_value_fclose$1=fclose(f);
+    return r | return_value_fclose$1;
+  }
+  return r;
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static void fflush_stdout_and_exit(signed int retval)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush(stdout);
+  if(!(return_value_fflush$1 == 0))
+    bb_perror_msg_and_die(bb_msg_standard_output);
+  if(die_sleep < 0)
+  {
+    xfunc_error_retval = (unsigned char)retval;
+    abort();
+  }
+  exit(retval);
+}
+static struct _IO_FILE * fopen_or_warn(const char *path, const char *mode)
+{
+  struct _IO_FILE *fp;
+  fp=fopen(path, mode);
+  if(fp == ((struct _IO_FILE *)((void *)0)))
+    bb_simple_perror_msg(path);
+  return fp;
+}
+static struct _IO_FILE * fopen_or_warn_stdin(const char *filename)
+{
+  struct _IO_FILE *fp = stdin;
+  _Bool tmp_if_expr$1;
+  if(!(filename == bb_msg_standard_input))
+  {
+    if(!((signed int)*filename == 45))
+      tmp_if_expr$1 = 1 != 0;
+    else
+      tmp_if_expr$1 = ((signed int)filename[(signed long int)1] != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    if(!(tmp_if_expr$1 == (_Bool)0))
+      fp=fopen_or_warn(filename, "r");
+  }
+  return fp;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void init_unicode(void)
+{
+  if((signed int)unicode_status == 0)
+  {
+    char *s;
+    s=getenv("LC_ALL");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LC_CTYPE");
+    if(s == ((char *)((void *)0)))
+      s=getenv("LANG");
+    reinit_unicode(s);
+  }
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static void reinit_unicode(const char *LANG)
+{
+  unicode_status = (unsigned char)1;
+  _Bool tmp_if_expr$4;
+  char *return_value_strstr$1;
+  _Bool tmp_if_expr$3;
+  char *return_value_strstr$2;
+  if(LANG == ((const char *)((void *)0)))
+    tmp_if_expr$4 = 1 != 0;
+  else
+  {
+    return_value_strstr$1=strstr(LANG, ".utf");
+    if(!(return_value_strstr$1 == ((char *)((void *)0))))
+      tmp_if_expr$3 = 1 != 0;
+    else
+    {
+      return_value_strstr$2=strstr(LANG, ".UTF");
+      tmp_if_expr$3 = (return_value_strstr$2 != (char *)((void *)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    }
+    tmp_if_expr$4 = (!(tmp_if_expr$3 != (_Bool)0) ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  if(!(tmp_if_expr$4 == (_Bool)0))
+    return;
+  unicode_status = (unsigned char)2;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  const char *arg;
+  const char *start_fmt = " %9u" + (signed long int)1;
+  const char *fname_fmt = " %s\n";
+  unsigned int *pcounts;
+  unsigned int counts[5l];
+  unsigned int totals[5l];
+  signed int num_files;
+  signed char status = (signed char)0;
+  unsigned int print_type;
+  init_unicode();
+  print_type=getopt32(argv, "lwmcL");
+  if(print_type == 0u)
+    print_type = (unsigned int)(1 << 0 | 1 << 1 | 1 << 3);
+  argv = argv + (signed long int)optind;
+  if(*argv == ((char *)((void *)0)))
+  {
+    argv = argv - 1l;
+    *argv = (char *)bb_msg_standard_input;
+    fname_fmt = "\n";
+  }
+  if(*(1l + argv) == ((char *)((void *)0)))
+  {
+    if((4294967295u + print_type & print_type) == 0u)
+      start_fmt = "%u";
+  }
+  memset((void *)totals, 0, sizeof(unsigned int [5l]) );
+  pcounts = counts;
+  num_files = 0;
+  char **tmp_post$1;
+  do
+  {
+    tmp_post$1 = argv;
+    argv = argv + 1l;
+    arg = *tmp_post$1;
+    if(arg == ((const char *)((void *)0)))
+      break;
+    struct _IO_FILE *fp;
+    const char *s;
+    unsigned int u;
+    unsigned int linepos;
+    signed char in_word;
+    num_files = num_files + 1;
+    fp=fopen_or_warn_stdin(arg);
+    if(fp == ((struct _IO_FILE *)((void *)0)))
+      status = (signed char)1;
+    else
+    {
+      memset((void *)counts, 0, sizeof(unsigned int [5l]) );
+      linepos = (unsigned int)0;
+      in_word = (signed char)0;
+      while((_Bool)1)
+      {
+        signed int c;
+        c=_IO_getc (fp);
+        if(c == -1)
+        {
+          signed int return_value_ferror$2;
+          return_value_ferror$2=ferror(fp);
+          if(!(return_value_ferror$2 == 0))
+          {
+            bb_simple_perror_msg(arg);
+            status = (signed char)1;
+          }
+          goto DO_EOF;
+        }
+        counts[(signed long int)3] = counts[(signed long int)3] + 1u;
+        if((signed int)unicode_status == 2)
+        {
+          if((192 & c) != 128)
+            goto __CPROVER_DUMP_L17;
+        }
+        else
+        {
+        __CPROVER_DUMP_L17:
+          ;
+          counts[(signed long int)2] = counts[(signed long int)2] + 1u;
+        }
+        if(4294967264u + (unsigned int)c <= 94u)
+        {
+          linepos = linepos + 1u;
+          if(!(c == 32))
+          {
+            in_word = (signed char)1;
+            continue;
+          }
+        }
+        else
+          if(4294967287u + (unsigned int)c <= 4u)
+          {
+            if(c == 9)
+              linepos = (linepos | (unsigned int)7) + (unsigned int)1;
+            else
+            {
+            DO_EOF:
+              ;
+              if(!(counts[4l] >= linepos))
+                counts[(signed long int)4] = linepos;
+              if(c == 10)
+                counts[(signed long int)0] = counts[(signed long int)0] + 1u;
+              if(!(c == 11))
+                linepos = (unsigned int)0;
+            }
+          }
+          else
+            continue;
+        counts[(signed long int)1] = counts[(signed long int)1] + (unsigned int)in_word;
+        in_word = (signed char)0;
+        if(c == -1)
+          break;
+      }
+      fclose_if_not_stdin(fp);
+      if(!(totals[4l] >= counts[4l]))
+        totals[(signed long int)4] = counts[(signed long int)4];
+      totals[(signed long int)4] = totals[(signed long int)4] - counts[(signed long int)4];
+    OUTPUT:
+      ;
+      s = start_fmt;
+      u = (unsigned int)0;
+      while((_Bool)1)
+      {
+        if(!((print_type & (unsigned int)(1 << u)) == 0u))
+        {
+          printf(s, pcounts[(signed long int)u]);
+          s = " %9u";
+        }
+        if((signed long int)u < 5l)
+          (void)0;
+        else
+          __VERIFIER_error();
+        totals[(signed long int)u] = totals[(signed long int)u] + pcounts[(signed long int)u];
+        u = u + 1u;
+        if(!(u < 5u))
+          break;
+      }
+      printf(fname_fmt, arg);
+    }
+  }
+  while((_Bool)1);
+  if(num_files > 1)
+  {
+    num_files = 0;
+    arg = "total";
+    pcounts = totals;
+    argv = argv - 1l;
+    goto OUTPUT;
+  }
+  fflush(stdout);
+  return (signed int)status;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -247,7 +247,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2275,7 +2275,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/who_false-no-overflow.c
+++ b/c/busybox-1.22.0/who_false-no-overflow.c
@@ -1,0 +1,1082 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <syslog.h>
+#include <getopt.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+// file libbb/getopt32.c line 307
+struct libbb_anonymous$0;
+
+// file include/libbb.h line 1040
+struct llist_t;
+
+// file include/libbb.h line 841
+struct suffix_mult;
+
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+// file coreutils/who.c line 55
+static void idle_string(char *str6, signed long int t);
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+// file include/libbb.h line 651
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr);
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size);
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+struct libbb_anonymous$0
+{
+  // opt_char
+  unsigned char opt_char;
+  // param_type
+  signed char param_type;
+  // switch_on
+  unsigned int switch_on;
+  // switch_off
+  unsigned int switch_off;
+  // incongruously
+  unsigned int incongruously;
+  // requires
+  unsigned int requires;
+  // optarg
+  void **optarg;
+  // counter
+  signed int *counter;
+};
+
+struct libbb_anonymous$22
+{
+  // tv_sec
+  signed int tv_sec;
+  // tv_usec
+  signed int tv_usec;
+};
+
+struct llist_t
+{
+  // link
+  struct llist_t *link;
+  // data
+  char *data;
+};
+
+struct suffix_mult
+{
+  // suffix
+  char suffix[4l];
+  // mult
+  unsigned int mult;
+};
+
+// file libbb/getopt32.c line 323
+static const char *applet_long_options;
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/messages.c line 25
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+// file libbb/getopt32.c line 320
+static struct option bb_null_long_options[1l] = { { .name=(const char *)NULL, .has_arg=0, .flag=(signed int *)NULL, .val=0 } };
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/getopt32.c line 299
+static const char *opt_complementary;
+// file libbb/getopt32.c line 326
+static unsigned int option_mask32;
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file include/libbb.h line 655
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file libbb/xatonum.c line 38
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+
+  return (unsigned int)v;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 1033
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)NULL)); argc = argc + 1)
+    ;
+  va_start(p, applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) /*1320ul*/ );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+
+      }
+      while((_Bool)1);
+    }
+
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)NULL)))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) /*32ul*/ );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)NULL)); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)NULL))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+
+        if(c >= 32)
+          break;
+
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=va_arg(p, __typeof__(on_off->optarg));
+
+        c = c + 1;
+      }
+
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)NULL;
+  }
+
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)NULL)))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+
+        }
+
+        else
+        {
+
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+
+          }
+
+          else
+          {
+
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+
+            bb_error_msg_and_die("NO OPT %c!", *s);
+
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+
+              on_off->param_type = (signed char)1;
+            }
+
+            else
+            {
+
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+
+              else
+              {
+
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+
+                else
+                {
+
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=va_arg(p, __typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+
+  __CPROVER_DUMP_L57:
+    ;
+
+  __CPROVER_DUMP_L58:
+    ;
+
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)NULL;
+  va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)NULL)); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+
+      }
+
+      if((2 & spec_flgs) == 0)
+        break;
+
+    }
+  }
+
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)NULL);
+    if(c == -1)
+      break;
+
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)NULL)))
+      *on_off->counter = *on_off->counter + 1;
+
+    if(!(optarg == ((char *)NULL)))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+
+        else
+          if(!(on_off->optarg == ((void **)NULL)))
+            *((char **)on_off->optarg) = optarg;
+
+    }
+
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+
+      }
+
+    }
+
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+
+  }
+
+  else
+  {
+
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+
+    }
+
+    else
+    {
+
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+
+    }
+  }
+
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+
+  return (unsigned int)(signed int)-1;
+}
+
+// file coreutils/who.c line 55
+static void idle_string(char *str6, signed long int t)
+{
+  signed long int return_value_time$1;
+  return_value_time$1=time((signed long int *)NULL);
+  t = return_value_time$1 - t;
+  if(t >= 0l)
+  {
+    if(t < 86400l)
+    {
+      sprintf(str6, "%02d:%02d", (signed int)(t / (signed long int)(60 * 60)), (signed int)((t % (signed long int)(60 * 60)) / (signed long int)60));
+      return;
+    }
+
+  }
+
+  strcpy(str6, "old");
+}
+
+// file include/libbb.h line 1045
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)NULL)); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) /*16ul*/ );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+
+// file include/libbb.h line 651
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size)
+{
+  if(size == 0ul)
+    return dst;
+
+  size = size - 1ul;
+  dst[(signed long int)size] = (char)0;
+  char *return_value_strncpy$1;
+  return_value_strncpy$1=strncpy(dst, src, size);
+  return return_value_strncpy$1;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// model stat function, in this benchmark there is used
+// only the st_atim.tv_sec variable
+int stat(const char *__file, struct stat *__buf)
+{
+  __buf->st_atim.tv_sec = __VERIFIER_nondet_long();
+  if (__VERIFIER_nondet_char())
+    return -1;
+
+  __VERIFIER_assume(__buf->st_atim.tv_sec >= 0);
+  return 0;
+}
+
+// file coreutils/who.c line 74
+signed int __main(signed int argc, char **argv)
+{
+  struct utmp *ut;
+  unsigned int opt;
+  signed int do_users = (signed int)(0 != 0);
+  const char *fmt = "%s";
+  opt_complementary = "=0";
+  opt=getopt32(argv, do_users != 0 ? "" : "aH");
+  if(!((2u & opt) == 0u))
+    printf("USER\t\tTTY\t\tIDLE\tTIME\t\t HOST\n");
+
+  setutent();
+  _Bool tmp_if_expr$4;
+  char *tmp_if_expr$1;
+  do
+  {
+    ut=getutent();
+    if(ut == ((struct utmp *)NULL))
+      break;
+
+
+    if(!((signed int)ut->ut_user[0l] == 0))
+    {
+      if(!((1u & opt) == 0u))
+        tmp_if_expr$4 = 1 != 0;
+
+      else
+      {
+
+        tmp_if_expr$4 = ((signed int)ut->ut_type == 7 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$4 == (_Bool)0))
+      {
+        if(do_users == 0)
+        {
+          char str6[6l];
+          char name[39l];
+          struct stat st;
+          signed long int seconds;
+          str6[(signed long int)0] = (char)63;
+          str6[(signed long int)1] = (char)0;
+          strcpy(name, "/dev/");
+
+          if((signed int)ut->ut_line[0l] == 47)
+            tmp_if_expr$1 = name;
+
+          else
+            tmp_if_expr$1 = (name + (signed long int)sizeof(char [6l]) /*6ul*/ ) - (signed long int)1;
+          safe_strncpy(tmp_if_expr$1, ut->ut_line, sizeof(char [32l]) /*32ul*/  + (unsigned long int)1);
+          signed int return_value_stat$2;
+          return_value_stat$2=stat(name, &st);
+          if(return_value_stat$2 == 0)
+            idle_string(str6, st.st_atim.tv_sec);
+
+
+          seconds = (signed long int)ut->ut_tv.tv_sec;
+          char *return_value_ctime$3;
+          return_value_ctime$3=ctime(&seconds);
+          printf("%-15.*s %-15.*s %-7s %-16.16s %.*s\n", (signed int)sizeof(char [32l]) /*32ul*/ , ut->ut_user, (signed int)sizeof(char [32l]) /*32ul*/ , ut->ut_line, str6, return_value_ctime$3 + (signed long int)4, (signed int)sizeof(char [256l]) /*256ul*/ , ut->ut_host);
+        }
+
+        else
+        {
+          printf(fmt, (const void *)ut->ut_user);
+          fmt = " %s";
+        }
+      }
+
+    }
+
+  }
+  while((_Bool)1);
+  if(!(do_users == 0))
+    bb_putchar(10);
+
+  return 0;
+}
+
+// file include/libbb.h line 858
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+
+// file include/xatonum.h line 99
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)NULL);
+  return return_value_xstrtou_range_sfx$1;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file include/libbb.h line 695
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == NULL)
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+
+  }
+
+  return ptr;
+}
+
+// file libbb/xatonum_template.c line 19
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)NULL)))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+
+          }
+
+        if((signed int)*e == 0)
+        {
+
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+
+          }
+
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+
+      }
+
+    }
+
+  }
+
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+
+// file include/libbb.h line 696
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/who_false-no-overflow.i
+++ b/c/busybox-1.22.0/who_false-no-overflow.i
@@ -1,0 +1,3310 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+struct stat
+  {
+    __dev_t st_dev;
+    __ino_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+struct stat64
+  {
+    __dev_t st_dev;
+    __ino64_t st_ino;
+    __nlink_t st_nlink;
+    __mode_t st_mode;
+    __uid_t st_uid;
+    __gid_t st_gid;
+    int __pad0;
+    __dev_t st_rdev;
+    __off_t st_size;
+    __blksize_t st_blksize;
+    __blkcnt64_t st_blocks;
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    __syscall_slong_t __glibc_reserved[3];
+  };
+extern int stat (const char *__restrict __file,
+   struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat (int __fd, struct stat *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int stat64 (const char *__restrict __file,
+     struct stat64 *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fstat64 (int __fd, struct stat64 *__buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int fstatat (int __fd, const char *__restrict __file,
+      struct stat *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int fstatat64 (int __fd, const char *__restrict __file,
+        struct stat64 *__restrict __buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int lstat (const char *__restrict __file,
+    struct stat *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lstat64 (const char *__restrict __file,
+      struct stat64 *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int chmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lchmod (const char *__file, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int fchmod (int __fd, __mode_t __mode) __attribute__ ((__nothrow__ , __leaf__));
+extern int fchmodat (int __fd, const char *__file, __mode_t __mode,
+       int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __mode_t umask (__mode_t __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern __mode_t getumask (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int mkdir (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkdirat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mknod (const char *__path, __mode_t __mode, __dev_t __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mknodat (int __fd, const char *__path, __mode_t __mode,
+      __dev_t __dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int mkfifo (const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkfifoat (int __fd, const char *__path, __mode_t __mode)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int utimensat (int __fd, const char *__path,
+        const struct timespec __times[2],
+        int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int futimens (int __fd, const struct timespec __times[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fxstat (int __ver, int __fildes, struct stat *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat (int __ver, const char *__filename,
+      struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat (int __ver, const char *__filename,
+       struct stat *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat (int __ver, int __fildes, const char *__filename,
+         struct stat *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __fxstat64 (int __ver, int __fildes, struct stat64 *__stat_buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int __xstat64 (int __ver, const char *__filename,
+        struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __lxstat64 (int __ver, const char *__filename,
+         struct stat64 *__stat_buf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int __fxstatat64 (int __ver, int __fildes, const char *__filename,
+    struct stat64 *__stat_buf, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4)));
+extern int __xmknod (int __ver, const char *__path, __mode_t __mode,
+       __dev_t *__dev) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int __xmknodat (int __ver, int __fd, const char *__path,
+         __mode_t __mode, __dev_t *__dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 5)));
+
+
+struct timex
+{
+  unsigned int modes;
+  __syscall_slong_t offset;
+  __syscall_slong_t freq;
+  __syscall_slong_t maxerror;
+  __syscall_slong_t esterror;
+  int status;
+  __syscall_slong_t constant;
+  __syscall_slong_t precision;
+  __syscall_slong_t tolerance;
+  struct timeval time;
+  __syscall_slong_t tick;
+  __syscall_slong_t ppsfreq;
+  __syscall_slong_t jitter;
+  int shift;
+  __syscall_slong_t stabil;
+  __syscall_slong_t jitcnt;
+  __syscall_slong_t calcnt;
+  __syscall_slong_t errcnt;
+  __syscall_slong_t stbcnt;
+  int tai;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32; int :32;
+  int :32; int :32; int :32;
+};
+
+extern int clock_adjtime (__clockid_t __clock_id, struct timex *__utx) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+
+
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strptime (const char *__restrict __s,
+         const char *__restrict __fmt, struct tm *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern char *strptime_l (const char *__restrict __s,
+    const char *__restrict __fmt, struct tm *__tp,
+    __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int getdate_err;
+extern struct tm *getdate (const char *__string);
+extern int getdate_r (const char *__restrict __string,
+        struct tm *__restrict __resbufp);
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+struct libbb_anonymous$0;
+struct llist_t;
+struct suffix_mult;
+static void bb_error_msg_and_die(const char *s, ...);
+static signed int bb_putchar(signed int ch);
+static void bb_show_usage(void);
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static unsigned int getopt32(char **argv, const char *applet_opts, ...);
+static void idle_string(char *str6, signed long int t);
+static void llist_add_to_end(struct llist_t **list_head, void *data);
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static signed int xatoi_positive(const char *numstr);
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper);
+static void xfunc_die(void);
+static void * xmalloc(unsigned long int size);
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes);
+static void * xzalloc(unsigned long int size);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+struct libbb_anonymous$0
+{
+  unsigned char opt_char;
+  signed char param_type;
+  unsigned int switch_on;
+  unsigned int switch_off;
+  unsigned int incongruously;
+  unsigned int requires;
+  void **optarg;
+  signed int *counter;
+};
+struct libbb_anonymous$22
+{
+  signed int tv_sec;
+  signed int tv_usec;
+};
+struct llist_t
+{
+  struct llist_t *link;
+  char *data;
+};
+struct suffix_mult
+{
+  char suffix[4l];
+  unsigned int mult;
+};
+static const char *applet_long_options;
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static const char bb_msg_memory_exhausted[14l] = { (const char)111, (const char)117, (const char)116, (const char)32, (const char)111, (const char)102, (const char)32, (const char)109, (const char)101, (const char)109, (const char)111, (const char)114, (const char)121, (const char)0 };
+static struct option bb_null_long_options[1l] = { { .name=(const char *)((void *)0), .has_arg=0, .flag=(signed int *)((void *)0), .val=0 } };
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static const char *opt_complementary;
+static unsigned int option_mask32;
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static signed int bb_putchar(signed int ch)
+{
+  signed int return_value_putchar_unlocked$1;
+  return_value_putchar_unlocked$1=putchar(ch);
+  return return_value_putchar_unlocked$1;
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static inline unsigned int bb_strtoui(const char *str, char **end, signed int b)
+{
+  unsigned long int v;
+  v=strtoul(str, end, b);
+  if(v > 4294967295ul)
+  {
+    *bb_errno = 34;
+    return (unsigned int)2147483647 * 2u + 1u;
+  }
+  return (unsigned int)v;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static unsigned int getopt32(char **argv, const char *applet_opts, ...)
+{
+  signed int argc;
+  unsigned int flags = (unsigned int)0;
+  unsigned int requires = (unsigned int)0;
+  struct libbb_anonymous$0 complementary[33l];
+  char first_char;
+  signed int c;
+  const unsigned char *s;
+  struct libbb_anonymous$0 *on_off;
+  __builtin_va_list p;
+  struct option *l_o;
+  struct option *long_options = (struct option *)&bb_null_long_options;
+  unsigned int trigger;
+  char **pargv;
+  signed int min_arg = 0;
+  signed int max_arg = -1;
+  signed int spec_flgs = 0;
+  argc = 1;
+  for( ; !(argv[(signed long int)argc] == ((char *)((void *)0))); argc = argc + 1)
+    ;
+  __builtin_va_start(p,applet_opts);
+  c = 0;
+  on_off = complementary;
+  memset((void *)on_off, 0, sizeof(struct libbb_anonymous$0 [33l]) );
+  first_char = applet_opts[(signed long int)0];
+  if((signed int)first_char == 33)
+    applet_opts = applet_opts + 1l;
+  s = (const unsigned char *)applet_opts;
+  _Bool tmp_if_expr$1;
+  if((signed int)*s == 43)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*s == 45 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    s = s + 1l;
+  for( ; !((signed int)*s == 0); c = c + 1)
+  {
+    if(c >= 32)
+      break;
+    on_off->opt_char = *s;
+    on_off->switch_on = (unsigned int)(1 << c);
+    s = s + 1l;
+    if((signed int)*s == 58)
+    {
+      on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+      do
+      {
+        s = s + 1l;
+        if(!((signed int)*s == 58))
+          break;
+      }
+      while((_Bool)1);
+    }
+    on_off = on_off + 1l;
+  }
+  const char *tmp_post$5;
+  const char *tmp_post$6;
+  if(!(applet_long_options == ((const char *)((void *)0))))
+  {
+    const char *optstr;
+    unsigned int i;
+    unsigned int count = (unsigned int)1;
+    optstr = applet_long_options;
+    while(!((signed int)*optstr == 0))
+    {
+      unsigned long int return_value_strlen$2;
+      return_value_strlen$2=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$2 + (unsigned long int)3);
+      count = count + 1u;
+    }
+    void *return_value___builtin_alloca$3;
+    return_value___builtin_alloca$3=__builtin_alloca((unsigned long int)count * sizeof(struct option) );
+    long_options = (struct option *)return_value___builtin_alloca$3;
+    memset((void *)long_options, 0, (unsigned long int)count * sizeof(struct option) );
+    i = (unsigned int)0;
+    optstr = applet_long_options;
+    do
+    {
+      count = count - 1u;
+      if(count == 0u)
+        break;
+      (long_options + (signed long int)i)->name = optstr;
+      unsigned long int return_value_strlen$4;
+      return_value_strlen$4=strlen(optstr);
+      optstr = optstr + (signed long int)(return_value_strlen$4 + (unsigned long int)1);
+      tmp_post$5 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->has_arg = (signed int)(unsigned char)*tmp_post$5;
+      tmp_post$6 = optstr;
+      optstr = optstr + 1l;
+      (long_options + (signed long int)i)->val = (signed int)(unsigned char)*tmp_post$6;
+      i = i + 1u;
+    }
+    while((_Bool)1);
+    l_o = long_options;
+    for( ; !(l_o->name == ((const char *)((void *)0))); l_o = l_o + 1l)
+    {
+      if(l_o->flag == ((signed int *)((void *)0)))
+      {
+        on_off = complementary;
+        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+          if((signed int)on_off->opt_char == l_o->val)
+            goto next_long;
+        if(c >= 32)
+          break;
+        on_off->opt_char = (unsigned char)l_o->val;
+        on_off->switch_on = (unsigned int)(1 << c);
+        if(!(l_o->has_arg == 0))
+          on_off->optarg=__builtin_va_arg(p,__typeof__(on_off->optarg));
+        c = c + 1;
+      }
+    next_long:
+      ;
+    }
+    applet_long_options = (const char *)((void *)0);
+  }
+  s = (const unsigned char *)opt_complementary;
+  _Bool tmp_if_expr$7;
+  _Bool tmp_if_expr$8;
+  _Bool tmp_if_expr$9;
+  _Bool tmp_if_expr$10;
+  while((_Bool)1)
+  {
+    if(!(s == ((const unsigned char *)((void *)0))))
+      tmp_if_expr$7 = ((signed int)*s != 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$7 = 0 != 0;
+    if(tmp_if_expr$7 == (_Bool)0)
+      break;
+    struct libbb_anonymous$0 *pair;
+    unsigned int *pair_switch;
+    if(!((signed int)*s == 58))
+    {
+      c = (signed int)s[(signed long int)1];
+      if((signed int)*s == 63)
+      {
+        if(!(c < 48))
+        {
+          if(c > 57)
+            goto __CPROVER_DUMP_L24;
+        }
+        else
+        {
+        __CPROVER_DUMP_L24:
+          ;
+          spec_flgs = spec_flgs | 1;
+          goto __CPROVER_DUMP_L57;
+        }
+        max_arg = c - 48;
+        s = s + 1l;
+      }
+      else
+        if((signed int)*s == 45)
+        {
+          if(!(c < 48))
+          {
+            if(c > 57)
+              goto __CPROVER_DUMP_L27;
+          }
+          else
+          {
+          __CPROVER_DUMP_L27:
+            ;
+            if(c == 45)
+            {
+              spec_flgs = spec_flgs | 4;
+              s = s + 1l;
+            }
+            else
+              spec_flgs = spec_flgs | 2;
+            goto __CPROVER_DUMP_L58;
+          }
+          min_arg = c - 48;
+          s = s + 1l;
+        }
+        else
+          if((signed int)*s == 61)
+          {
+            max_arg = c - 48;
+            min_arg = max_arg;
+            s = s + 1l;
+          }
+          else
+          {
+            on_off = complementary;
+            for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+              if(on_off->opt_char == *s)
+                goto found_opt;
+            bb_error_msg_and_die("NO OPT %c!", *s);
+          found_opt:
+            ;
+            if(c == 58)
+            {
+              if(!((signed int)*(2l + s) == 58))
+                goto __CPROVER_DUMP_L36;
+              on_off->param_type = (signed char)1;
+            }
+            else
+            {
+            __CPROVER_DUMP_L36:
+              ;
+              if(c == 43)
+              {
+                if((signed int)*(2l + s) == 58)
+                  tmp_if_expr$8 = 1 != 0;
+                else
+                  tmp_if_expr$8 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                if(tmp_if_expr$8 == (_Bool)0)
+                  goto __CPROVER_DUMP_L39;
+                on_off->param_type = (signed char)2;
+                s = s + 1l;
+              }
+              else
+              {
+              __CPROVER_DUMP_L39:
+                ;
+                if(!(c == 58))
+                {
+                  if(c == 0)
+                    goto __CPROVER_DUMP_L40;
+                }
+                else
+                {
+                __CPROVER_DUMP_L40:
+                  ;
+                  requires = requires | on_off->switch_on;
+                  goto __CPROVER_DUMP_L59;
+                }
+                if(c == 45)
+                {
+                  if((signed int)*(2l + s) == 58)
+                    tmp_if_expr$9 = 1 != 0;
+                  else
+                    tmp_if_expr$9 = ((signed int)s[(signed long int)2] == 0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                  if(tmp_if_expr$9 == (_Bool)0)
+                    goto __CPROVER_DUMP_L44;
+                  flags = flags | on_off->switch_on;
+                  on_off->incongruously = on_off->incongruously | on_off->switch_on;
+                  s = s + 1l;
+                }
+                else
+                {
+                __CPROVER_DUMP_L44:
+                  ;
+                  if(c == (signed int)*s)
+                  {
+                    on_off->counter=__builtin_va_arg(p,__typeof__(on_off->counter));
+                    s = s + 1l;
+                  }
+                  pair = on_off;
+                  pair_switch = &pair->switch_on;
+                  s = s + 1l;
+                  while((_Bool)1)
+                  {
+                    if(!((signed int)*s == 0))
+                      tmp_if_expr$10 = ((signed int)*s != 58 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+                    else
+                      tmp_if_expr$10 = 0 != 0;
+                    if(tmp_if_expr$10 == (_Bool)0)
+                      break;
+                    if((signed int)*s == 63)
+                      pair_switch = &pair->requires;
+                    else
+                      if((signed int)*s == 45)
+                      {
+                        if(pair_switch == &pair->switch_off)
+                          pair_switch = &pair->incongruously;
+                        else
+                          pair_switch = &pair->switch_off;
+                      }
+                      else
+                      {
+                        on_off = complementary;
+                        for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+                          if(on_off->opt_char == *s)
+                          {
+                            *pair_switch = *pair_switch | on_off->switch_on;
+                            break;
+                          }
+                      }
+                    s = s + 1l;
+                  }
+                  s = s - 1l;
+                }
+              }
+            }
+          }
+    }
+  __CPROVER_DUMP_L57:
+    ;
+  __CPROVER_DUMP_L58:
+    ;
+  __CPROVER_DUMP_L59:
+    ;
+    s = s + 1l;
+  }
+  opt_complementary = (const char *)((void *)0);
+  __builtin_va_end(p);
+  if(!((6 & spec_flgs) == 0))
+  {
+    pargv = argv + (signed long int)1;
+    for( ; !(*pargv == ((char *)((void *)0))); pargv = pargv + 1l)
+    {
+      if(!((signed int)*(*pargv) == 45))
+      {
+        if(!((signed int)*(*pargv) == 0))
+        {
+          char *pp;
+          unsigned long int return_value_strlen$11;
+          return_value_strlen$11=strlen(*pargv);
+          void *return_value_xmalloc$12;
+          return_value_xmalloc$12=xmalloc(return_value_strlen$11 + (unsigned long int)2);
+          pp = (char *)return_value_xmalloc$12;
+          *pp = (char)45;
+          strcpy(pp + (signed long int)1, *pargv);
+          *pargv = pp;
+        }
+      }
+      if((2 & spec_flgs) == 0)
+        break;
+    }
+  }
+  optind = 0;
+  do
+  {
+    c=getopt_long(argc, argv, applet_opts, long_options, (signed int *)((void *)0));
+    if(c == -1)
+      break;
+    c = c & 255;
+    on_off = complementary;
+    for( ; !((signed int)on_off->opt_char == c); on_off = on_off + 1l)
+      if((signed int)on_off->opt_char == 0)
+        goto error;
+    if((on_off->incongruously & flags) != 0u)
+      goto error;
+    trigger = on_off->switch_on & on_off->switch_off;
+    flags = flags & ~(on_off->switch_off ^ trigger);
+    flags = flags | on_off->switch_on ^ trigger;
+    flags = flags ^ trigger;
+    if(!(on_off->counter == ((signed int *)((void *)0))))
+      *on_off->counter = *on_off->counter + 1;
+    if(!(optarg == ((char *)((void *)0))))
+    {
+      if((signed int)on_off->param_type == 1)
+        llist_add_to_end((struct llist_t **)on_off->optarg, (void *)optarg);
+      else
+        if((signed int)on_off->param_type == 2)
+        {
+          signed int return_value_xatoi_positive$13;
+          return_value_xatoi_positive$13=xatoi_positive(optarg);
+          *((unsigned int *)on_off->optarg) = (unsigned int)return_value_xatoi_positive$13;
+        }
+        else
+          if(!(on_off->optarg == ((void **)((void *)0))))
+            *((char **)on_off->optarg) = optarg;
+    }
+  }
+  while((_Bool)1);
+  on_off = complementary;
+  for( ; !((signed int)on_off->opt_char == 0); on_off = on_off + 1l)
+    if(!(on_off->requires == 0u))
+    {
+      if(!((on_off->switch_on & flags) == 0u))
+      {
+        if((on_off->requires & flags) == 0u)
+          goto error;
+      }
+    }
+  if((flags & requires) == 0u)
+  {
+    if(requires == 0u)
+      goto __CPROVER_DUMP_L75;
+  }
+  else
+  {
+  __CPROVER_DUMP_L75:
+    ;
+    argc = argc - optind;
+    if(max_arg >= 0)
+    {
+      if(max_arg >= argc)
+        goto __CPROVER_DUMP_L76;
+    }
+    else
+    {
+    __CPROVER_DUMP_L76:
+      ;
+      if(argc >= min_arg)
+      {
+        option_mask32 = flags;
+        return flags;
+      }
+    }
+  }
+error:
+  ;
+  if(!((signed int)first_char == 33))
+    bb_show_usage();
+  return (unsigned int)(signed int)-1;
+}
+static void idle_string(char *str6, signed long int t)
+{
+  signed long int return_value_time$1;
+  return_value_time$1=time((signed long int *)((void *)0));
+  t = return_value_time$1 - t;
+  if(t >= 0l)
+  {
+    if(t < 86400l)
+    {
+      sprintf(str6, "%02d:%02d", (signed int)(t / (signed long int)(60 * 60)), (signed int)((t % (signed long int)(60 * 60)) / (signed long int)60));
+      return;
+    }
+  }
+  strcpy(str6, "old");
+}
+static void llist_add_to_end(struct llist_t **list_head, void *data)
+{
+  for( ; !(*list_head == ((struct llist_t *)((void *)0))); list_head = &(*list_head)->link)
+    ;
+  void *return_value_xzalloc$1;
+  return_value_xzalloc$1=xzalloc(sizeof(struct llist_t) );
+  *list_head = (struct llist_t *)return_value_xzalloc$1;
+  (*list_head)->data = (char *)data;
+}
+static char * safe_strncpy(char *dst, const char *src, unsigned long int size)
+{
+  if(size == 0ul)
+    return dst;
+  size = size - 1ul;
+  dst[(signed long int)size] = (char)0;
+  char *return_value_strncpy$1;
+  return_value_strncpy$1=strncpy(dst, src, size);
+  return return_value_strncpy$1;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+int stat(const char *__file, struct stat *__buf)
+{
+  __buf->st_atim.tv_sec = __VERIFIER_nondet_long();
+  if (__VERIFIER_nondet_char())
+    return -1;
+  __VERIFIER_assume(__buf->st_atim.tv_sec >= 0);
+  return 0;
+}
+signed int __main(signed int argc, char **argv)
+{
+  struct utmp *ut;
+  unsigned int opt;
+  signed int do_users = (signed int)(0 != 0);
+  const char *fmt = "%s";
+  opt_complementary = "=0";
+  opt=getopt32(argv, do_users != 0 ? "" : "aH");
+  if(!((2u & opt) == 0u))
+    printf("USER\t\tTTY\t\tIDLE\tTIME\t\t HOST\n");
+  setutent();
+  _Bool tmp_if_expr$4;
+  char *tmp_if_expr$1;
+  do
+  {
+    ut=getutent();
+    if(ut == ((struct utmp *)((void *)0)))
+      break;
+    if(!((signed int)ut->ut_user[0l] == 0))
+    {
+      if(!((1u & opt) == 0u))
+        tmp_if_expr$4 = 1 != 0;
+      else
+      {
+        tmp_if_expr$4 = ((signed int)ut->ut_type == 7 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+      }
+      if(!(tmp_if_expr$4 == (_Bool)0))
+      {
+        if(do_users == 0)
+        {
+          char str6[6l];
+          char name[39l];
+          struct stat st;
+          signed long int seconds;
+          str6[(signed long int)0] = (char)63;
+          str6[(signed long int)1] = (char)0;
+          strcpy(name, "/dev/");
+          if((signed int)ut->ut_line[0l] == 47)
+            tmp_if_expr$1 = name;
+          else
+            tmp_if_expr$1 = (name + (signed long int)sizeof(char [6l]) ) - (signed long int)1;
+          safe_strncpy(tmp_if_expr$1, ut->ut_line, sizeof(char [32l]) + (unsigned long int)1);
+          signed int return_value_stat$2;
+          return_value_stat$2=stat(name, &st);
+          if(return_value_stat$2 == 0)
+            idle_string(str6, st.st_atim.tv_sec);
+          seconds = (signed long int)ut->ut_tv.tv_sec;
+          char *return_value_ctime$3;
+          return_value_ctime$3=ctime(&seconds);
+          printf("%-15.*s %-15.*s %-7s %-16.16s %.*s\n", (signed int)sizeof(char [32l]) , ut->ut_user, (signed int)sizeof(char [32l]) , ut->ut_line, str6, return_value_ctime$3 + (signed long int)4, (signed int)sizeof(char [256l]) , ut->ut_host);
+        }
+        else
+        {
+          printf(fmt, (const void *)ut->ut_user);
+          fmt = " %s";
+        }
+      }
+    }
+  }
+  while((_Bool)1);
+  if(!(do_users == 0))
+    bb_putchar(10);
+  return 0;
+}
+static signed int xatoi_positive(const char *numstr)
+{
+  unsigned int return_value_xatou_range$1;
+  return_value_xatou_range$1=xatou_range(numstr, (unsigned int)0, (unsigned int)2147483647);
+  return (signed int)return_value_xatou_range$1;
+}
+static unsigned int xatou_range(const char *numstr, unsigned int lower, unsigned int upper)
+{
+  unsigned int return_value_xstrtou_range_sfx$1;
+  return_value_xstrtou_range_sfx$1=xstrtou_range_sfx(numstr, 10, lower, upper, (struct suffix_mult *)((void *)0));
+  return return_value_xstrtou_range_sfx$1;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static void * xmalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=malloc(size);
+  if(ptr == ((void *)0))
+  {
+    if(!(size == 0ul))
+      bb_error_msg_and_die(bb_msg_memory_exhausted);
+  }
+  return ptr;
+}
+static unsigned int xstrtou_range_sfx(const char *numstr, signed int base, unsigned int lower, unsigned int upper, struct suffix_mult *suffixes)
+{
+  unsigned int r;
+  signed int old_errno;
+  char *e;
+  _Bool tmp_if_expr$1;
+  if((signed int)*numstr == 45)
+    tmp_if_expr$1 = 1 != 0;
+  else
+    tmp_if_expr$1 = ((signed int)*numstr == 43 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  _Bool tmp_if_expr$3;
+  _Bool tmp_statement_expression$2;
+  if(!(tmp_if_expr$1 == (_Bool)0))
+    tmp_if_expr$3 = 1 != 0;
+  else
+  {
+    unsigned char bb__isspace = (unsigned char)((signed int)*numstr - 9);
+    tmp_statement_expression$2 = (signed int)bb__isspace == 32 - 9 || (signed int)bb__isspace <= 13 - 9;
+    tmp_if_expr$3 = (tmp_statement_expression$2 != (_Bool)0 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+  }
+  signed int tmp_statement_expression$4;
+  if(tmp_if_expr$3 == (_Bool)0)
+  {
+    old_errno = *bb_errno;
+    *bb_errno = 0;
+    r=bb_strtoui(numstr, &e, base);
+    if(!(numstr == e))
+    {
+      if(*bb_errno == 0)
+      {
+        *bb_errno = old_errno;
+        if(!(suffixes == ((struct suffix_mult *)((void *)0))))
+          for( ; !(suffixes->mult == 0u); suffixes = suffixes + 1l)
+          {
+            unsigned long int __s1_len;
+            unsigned long int __s2_len;
+            signed int return_value___builtin_strcmp$5;
+            return_value___builtin_strcmp$5=strcmp(suffixes->suffix, e);
+            tmp_statement_expression$4 = return_value___builtin_strcmp$5;
+            if(tmp_statement_expression$4 == 0)
+            {
+              if(!(4294967295u / suffixes->mult >= r))
+                goto range;
+              r = r * suffixes->mult;
+              goto chk_range;
+            }
+          }
+        if((signed int)*e == 0)
+        {
+        chk_range:
+          ;
+          if(r >= lower)
+          {
+            if(upper >= r)
+              return r;
+          }
+        range:
+          ;
+          bb_error_msg_and_die("number %s is not in %llu..%llu range", numstr, (unsigned long long int)lower, (unsigned long long int)upper);
+        }
+      }
+    }
+  }
+inval:
+  ;
+  bb_error_msg_and_die("invalid number '%s'", numstr);
+}
+static void * xzalloc(unsigned long int size)
+{
+  void *ptr;
+  ptr=xmalloc(size);
+  memset(ptr, 0, size);
+  return ptr;
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.c
@@ -202,7 +202,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.i
@@ -2472,7 +2472,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.c
@@ -1,0 +1,284 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <pwd.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...);
+// file include/pwd_.h line 70
+struct passwd * bb_internal_getpwuid(unsigned int);
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+// file libbb/bb_pwd.c line 35
+static struct passwd * xgetpwuid(unsigned int uid);
+// file libbb/bb_pwd.c line 51
+static char * xuid2uname(unsigned int uid);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1082
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  bb_verror_msg(s, p, (const char *)NULL);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file ./libbb-dump.i line 1
+static void bb_show_usage(void)
+{
+  ;
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file coreutils/whoami.c line 22
+signed int __main(signed int argc, char **argv)
+{
+
+  if(!(*(1l + argv) == ((char *)NULL)))
+    bb_show_usage();
+
+  unsigned int return_value_geteuid$1;
+  return_value_geteuid$1=geteuid();
+  char *return_value_xuid2uname$2;
+  return_value_xuid2uname$2=xuid2uname(return_value_geteuid$1);
+  puts(return_value_xuid2uname$2);
+  signed int return_value_fflush_all$3;
+  return_value_fflush_all$3=fflush_all();
+  return return_value_fflush_all$3;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file libbb/bb_pwd.c line 35
+static struct passwd * xgetpwuid(unsigned int uid)
+{
+  struct passwd *pw;
+  pw=bb_internal_getpwuid(uid);
+  if(pw == ((struct passwd *)NULL))
+    bb_error_msg_and_die("unknown uid %u", (unsigned int)uid);
+
+  return pw;
+}
+
+// file libbb/bb_pwd.c line 51
+static char * xuid2uname(unsigned int uid)
+{
+  struct passwd *pw;
+  pw=xgetpwuid(uid);
+  return pw->pw_name;
+}
+
+#include "busybox_sv_comp-getpwnam.h"
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
@@ -1,0 +1,2558 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef __gid_t gid_t;
+typedef __uid_t uid_t;
+struct passwd
+{
+  char *pw_name;
+  char *pw_passwd;
+  __uid_t pw_uid;
+  __gid_t pw_gid;
+  char *pw_gecos;
+  char *pw_dir;
+  char *pw_shell;
+};
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+extern void setpwent (void);
+extern void endpwent (void);
+extern struct passwd *getpwent (void);
+extern struct passwd *fgetpwent (FILE *__stream);
+extern int putpwent (const struct passwd *__restrict __p,
+       FILE *__restrict __f);
+extern struct passwd *getpwuid (__uid_t __uid);
+extern struct passwd *getpwnam (const char *__name);
+extern int getpwent_r (struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int getpwuid_r (__uid_t __uid,
+         struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int getpwnam_r (const char *__restrict __name,
+         struct passwd *__restrict __resultbuf,
+         char *__restrict __buffer, size_t __buflen,
+         struct passwd **__restrict __result);
+extern int fgetpwent_r (FILE *__restrict __stream,
+   struct passwd *__restrict __resultbuf,
+   char *__restrict __buffer, size_t __buflen,
+   struct passwd **__restrict __result);
+extern int getpw (__uid_t __uid, char *__buffer);
+
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_error_msg_and_die(const char *s, ...);
+struct passwd * bb_internal_getpwuid(unsigned int);
+static void bb_show_usage(void);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void xfunc_die(void);
+static struct passwd * xgetpwuid(unsigned int uid);
+static char * xuid2uname(unsigned int uid);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_error_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  bb_verror_msg(s, p, (const char *)((void *)0));
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_show_usage(void)
+{
+  ;
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+signed int __main(signed int argc, char **argv)
+{
+  if(!(*(1l + argv) == ((char *)((void *)0))))
+    bb_show_usage();
+  unsigned int return_value_geteuid$1;
+  return_value_geteuid$1=geteuid();
+  char *return_value_xuid2uname$2;
+  return_value_xuid2uname$2=xuid2uname(return_value_geteuid$1);
+  puts(return_value_xuid2uname$2);
+  signed int return_value_fflush_all$3;
+  return_value_fflush_all$3=fflush_all();
+  return return_value_fflush_all$3;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+static struct passwd * xgetpwuid(unsigned int uid)
+{
+  struct passwd *pw;
+  pw=bb_internal_getpwuid(uid);
+  if(pw == ((struct passwd *)((void *)0)))
+    bb_error_msg_and_die("unknown uid %u", (unsigned int)uid);
+  return pw;
+}
+static char * xuid2uname(unsigned int uid)
+{
+  struct passwd *pw;
+  pw=xgetpwuid(uid);
+  return pw->pw_name;
+}
+struct passwd *bb_internal_getpwnam(const char *name)
+{
+  (void)name;
+  static struct passwd p;
+  p.pw_name = "";
+  p.pw_passwd = "";
+  p.pw_uid = __VERIFIER_nondet_uint();
+  p.pw_gid = __VERIFIER_nondet_uint();
+  p.pw_gecos = "";
+  p.pw_dir = "";
+  p.pw_shell = "";
+  return &p;
+}
+struct passwd *bb_internal_getpwuid(uid_t uid)
+{
+  (void)uid;
+  return bb_internal_getpwnam(0);
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.c
@@ -99,7 +99,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -2279,7 +2279,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/yes_false-no-overflow.c
+++ b/c/busybox-1.22.0/yes_false-no-overflow.c
@@ -1,0 +1,281 @@
+/*
+   This package is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 dated June, 1991.
+
+   This package is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this package; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+*/
+
+#include "busybox_sv_comp.h"
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <syslog.h>
+#include <libio.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <stdarg.h>
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...);
+// file libbb/perror_nomsg_and_die.c line 19
+static void bb_perror_nomsg_and_die(void);
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+// file include/libbb.h line 785
+static signed int fflush_all(void);
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+// file include/libbb.h line 1079
+static void xfunc_die(void);
+
+struct libbb_anonymous$7
+{
+  // __val
+  unsigned long int __val[16l];
+};
+
+// file include/libbb.h line 1708
+static const char *applet_name;
+// file libbb/ptr_to_globals.c line 19
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+// file libbb/xfunc_die.c line 17
+static struct __jmp_buf_tag die_jmp[1l];
+// file libbb/xfunc_die.c line 15
+static signed int die_sleep;
+// file libbb/verror_msg.c line 14
+static signed char logmode = (signed char)1;
+// file libbb/verror_msg.c line 15
+static const char *msg_eol = "\n";
+// file libbb/default_error_retval.c line 18
+static unsigned char xfunc_error_retval = (unsigned char)1;
+
+// file include/libbb.h line 1085
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+
+  else
+    tmp_if_expr$2 = (char *)NULL;
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  va_end(p);
+  abort(); // xfunc_die() invokes exit() and would thus leak memory
+}
+
+// file libbb/perror_nomsg_and_die.c line 19
+static void bb_perror_nomsg_and_die(void)
+{
+  bb_perror_msg_and_die((const char *)NULL);
+}
+
+// file include/libbb.h line 1092
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+
+  if(s == ((const char *)NULL))
+    s = "";
+
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)NULL)))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)NULL))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)NULL)))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+
+  free((void *)msg);
+}
+
+// file include/libbb.h line 785
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)NULL);
+  return return_value_fflush$1;
+}
+
+// file include/libbb.h line 751
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+
+      return cc;
+    }
+
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+
+// file include/libbb.h line 748
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+
+// file include/libbb.h line 1079
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+
+    sleep((unsigned int)die_sleep);
+  }
+
+  exit((signed int)xfunc_error_retval);
+}
+
+// file coreutils/yes.c line 27
+signed int __main(signed int argc, char **argv)
+{
+  char **pp;
+
+  argv[(signed long int)0] = (char *)"y";
+
+  if(!(*(1l + argv) == ((char *)NULL)))
+    argv = argv + 1l;
+
+  signed int return_value_putchar_unlocked$1;
+  do
+  {
+    pp = argv;
+    while((_Bool)1)
+    {
+
+      fputs(*pp, stdout);
+      pp = pp + 1l;
+
+      if(*pp == ((char *)NULL))
+        break;
+
+      putchar(32);
+    }
+    return_value_putchar_unlocked$1=putchar(10);
+  }
+  while(return_value_putchar_unlocked$1 != -1);
+  bb_perror_nomsg_and_die();
+}
+
+#include "busybox_sv_comp_impl.h"

--- a/c/busybox-1.22.0/yes_false-no-overflow.i
+++ b/c/busybox-1.22.0/yes_false-no-overflow.i
@@ -1,0 +1,2506 @@
+extern long __VERIFIER_nondet_long(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_uint(void);
+extern char __VERIFIER_nondet_char(void);
+extern short __VERIFIER_nondet_short(void);
+extern void __VERIFIER_assume(int);
+extern void __VERIFIER_error(void);
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef int __daddr_t;
+typedef int __key_t;
+typedef int __clockid_t;
+typedef void * __timer_t;
+typedef long int __blksize_t;
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+typedef long int __fsword_t;
+typedef long int __ssize_t;
+typedef long int __syscall_slong_t;
+typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef __quad_t *__qaddr_t;
+typedef char *__caddr_t;
+typedef long int __intptr_t;
+typedef unsigned int __socklen_t;
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+enum
+{
+  _ISupper = ((0) < 8 ? ((1 << (0)) << 8) : ((1 << (0)) >> 8)),
+  _ISlower = ((1) < 8 ? ((1 << (1)) << 8) : ((1 << (1)) >> 8)),
+  _ISalpha = ((2) < 8 ? ((1 << (2)) << 8) : ((1 << (2)) >> 8)),
+  _ISdigit = ((3) < 8 ? ((1 << (3)) << 8) : ((1 << (3)) >> 8)),
+  _ISxdigit = ((4) < 8 ? ((1 << (4)) << 8) : ((1 << (4)) >> 8)),
+  _ISspace = ((5) < 8 ? ((1 << (5)) << 8) : ((1 << (5)) >> 8)),
+  _ISprint = ((6) < 8 ? ((1 << (6)) << 8) : ((1 << (6)) >> 8)),
+  _ISgraph = ((7) < 8 ? ((1 << (7)) << 8) : ((1 << (7)) >> 8)),
+  _ISblank = ((8) < 8 ? ((1 << (8)) << 8) : ((1 << (8)) >> 8)),
+  _IScntrl = ((9) < 8 ? ((1 << (9)) << 8) : ((1 << (9)) >> 8)),
+  _ISpunct = ((10) < 8 ? ((1 << (10)) << 8) : ((1 << (10)) >> 8)),
+  _ISalnum = ((11) < 8 ? ((1 << (11)) << 8) : ((1 << (11)) >> 8))
+};
+extern const unsigned short int **__ctype_b_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_tolower_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern const __int32_t **__ctype_toupper_loc (void)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+extern int isalnum (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper (int __c) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int isblank (int) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int isctype (int __c, int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern int isascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int toascii (int __c) __attribute__ ((__nothrow__ , __leaf__));
+extern int _toupper (int) __attribute__ ((__nothrow__ , __leaf__));
+extern int _tolower (int) __attribute__ ((__nothrow__ , __leaf__));
+typedef struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+} *__locale_t;
+typedef __locale_t locale_t;
+extern int isalnum_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isalpha_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int iscntrl_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int islower_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isgraph_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isprint_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int ispunct_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isspace_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isupper_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isxdigit_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int isblank_l (int, __locale_t) __attribute__ ((__nothrow__ , __leaf__));
+extern int __tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int tolower_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int __toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern int toupper_l (int __c, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long (int ___argc, char *const *___argv,
+   const char *__shortopts,
+          const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+extern int getopt_long_only (int ___argc, char *const *___argv,
+        const char *__shortopts,
+               const struct option *__longopts, int *__longind)
+       __attribute__ ((__nothrow__ , __leaf__));
+typedef __builtin_va_list __gnuc_va_list;
+
+extern void closelog (void);
+extern void openlog (const char *__ident, int __option, int __facility);
+extern int setlogmask (int __mask) __attribute__ ((__nothrow__ , __leaf__));
+extern void syslog (int __pri, const char *__fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+extern void vsyslog (int __pri, const char *__fmt, __gnuc_va_list __ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+
+typedef long unsigned int size_t;
+typedef struct
+{
+  int __count;
+  union
+  {
+    unsigned int __wch;
+    char __wchb[4];
+  } __value;
+} __mbstate_t;
+typedef struct
+{
+  __off_t __pos;
+  __mbstate_t __state;
+} _G_fpos_t;
+typedef struct
+{
+  __off64_t __pos;
+  __mbstate_t __state;
+} _G_fpos64_t;
+struct _IO_jump_t; struct _IO_FILE;
+typedef void _IO_lock_t;
+struct _IO_marker {
+  struct _IO_marker *_next;
+  struct _IO_FILE *_sbuf;
+  int _pos;
+};
+enum __codecvt_result
+{
+  __codecvt_ok,
+  __codecvt_partial,
+  __codecvt_error,
+  __codecvt_noconv
+};
+struct _IO_FILE {
+  int _flags;
+  char* _IO_read_ptr;
+  char* _IO_read_end;
+  char* _IO_read_base;
+  char* _IO_write_base;
+  char* _IO_write_ptr;
+  char* _IO_write_end;
+  char* _IO_buf_base;
+  char* _IO_buf_end;
+  char *_IO_save_base;
+  char *_IO_backup_base;
+  char *_IO_save_end;
+  struct _IO_marker *_markers;
+  struct _IO_FILE *_chain;
+  int _fileno;
+  int _flags2;
+  __off_t _old_offset;
+  unsigned short _cur_column;
+  signed char _vtable_offset;
+  char _shortbuf[1];
+  _IO_lock_t *_lock;
+  __off64_t _offset;
+  void *__pad1;
+  void *__pad2;
+  void *__pad3;
+  void *__pad4;
+  size_t __pad5;
+  int _mode;
+  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
+};
+typedef struct _IO_FILE _IO_FILE;
+struct _IO_FILE_plus;
+extern struct _IO_FILE_plus _IO_2_1_stdin_;
+extern struct _IO_FILE_plus _IO_2_1_stdout_;
+extern struct _IO_FILE_plus _IO_2_1_stderr_;
+typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
+typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
+     size_t __n);
+typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
+typedef int __io_close_fn (void *__cookie);
+typedef __io_read_fn cookie_read_function_t;
+typedef __io_write_fn cookie_write_function_t;
+typedef __io_seek_fn cookie_seek_function_t;
+typedef __io_close_fn cookie_close_function_t;
+typedef struct
+{
+  __io_read_fn *read;
+  __io_write_fn *write;
+  __io_seek_fn *seek;
+  __io_close_fn *close;
+} _IO_cookie_io_functions_t;
+typedef _IO_cookie_io_functions_t cookie_io_functions_t;
+struct _IO_cookie_file;
+extern void _IO_cookie_init (struct _IO_cookie_file *__cfile, int __read_write,
+        void *__cookie, _IO_cookie_io_functions_t __fns);
+extern int __underflow (_IO_FILE *);
+extern int __uflow (_IO_FILE *);
+extern int __overflow (_IO_FILE *, int);
+extern int _IO_getc (_IO_FILE *__fp);
+extern int _IO_putc (int __c, _IO_FILE *__fp);
+extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_peekc_locked (_IO_FILE *__fp);
+extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
+   __gnuc_va_list, int *__restrict);
+extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
+    __gnuc_va_list);
+extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
+extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
+extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
+extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
+extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef long int __jmp_buf[8];
+typedef int __sig_atomic_t;
+typedef struct
+  {
+    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
+  } __sigset_t;
+struct __jmp_buf_tag
+  {
+    __jmp_buf __jmpbuf;
+    int __mask_was_saved;
+    __sigset_t __saved_mask;
+  };
+
+typedef struct __jmp_buf_tag jmp_buf[1];
+extern int setjmp (jmp_buf __env) __attribute__ ((__nothrow__));
+
+extern int __sigsetjmp (struct __jmp_buf_tag __env[1], int __savemask) __attribute__ ((__nothrow__));
+extern int _setjmp (struct __jmp_buf_tag __env[1]) __attribute__ ((__nothrow__));
+
+extern void longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+extern void _longjmp (struct __jmp_buf_tag __env[1], int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+typedef struct __jmp_buf_tag sigjmp_buf[1];
+extern void siglongjmp (sigjmp_buf __env, int __val)
+     __attribute__ ((__nothrow__)) __attribute__ ((__noreturn__));
+
+
+extern int __sigismember (const __sigset_t *, int);
+extern int __sigaddset (__sigset_t *, int);
+extern int __sigdelset (__sigset_t *, int);
+
+typedef __sig_atomic_t sig_atomic_t;
+
+typedef __sigset_t sigset_t;
+typedef __pid_t pid_t;
+typedef __uid_t uid_t;
+struct timespec
+  {
+    __time_t tv_sec;
+    __syscall_slong_t tv_nsec;
+  };
+typedef union sigval
+  {
+    int sival_int;
+    void *sival_ptr;
+  } sigval_t;
+typedef __clock_t __sigchld_clock_t;
+typedef struct
+  {
+    int si_signo;
+    int si_errno;
+    int si_code;
+    union
+      {
+ int _pad[((128 / sizeof (int)) - 4)];
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+   } _kill;
+ struct
+   {
+     int si_tid;
+     int si_overrun;
+     sigval_t si_sigval;
+   } _timer;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     sigval_t si_sigval;
+   } _rt;
+ struct
+   {
+     __pid_t si_pid;
+     __uid_t si_uid;
+     int si_status;
+     __sigchld_clock_t si_utime;
+     __sigchld_clock_t si_stime;
+   } _sigchld;
+ struct
+   {
+     void *si_addr;
+     short int si_addr_lsb;
+   } _sigfault;
+ struct
+   {
+     long int si_band;
+     int si_fd;
+   } _sigpoll;
+ struct
+   {
+     void *_call_addr;
+     int _syscall;
+     unsigned int _arch;
+   } _sigsys;
+      } _sifields;
+  } siginfo_t ;
+enum
+{
+  SI_ASYNCNL = -60,
+  SI_TKILL = -6,
+  SI_SIGIO,
+  SI_ASYNCIO,
+  SI_MESGQ,
+  SI_TIMER,
+  SI_QUEUE,
+  SI_USER,
+  SI_KERNEL = 0x80
+};
+enum
+{
+  ILL_ILLOPC = 1,
+  ILL_ILLOPN,
+  ILL_ILLADR,
+  ILL_ILLTRP,
+  ILL_PRVOPC,
+  ILL_PRVREG,
+  ILL_COPROC,
+  ILL_BADSTK
+};
+enum
+{
+  FPE_INTDIV = 1,
+  FPE_INTOVF,
+  FPE_FLTDIV,
+  FPE_FLTOVF,
+  FPE_FLTUND,
+  FPE_FLTRES,
+  FPE_FLTINV,
+  FPE_FLTSUB
+};
+enum
+{
+  SEGV_MAPERR = 1,
+  SEGV_ACCERR
+};
+enum
+{
+  BUS_ADRALN = 1,
+  BUS_ADRERR,
+  BUS_OBJERR,
+  BUS_MCEERR_AR,
+  BUS_MCEERR_AO
+};
+enum
+{
+  TRAP_BRKPT = 1,
+  TRAP_TRACE
+};
+enum
+{
+  CLD_EXITED = 1,
+  CLD_KILLED,
+  CLD_DUMPED,
+  CLD_TRAPPED,
+  CLD_STOPPED,
+  CLD_CONTINUED
+};
+enum
+{
+  POLL_IN = 1,
+  POLL_OUT,
+  POLL_MSG,
+  POLL_ERR,
+  POLL_PRI,
+  POLL_HUP
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef struct sigevent
+  {
+    sigval_t sigev_value;
+    int sigev_signo;
+    int sigev_notify;
+    union
+      {
+ int _pad[((64 / sizeof (int)) - 4)];
+ __pid_t _tid;
+ struct
+   {
+     void (*_function) (sigval_t);
+     pthread_attr_t *_attribute;
+   } _sigev_thread;
+      } _sigev_un;
+  } sigevent_t;
+enum
+{
+  SIGEV_SIGNAL = 0,
+  SIGEV_NONE,
+  SIGEV_THREAD,
+  SIGEV_THREAD_ID = 4
+};
+typedef void (*__sighandler_t) (int);
+extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sysv_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t bsd_signal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+
+extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern void psignal (int __sig, const char *__s);
+extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
+extern int __sigpause (int __sig_or_mask, int __is_sig);
+extern int sigpause (int __sig) __asm__ ("__xpg_sigpause");
+extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+typedef __sighandler_t sighandler_t;
+typedef __sighandler_t sig_t;
+extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigismember (const sigset_t *__set, int __signo)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigisemptyset (const sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigandset (sigset_t *__set, const sigset_t *__left,
+        const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int sigorset (sigset_t *__set, const sigset_t *__left,
+       const sigset_t *__right) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+struct sigaction
+  {
+    union
+      {
+ __sighandler_t sa_handler;
+ void (*sa_sigaction) (int, siginfo_t *, void *);
+      }
+    __sigaction_handler;
+    __sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer) (void);
+  };
+extern int sigprocmask (int __how, const sigset_t *__restrict __set,
+   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
+extern int sigaction (int __sig, const struct sigaction *__restrict __act,
+        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int sigwaitinfo (const sigset_t *__restrict __set,
+   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
+extern int sigtimedwait (const sigset_t *__restrict __set,
+    siginfo_t *__restrict __info,
+    const struct timespec *__restrict __timeout)
+     __attribute__ ((__nonnull__ (1)));
+extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern const char *const _sys_siglist[65];
+extern const char *const sys_siglist[65];
+struct sigvec
+  {
+    __sighandler_t sv_handler;
+    int sv_mask;
+    int sv_flags;
+  };
+extern int sigvec (int __sig, const struct sigvec *__vec,
+     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
+struct _fpx_sw_bytes
+{
+  __uint32_t magic1;
+  __uint32_t extended_size;
+  __uint64_t xstate_bv;
+  __uint32_t xstate_size;
+  __uint32_t padding[7];
+};
+struct _fpreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+};
+struct _fpxreg
+{
+  unsigned short significand[4];
+  unsigned short exponent;
+  unsigned short padding[3];
+};
+struct _xmmreg
+{
+  __uint32_t element[4];
+};
+struct _fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _fpxreg _st[8];
+  struct _xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+struct sigcontext
+{
+  __uint64_t r8;
+  __uint64_t r9;
+  __uint64_t r10;
+  __uint64_t r11;
+  __uint64_t r12;
+  __uint64_t r13;
+  __uint64_t r14;
+  __uint64_t r15;
+  __uint64_t rdi;
+  __uint64_t rsi;
+  __uint64_t rbp;
+  __uint64_t rbx;
+  __uint64_t rdx;
+  __uint64_t rax;
+  __uint64_t rcx;
+  __uint64_t rsp;
+  __uint64_t rip;
+  __uint64_t eflags;
+  unsigned short cs;
+  unsigned short gs;
+  unsigned short fs;
+  unsigned short __pad0;
+  __uint64_t err;
+  __uint64_t trapno;
+  __uint64_t oldmask;
+  __uint64_t cr2;
+  __extension__ union
+    {
+      struct _fpstate * fpstate;
+      __uint64_t __fpstate_word;
+    };
+  __uint64_t __reserved1 [8];
+};
+struct _xsave_hdr
+{
+  __uint64_t xstate_bv;
+  __uint64_t reserved1[2];
+  __uint64_t reserved2[5];
+};
+struct _ymmh_state
+{
+  __uint32_t ymmh_space[64];
+};
+struct _xstate
+{
+  struct _fpstate fpstate;
+  struct _xsave_hdr xstate_hdr;
+  struct _ymmh_state ymmh;
+};
+extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
+extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
+struct sigstack
+  {
+    void *ss_sp;
+    int ss_onstack;
+  };
+enum
+{
+  SS_ONSTACK = 1,
+  SS_DISABLE
+};
+typedef struct sigaltstack
+  {
+    void *ss_sp;
+    int ss_flags;
+    size_t ss_size;
+  } stack_t;
+__extension__ typedef long long int greg_t;
+typedef greg_t gregset_t[23];
+enum
+{
+  REG_R8 = 0,
+  REG_R9,
+  REG_R10,
+  REG_R11,
+  REG_R12,
+  REG_R13,
+  REG_R14,
+  REG_R15,
+  REG_RDI,
+  REG_RSI,
+  REG_RBP,
+  REG_RBX,
+  REG_RDX,
+  REG_RAX,
+  REG_RCX,
+  REG_RSP,
+  REG_RIP,
+  REG_EFL,
+  REG_CSGSFS,
+  REG_ERR,
+  REG_TRAPNO,
+  REG_OLDMASK,
+  REG_CR2
+};
+struct _libc_fpxreg
+{
+  unsigned short int significand[4];
+  unsigned short int exponent;
+  unsigned short int padding[3];
+};
+struct _libc_xmmreg
+{
+  __uint32_t element[4];
+};
+struct _libc_fpstate
+{
+  __uint16_t cwd;
+  __uint16_t swd;
+  __uint16_t ftw;
+  __uint16_t fop;
+  __uint64_t rip;
+  __uint64_t rdp;
+  __uint32_t mxcsr;
+  __uint32_t mxcr_mask;
+  struct _libc_fpxreg _st[8];
+  struct _libc_xmmreg _xmm[16];
+  __uint32_t padding[24];
+};
+typedef struct _libc_fpstate *fpregset_t;
+typedef struct
+  {
+    gregset_t gregs;
+    fpregset_t fpregs;
+    __extension__ unsigned long long __reserved1 [8];
+} mcontext_t;
+typedef struct ucontext
+  {
+    unsigned long int uc_flags;
+    struct ucontext *uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+  } ucontext_t;
+extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
+extern int sigaltstack (const struct sigaltstack *__restrict __ss,
+   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
+extern int sighold (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigrelse (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern int sigignore (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern __sighandler_t sigset (int __sig, __sighandler_t __disp) __attribute__ ((__nothrow__ , __leaf__));
+typedef unsigned long int pthread_t;
+union pthread_attr_t
+{
+  char __size[56];
+  long int __align;
+};
+typedef struct __pthread_internal_list
+{
+  struct __pthread_internal_list *__prev;
+  struct __pthread_internal_list *__next;
+} __pthread_list_t;
+typedef union
+{
+  struct __pthread_mutex_s
+  {
+    int __lock;
+    unsigned int __count;
+    int __owner;
+    unsigned int __nusers;
+    int __kind;
+    short __spins;
+    short __elision;
+    __pthread_list_t __list;
+  } __data;
+  char __size[40];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __futex;
+    __extension__ unsigned long long int __total_seq;
+    __extension__ unsigned long long int __wakeup_seq;
+    __extension__ unsigned long long int __woken_seq;
+    void *__mutex;
+    unsigned int __nwaiters;
+    unsigned int __broadcast_seq;
+  } __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+typedef union
+{
+  struct
+  {
+    int __lock;
+    unsigned int __nr_readers;
+    unsigned int __readers_wakeup;
+    unsigned int __writer_wakeup;
+    unsigned int __nr_readers_queued;
+    unsigned int __nr_writers_queued;
+    int __writer;
+    int __shared;
+    unsigned long int __pad1;
+    unsigned long int __pad2;
+    unsigned int __flags;
+  } __data;
+  char __size[56];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[32];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+extern int pthread_sigmask (int __how,
+       const __sigset_t *__restrict __newmask,
+       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_sigqueue (pthread_t __threadid, int __signo,
+        const union sigval __value) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
+
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+
+typedef struct _IO_FILE __FILE;
+typedef __gnuc_va_list va_list;
+typedef __off_t off_t;
+typedef __off64_t off64_t;
+typedef __ssize_t ssize_t;
+
+typedef _G_fpos_t fpos_t;
+
+typedef _G_fpos64_t fpos64_t;
+extern struct _IO_FILE *stdin;
+extern struct _IO_FILE *stdout;
+extern struct _IO_FILE *stderr;
+
+extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
+extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int renameat (int __oldfd, const char *__old, int __newfd,
+       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
+
+extern FILE *tmpfile (void) ;
+extern FILE *tmpfile64 (void) ;
+extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *tempnam (const char *__dir, const char *__pfx)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int fclose (FILE *__stream);
+extern int fflush (FILE *__stream);
+
+extern int fflush_unlocked (FILE *__stream);
+extern int fcloseall (void);
+
+extern FILE *fopen (const char *__restrict __filename,
+      const char *__restrict __modes) ;
+extern FILE *freopen (const char *__restrict __filename,
+        const char *__restrict __modes,
+        FILE *__restrict __stream) ;
+
+extern FILE *fopen64 (const char *__restrict __filename,
+        const char *__restrict __modes) ;
+extern FILE *freopen64 (const char *__restrict __filename,
+   const char *__restrict __modes,
+   FILE *__restrict __stream) ;
+extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fopencookie (void *__restrict __magic_cookie,
+     const char *__restrict __modes,
+     _IO_cookie_io_functions_t __io_funcs) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
+  __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
+      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
+         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int fprintf (FILE *__restrict __stream,
+      const char *__restrict __format, ...);
+extern int printf (const char *__restrict __format, ...);
+extern int sprintf (char *__restrict __s,
+      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
+extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg);
+extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
+extern int vsprintf (char *__restrict __s, const char *__restrict __format,
+       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
+
+
+extern int snprintf (char *__restrict __s, size_t __maxlen,
+       const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
+extern int vsnprintf (char *__restrict __s, size_t __maxlen,
+        const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
+
+extern int vasprintf (char **__restrict __ptr, const char *__restrict __f,
+        __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0))) ;
+extern int __asprintf (char **__restrict __ptr,
+         const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int asprintf (char **__restrict __ptr,
+       const char *__restrict __fmt, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3))) ;
+extern int vdprintf (int __fd, const char *__restrict __fmt,
+       __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
+extern int dprintf (int __fd, const char *__restrict __fmt, ...)
+     __attribute__ ((__format__ (__printf__, 2, 3)));
+
+extern int fscanf (FILE *__restrict __stream,
+     const char *__restrict __format, ...) ;
+extern int scanf (const char *__restrict __format, ...) ;
+extern int sscanf (const char *__restrict __s,
+     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
+      __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
+extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
+extern int vsscanf (const char *__restrict __s,
+      const char *__restrict __format, __gnuc_va_list __arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
+
+
+extern int fgetc (FILE *__stream);
+extern int getc (FILE *__stream);
+extern int getchar (void);
+
+extern int getc_unlocked (FILE *__stream);
+extern int getchar_unlocked (void);
+extern int fgetc_unlocked (FILE *__stream);
+
+extern int fputc (int __c, FILE *__stream);
+extern int putc (int __c, FILE *__stream);
+extern int putchar (int __c);
+
+extern int fputc_unlocked (int __c, FILE *__stream);
+extern int putc_unlocked (int __c, FILE *__stream);
+extern int putchar_unlocked (int __c);
+extern int getw (FILE *__stream);
+extern int putw (int __w, FILE *__stream);
+
+extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
+     ;
+
+extern char *fgets_unlocked (char *__restrict __s, int __n,
+        FILE *__restrict __stream) ;
+extern __ssize_t __getdelim (char **__restrict __lineptr,
+          size_t *__restrict __n, int __delimiter,
+          FILE *__restrict __stream) ;
+extern __ssize_t getdelim (char **__restrict __lineptr,
+        size_t *__restrict __n, int __delimiter,
+        FILE *__restrict __stream) ;
+extern __ssize_t getline (char **__restrict __lineptr,
+       size_t *__restrict __n,
+       FILE *__restrict __stream) ;
+
+extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
+extern int puts (const char *__s);
+extern int ungetc (int __c, FILE *__stream);
+extern size_t fread (void *__restrict __ptr, size_t __size,
+       size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite (const void *__restrict __ptr, size_t __size,
+        size_t __n, FILE *__restrict __s);
+
+extern int fputs_unlocked (const char *__restrict __s,
+      FILE *__restrict __stream);
+extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
+         size_t __n, FILE *__restrict __stream) ;
+extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
+          size_t __n, FILE *__restrict __stream);
+
+extern int fseek (FILE *__stream, long int __off, int __whence);
+extern long int ftell (FILE *__stream) ;
+extern void rewind (FILE *__stream);
+
+extern int fseeko (FILE *__stream, __off_t __off, int __whence);
+extern __off_t ftello (FILE *__stream) ;
+
+extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos);
+extern int fsetpos (FILE *__stream, const fpos_t *__pos);
+
+extern int fseeko64 (FILE *__stream, __off64_t __off, int __whence);
+extern __off64_t ftello64 (FILE *__stream) ;
+extern int fgetpos64 (FILE *__restrict __stream, fpos64_t *__restrict __pos);
+extern int fsetpos64 (FILE *__stream, const fpos64_t *__pos);
+
+extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern void perror (const char *__s);
+
+extern int sys_nerr;
+extern const char *const sys_errlist[];
+extern int _sys_nerr;
+extern const char *const _sys_errlist[];
+extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern FILE *popen (const char *__command, const char *__modes) ;
+extern int pclose (FILE *__stream);
+extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
+extern char *cuserid (char *__s);
+struct obstack;
+extern int obstack_printf (struct obstack *__restrict __obstack,
+      const char *__restrict __format, ...)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 3)));
+extern int obstack_vprintf (struct obstack *__restrict __obstack,
+       const char *__restrict __format,
+       __gnuc_va_list __args)
+     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 2, 0)));
+extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef int wchar_t;
+
+typedef enum
+{
+  P_ALL,
+  P_PID,
+  P_PGID
+} idtype_t;
+union wait
+  {
+    int w_status;
+    struct
+      {
+ unsigned int __w_termsig:7;
+ unsigned int __w_coredump:1;
+ unsigned int __w_retcode:8;
+ unsigned int:16;
+      } __wait_terminated;
+    struct
+      {
+ unsigned int __w_stopval:8;
+ unsigned int __w_stopsig:8;
+ unsigned int:16;
+      } __wait_stopped;
+  };
+typedef union
+  {
+    union wait *__uptr;
+    int *__iptr;
+  } __WAIT_STATUS __attribute__ ((__transparent_union__));
+
+typedef struct
+  {
+    int quot;
+    int rem;
+  } div_t;
+typedef struct
+  {
+    long int quot;
+    long int rem;
+  } ldiv_t;
+
+
+__extension__ typedef struct
+  {
+    long long int quot;
+    long long int rem;
+  } lldiv_t;
+
+extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
+
+extern double atof (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern int atoi (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+extern long int atol (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+__extension__ extern long long int atoll (const char *__nptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+
+extern double strtod (const char *__restrict __nptr,
+        char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern float strtof (const char *__restrict __nptr,
+       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long double strtold (const char *__restrict __nptr,
+       char **__restrict __endptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+extern long int strtol (const char *__restrict __nptr,
+   char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern unsigned long int strtoul (const char *__restrict __nptr,
+      char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoq (const char *__restrict __nptr,
+        char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtouq (const char *__restrict __nptr,
+           char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+__extension__
+extern long long int strtoll (const char *__restrict __nptr,
+         char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+__extension__
+extern unsigned long long int strtoull (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern long int strtol_l (const char *__restrict __nptr,
+     char **__restrict __endptr, int __base,
+     __locale_t __loc) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern unsigned long int strtoul_l (const char *__restrict __nptr,
+        char **__restrict __endptr,
+        int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern long long int strtoll_l (const char *__restrict __nptr,
+    char **__restrict __endptr, int __base,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+__extension__
+extern unsigned long long int strtoull_l (const char *__restrict __nptr,
+       char **__restrict __endptr,
+       int __base, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 4)));
+extern double strtod_l (const char *__restrict __nptr,
+   char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern float strtof_l (const char *__restrict __nptr,
+         char **__restrict __endptr, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern long double strtold_l (const char *__restrict __nptr,
+         char **__restrict __endptr,
+         __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern long int a64l (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
+
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+typedef __loff_t loff_t;
+typedef __ino_t ino_t;
+typedef __ino64_t ino64_t;
+typedef __dev_t dev_t;
+typedef __gid_t gid_t;
+typedef __mode_t mode_t;
+typedef __nlink_t nlink_t;
+typedef __id_t id_t;
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+typedef __key_t key_t;
+
+typedef __clock_t clock_t;
+
+
+
+typedef __time_t time_t;
+
+
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+typedef __useconds_t useconds_t;
+typedef __suseconds_t suseconds_t;
+typedef unsigned long int ulong;
+typedef unsigned short int ushort;
+typedef unsigned int uint;
+typedef int int8_t __attribute__ ((__mode__ (__QI__)));
+typedef int int16_t __attribute__ ((__mode__ (__HI__)));
+typedef int int32_t __attribute__ ((__mode__ (__SI__)));
+typedef int int64_t __attribute__ ((__mode__ (__DI__)));
+typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
+typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
+typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
+typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
+typedef int register_t __attribute__ ((__mode__ (__word__)));
+struct timeval
+  {
+    __time_t tv_sec;
+    __suseconds_t tv_usec;
+  };
+typedef long int __fd_mask;
+typedef struct
+  {
+    __fd_mask fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
+  } fd_set;
+typedef __fd_mask fd_mask;
+
+extern int select (int __nfds, fd_set *__restrict __readfds,
+     fd_set *__restrict __writefds,
+     fd_set *__restrict __exceptfds,
+     struct timeval *__restrict __timeout);
+extern int pselect (int __nfds, fd_set *__restrict __readfds,
+      fd_set *__restrict __writefds,
+      fd_set *__restrict __exceptfds,
+      const struct timespec *__restrict __timeout,
+      const __sigset_t *__restrict __sigmask);
+
+
+__extension__
+extern unsigned int gnu_dev_major (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned int gnu_dev_minor (unsigned long long int __dev)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__
+extern unsigned long long int gnu_dev_makedev (unsigned int __major,
+            unsigned int __minor)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+
+typedef __blksize_t blksize_t;
+typedef __blkcnt_t blkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
+typedef __blkcnt64_t blkcnt64_t;
+typedef __fsblkcnt64_t fsblkcnt64_t;
+typedef __fsfilcnt64_t fsfilcnt64_t;
+
+extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+extern char *initstate (unsigned int __seed, char *__statebuf,
+   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct random_data
+  {
+    int32_t *fptr;
+    int32_t *rptr;
+    int32_t *state;
+    int rand_type;
+    int rand_deg;
+    int rand_sep;
+    int32_t *end_ptr;
+  };
+extern int random_r (struct random_data *__restrict __buf,
+       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srandom_r (unsigned int __seed, struct random_data *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
+   size_t __statelen,
+   struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern int setstate_r (char *__restrict __statebuf,
+         struct random_data *__restrict __buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
+extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int nrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
+extern long int jrand48 (unsigned short int __xsubi[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned short int *seed48 (unsigned short int __seed16v[3])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+struct drand48_data
+  {
+    unsigned short int __x[3];
+    unsigned short int __old_x[3];
+    unsigned short int __c;
+    unsigned short int __init;
+    __extension__ unsigned long long int __a;
+  };
+extern int drand48_r (struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int erand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int mrand48_r (struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int jrand48_r (unsigned short int __xsubi[3],
+        struct drand48_data *__restrict __buffer,
+        long int *__restrict __result)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int seed48_r (unsigned short int __seed16v[3],
+       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int lcong48_r (unsigned short int __param[7],
+        struct drand48_data *__buffer)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern void *calloc (size_t __nmemb, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+
+extern void *realloc (void *__ptr, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
+extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
+
+extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__alloc_size__ (2))) ;
+
+extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+
+extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+
+extern char *secure_getenv (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int setenv (const char *__name, const char *__value, int __replace)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int mkstemp (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemp64 (char *__template) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps (char *__template, int __suffixlen) __attribute__ ((__nonnull__ (1))) ;
+extern int mkstemps64 (char *__template, int __suffixlen)
+     __attribute__ ((__nonnull__ (1))) ;
+extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemp64 (char *__template, int __flags) __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+extern int mkostemps64 (char *__template, int __suffixlen, int __flags)
+     __attribute__ ((__nonnull__ (1))) ;
+
+extern int system (const char *__command) ;
+
+extern char *canonicalize_file_name (const char *__name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *realpath (const char *__restrict __name,
+         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
+typedef int (*__compar_fn_t) (const void *, const void *);
+typedef __compar_fn_t comparison_fn_t;
+typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
+
+extern void *bsearch (const void *__key, const void *__base,
+        size_t __nmemb, size_t __size, __compar_fn_t __compar)
+     __attribute__ ((__nonnull__ (1, 2, 5))) ;
+extern void qsort (void *__base, size_t __nmemb, size_t __size,
+     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
+extern void qsort_r (void *__base, size_t __nmemb, size_t __size,
+       __compar_d_fn_t __compar, void *__arg)
+  __attribute__ ((__nonnull__ (1, 4)));
+extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+__extension__ extern long long int llabs (long long int __x)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern div_t div (int __numer, int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+extern ldiv_t ldiv (long int __numer, long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+
+__extension__ extern lldiv_t lldiv (long long int __numer,
+        long long int __denom)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
+
+extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *gcvt (double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern char *qecvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qfcvt (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
+extern char *qgcvt (long double __value, int __ndigit, char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
+extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
+     int *__restrict __sign, char *__restrict __buf,
+     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qecvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+extern int qfcvt_r (long double __value, int __ndigit,
+      int *__restrict __decpt, int *__restrict __sign,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
+
+extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int mbtowc (wchar_t *__restrict __pwc,
+     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t mbstowcs (wchar_t *__restrict __pwcs,
+   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t wcstombs (char *__restrict __s,
+   const wchar_t *__restrict __pwcs, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__));
+
+extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int getsubopt (char **__restrict __optionp,
+        char *const *__restrict __tokens,
+        char **__restrict __valuep)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
+extern void setkey (const char *__key) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int posix_openpt (int __oflag) ;
+extern int grantpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int unlockpt (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ptsname (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ptsname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int getpt (void);
+extern int getloadavg (double __loadavg[], int __nelem)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+
+extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
+       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmove (void *__dest, const void *__src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
+        int __c, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int memcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern void *rawmemchr (const void *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern void *memrchr (const void *__s, int __c, size_t __n)
+      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strcat (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strncat (char *__restrict __dest, const char *__restrict __src,
+        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcoll (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strxfrm (char *__restrict __dest,
+         const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
+    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
+extern char *strdup (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+extern char *strndup (const char *__string, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *strrchr (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strchrnul (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strcspn (const char *__s, const char *__reject)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern size_t strspn (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strpbrk (const char *__s, const char *__accept)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strstr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strtok (char *__restrict __s, const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+
+extern char *__strtok_r (char *__restrict __s,
+    const char *__restrict __delim,
+    char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
+         char **__restrict __save_ptr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern char *strcasestr (const char *__haystack, const char *__needle)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *memmem (const void *__haystack, size_t __haystacklen,
+       const void *__needle, size_t __needlelen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void *__mempcpy (void *__restrict __dest,
+   const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void *mempcpy (void *__restrict __dest,
+        const void *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+extern size_t strlen (const char *__s)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern size_t strnlen (const char *__string, size_t __maxlen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+
+extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
+
+extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
+extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void bcopy (const void *__src, void *__dest, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int bcmp (const void *__s1, const void *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *index (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern char *rindex (const char *__s, int __c)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
+extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int ffsl (long int __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+__extension__ extern int ffsll (long long int __ll)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int strcasecmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strcasecmp_l (const char *__s1, const char *__s2,
+    __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int strncasecmp_l (const char *__s1, const char *__s2,
+     size_t __n, __locale_t __loc)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 4)));
+extern char *strsep (char **__restrict __stringp,
+       const char *__restrict __delim)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *__stpncpy (char *__restrict __dest,
+   const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *stpncpy (char *__restrict __dest,
+        const char *__restrict __src, size_t __n)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int strverscmp (const char *__s1, const char *__s2)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
+extern char *strfry (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void *memfrob (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern char *basename (const char *__filename) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+
+typedef __intptr_t intptr_t;
+typedef __socklen_t socklen_t;
+extern int access (const char *__name, int __type) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int euidaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int eaccess (const char *__name, int __type)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int faccessat (int __fd, const char *__file, int __type, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern __off_t lseek (int __fd, __off_t __offset, int __whence) __attribute__ ((__nothrow__ , __leaf__));
+extern __off64_t lseek64 (int __fd, __off64_t __offset, int __whence)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int close (int __fd);
+extern ssize_t read (int __fd, void *__buf, size_t __nbytes) ;
+extern ssize_t write (int __fd, const void *__buf, size_t __n) ;
+extern ssize_t pread (int __fd, void *__buf, size_t __nbytes,
+        __off_t __offset) ;
+extern ssize_t pwrite (int __fd, const void *__buf, size_t __n,
+         __off_t __offset) ;
+extern ssize_t pread64 (int __fd, void *__buf, size_t __nbytes,
+   __off64_t __offset) ;
+extern ssize_t pwrite64 (int __fd, const void *__buf, size_t __n,
+    __off64_t __offset) ;
+extern int pipe (int __pipedes[2]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pipe2 (int __pipedes[2], int __flags) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern unsigned int alarm (unsigned int __seconds) __attribute__ ((__nothrow__ , __leaf__));
+extern unsigned int sleep (unsigned int __seconds);
+extern __useconds_t ualarm (__useconds_t __value, __useconds_t __interval)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int usleep (__useconds_t __useconds);
+extern int pause (void);
+extern int chown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchown (int __fd, __uid_t __owner, __gid_t __group) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int lchown (const char *__file, __uid_t __owner, __gid_t __group)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchownat (int __fd, const char *__file, __uid_t __owner,
+       __gid_t __group, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int chdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int fchdir (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *getcwd (char *__buf, size_t __size) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern char *get_current_dir_name (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getwd (char *__buf)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__)) ;
+extern int dup (int __fd) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int dup2 (int __fd, int __fd2) __attribute__ ((__nothrow__ , __leaf__));
+extern int dup3 (int __fd, int __fd2, int __flags) __attribute__ ((__nothrow__ , __leaf__));
+extern char **__environ;
+extern char **environ;
+extern int execve (const char *__path, char *const __argv[],
+     char *const __envp[]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int fexecve (int __fd, char *const __argv[], char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int execv (const char *__path, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execle (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execl (const char *__path, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvp (const char *__file, char *const __argv[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execlp (const char *__file, const char *__arg, ...)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int execvpe (const char *__file, char *const __argv[],
+      char *const __envp[])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int nice (int __inc) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void _exit (int __status) __attribute__ ((__noreturn__));
+enum
+  {
+    _PC_LINK_MAX,
+    _PC_MAX_CANON,
+    _PC_MAX_INPUT,
+    _PC_NAME_MAX,
+    _PC_PATH_MAX,
+    _PC_PIPE_BUF,
+    _PC_CHOWN_RESTRICTED,
+    _PC_NO_TRUNC,
+    _PC_VDISABLE,
+    _PC_SYNC_IO,
+    _PC_ASYNC_IO,
+    _PC_PRIO_IO,
+    _PC_SOCK_MAXBUF,
+    _PC_FILESIZEBITS,
+    _PC_REC_INCR_XFER_SIZE,
+    _PC_REC_MAX_XFER_SIZE,
+    _PC_REC_MIN_XFER_SIZE,
+    _PC_REC_XFER_ALIGN,
+    _PC_ALLOC_SIZE_MIN,
+    _PC_SYMLINK_MAX,
+    _PC_2_SYMLINKS
+  };
+enum
+  {
+    _SC_ARG_MAX,
+    _SC_CHILD_MAX,
+    _SC_CLK_TCK,
+    _SC_NGROUPS_MAX,
+    _SC_OPEN_MAX,
+    _SC_STREAM_MAX,
+    _SC_TZNAME_MAX,
+    _SC_JOB_CONTROL,
+    _SC_SAVED_IDS,
+    _SC_REALTIME_SIGNALS,
+    _SC_PRIORITY_SCHEDULING,
+    _SC_TIMERS,
+    _SC_ASYNCHRONOUS_IO,
+    _SC_PRIORITIZED_IO,
+    _SC_SYNCHRONIZED_IO,
+    _SC_FSYNC,
+    _SC_MAPPED_FILES,
+    _SC_MEMLOCK,
+    _SC_MEMLOCK_RANGE,
+    _SC_MEMORY_PROTECTION,
+    _SC_MESSAGE_PASSING,
+    _SC_SEMAPHORES,
+    _SC_SHARED_MEMORY_OBJECTS,
+    _SC_AIO_LISTIO_MAX,
+    _SC_AIO_MAX,
+    _SC_AIO_PRIO_DELTA_MAX,
+    _SC_DELAYTIMER_MAX,
+    _SC_MQ_OPEN_MAX,
+    _SC_MQ_PRIO_MAX,
+    _SC_VERSION,
+    _SC_PAGESIZE,
+    _SC_RTSIG_MAX,
+    _SC_SEM_NSEMS_MAX,
+    _SC_SEM_VALUE_MAX,
+    _SC_SIGQUEUE_MAX,
+    _SC_TIMER_MAX,
+    _SC_BC_BASE_MAX,
+    _SC_BC_DIM_MAX,
+    _SC_BC_SCALE_MAX,
+    _SC_BC_STRING_MAX,
+    _SC_COLL_WEIGHTS_MAX,
+    _SC_EQUIV_CLASS_MAX,
+    _SC_EXPR_NEST_MAX,
+    _SC_LINE_MAX,
+    _SC_RE_DUP_MAX,
+    _SC_CHARCLASS_NAME_MAX,
+    _SC_2_VERSION,
+    _SC_2_C_BIND,
+    _SC_2_C_DEV,
+    _SC_2_FORT_DEV,
+    _SC_2_FORT_RUN,
+    _SC_2_SW_DEV,
+    _SC_2_LOCALEDEF,
+    _SC_PII,
+    _SC_PII_XTI,
+    _SC_PII_SOCKET,
+    _SC_PII_INTERNET,
+    _SC_PII_OSI,
+    _SC_POLL,
+    _SC_SELECT,
+    _SC_UIO_MAXIOV,
+    _SC_IOV_MAX = _SC_UIO_MAXIOV,
+    _SC_PII_INTERNET_STREAM,
+    _SC_PII_INTERNET_DGRAM,
+    _SC_PII_OSI_COTS,
+    _SC_PII_OSI_CLTS,
+    _SC_PII_OSI_M,
+    _SC_T_IOV_MAX,
+    _SC_THREADS,
+    _SC_THREAD_SAFE_FUNCTIONS,
+    _SC_GETGR_R_SIZE_MAX,
+    _SC_GETPW_R_SIZE_MAX,
+    _SC_LOGIN_NAME_MAX,
+    _SC_TTY_NAME_MAX,
+    _SC_THREAD_DESTRUCTOR_ITERATIONS,
+    _SC_THREAD_KEYS_MAX,
+    _SC_THREAD_STACK_MIN,
+    _SC_THREAD_THREADS_MAX,
+    _SC_THREAD_ATTR_STACKADDR,
+    _SC_THREAD_ATTR_STACKSIZE,
+    _SC_THREAD_PRIORITY_SCHEDULING,
+    _SC_THREAD_PRIO_INHERIT,
+    _SC_THREAD_PRIO_PROTECT,
+    _SC_THREAD_PROCESS_SHARED,
+    _SC_NPROCESSORS_CONF,
+    _SC_NPROCESSORS_ONLN,
+    _SC_PHYS_PAGES,
+    _SC_AVPHYS_PAGES,
+    _SC_ATEXIT_MAX,
+    _SC_PASS_MAX,
+    _SC_XOPEN_VERSION,
+    _SC_XOPEN_XCU_VERSION,
+    _SC_XOPEN_UNIX,
+    _SC_XOPEN_CRYPT,
+    _SC_XOPEN_ENH_I18N,
+    _SC_XOPEN_SHM,
+    _SC_2_CHAR_TERM,
+    _SC_2_C_VERSION,
+    _SC_2_UPE,
+    _SC_XOPEN_XPG2,
+    _SC_XOPEN_XPG3,
+    _SC_XOPEN_XPG4,
+    _SC_CHAR_BIT,
+    _SC_CHAR_MAX,
+    _SC_CHAR_MIN,
+    _SC_INT_MAX,
+    _SC_INT_MIN,
+    _SC_LONG_BIT,
+    _SC_WORD_BIT,
+    _SC_MB_LEN_MAX,
+    _SC_NZERO,
+    _SC_SSIZE_MAX,
+    _SC_SCHAR_MAX,
+    _SC_SCHAR_MIN,
+    _SC_SHRT_MAX,
+    _SC_SHRT_MIN,
+    _SC_UCHAR_MAX,
+    _SC_UINT_MAX,
+    _SC_ULONG_MAX,
+    _SC_USHRT_MAX,
+    _SC_NL_ARGMAX,
+    _SC_NL_LANGMAX,
+    _SC_NL_MSGMAX,
+    _SC_NL_NMAX,
+    _SC_NL_SETMAX,
+    _SC_NL_TEXTMAX,
+    _SC_XBS5_ILP32_OFF32,
+    _SC_XBS5_ILP32_OFFBIG,
+    _SC_XBS5_LP64_OFF64,
+    _SC_XBS5_LPBIG_OFFBIG,
+    _SC_XOPEN_LEGACY,
+    _SC_XOPEN_REALTIME,
+    _SC_XOPEN_REALTIME_THREADS,
+    _SC_ADVISORY_INFO,
+    _SC_BARRIERS,
+    _SC_BASE,
+    _SC_C_LANG_SUPPORT,
+    _SC_C_LANG_SUPPORT_R,
+    _SC_CLOCK_SELECTION,
+    _SC_CPUTIME,
+    _SC_THREAD_CPUTIME,
+    _SC_DEVICE_IO,
+    _SC_DEVICE_SPECIFIC,
+    _SC_DEVICE_SPECIFIC_R,
+    _SC_FD_MGMT,
+    _SC_FIFO,
+    _SC_PIPE,
+    _SC_FILE_ATTRIBUTES,
+    _SC_FILE_LOCKING,
+    _SC_FILE_SYSTEM,
+    _SC_MONOTONIC_CLOCK,
+    _SC_MULTI_PROCESS,
+    _SC_SINGLE_PROCESS,
+    _SC_NETWORKING,
+    _SC_READER_WRITER_LOCKS,
+    _SC_SPIN_LOCKS,
+    _SC_REGEXP,
+    _SC_REGEX_VERSION,
+    _SC_SHELL,
+    _SC_SIGNALS,
+    _SC_SPAWN,
+    _SC_SPORADIC_SERVER,
+    _SC_THREAD_SPORADIC_SERVER,
+    _SC_SYSTEM_DATABASE,
+    _SC_SYSTEM_DATABASE_R,
+    _SC_TIMEOUTS,
+    _SC_TYPED_MEMORY_OBJECTS,
+    _SC_USER_GROUPS,
+    _SC_USER_GROUPS_R,
+    _SC_2_PBS,
+    _SC_2_PBS_ACCOUNTING,
+    _SC_2_PBS_LOCATE,
+    _SC_2_PBS_MESSAGE,
+    _SC_2_PBS_TRACK,
+    _SC_SYMLOOP_MAX,
+    _SC_STREAMS,
+    _SC_2_PBS_CHECKPOINT,
+    _SC_V6_ILP32_OFF32,
+    _SC_V6_ILP32_OFFBIG,
+    _SC_V6_LP64_OFF64,
+    _SC_V6_LPBIG_OFFBIG,
+    _SC_HOST_NAME_MAX,
+    _SC_TRACE,
+    _SC_TRACE_EVENT_FILTER,
+    _SC_TRACE_INHERIT,
+    _SC_TRACE_LOG,
+    _SC_LEVEL1_ICACHE_SIZE,
+    _SC_LEVEL1_ICACHE_ASSOC,
+    _SC_LEVEL1_ICACHE_LINESIZE,
+    _SC_LEVEL1_DCACHE_SIZE,
+    _SC_LEVEL1_DCACHE_ASSOC,
+    _SC_LEVEL1_DCACHE_LINESIZE,
+    _SC_LEVEL2_CACHE_SIZE,
+    _SC_LEVEL2_CACHE_ASSOC,
+    _SC_LEVEL2_CACHE_LINESIZE,
+    _SC_LEVEL3_CACHE_SIZE,
+    _SC_LEVEL3_CACHE_ASSOC,
+    _SC_LEVEL3_CACHE_LINESIZE,
+    _SC_LEVEL4_CACHE_SIZE,
+    _SC_LEVEL4_CACHE_ASSOC,
+    _SC_LEVEL4_CACHE_LINESIZE,
+    _SC_IPV6 = _SC_LEVEL1_ICACHE_SIZE + 50,
+    _SC_RAW_SOCKETS,
+    _SC_V7_ILP32_OFF32,
+    _SC_V7_ILP32_OFFBIG,
+    _SC_V7_LP64_OFF64,
+    _SC_V7_LPBIG_OFFBIG,
+    _SC_SS_REPL_MAX,
+    _SC_TRACE_EVENT_NAME_MAX,
+    _SC_TRACE_NAME_MAX,
+    _SC_TRACE_SYS_MAX,
+    _SC_TRACE_USER_EVENT_MAX,
+    _SC_XOPEN_STREAMS,
+    _SC_THREAD_ROBUST_PRIO_INHERIT,
+    _SC_THREAD_ROBUST_PRIO_PROTECT
+  };
+enum
+  {
+    _CS_PATH,
+    _CS_V6_WIDTH_RESTRICTED_ENVS,
+    _CS_GNU_LIBC_VERSION,
+    _CS_GNU_LIBPTHREAD_VERSION,
+    _CS_V5_WIDTH_RESTRICTED_ENVS,
+    _CS_V7_WIDTH_RESTRICTED_ENVS,
+    _CS_LFS_CFLAGS = 1000,
+    _CS_LFS_LDFLAGS,
+    _CS_LFS_LIBS,
+    _CS_LFS_LINTFLAGS,
+    _CS_LFS64_CFLAGS,
+    _CS_LFS64_LDFLAGS,
+    _CS_LFS64_LIBS,
+    _CS_LFS64_LINTFLAGS,
+    _CS_XBS5_ILP32_OFF32_CFLAGS = 1100,
+    _CS_XBS5_ILP32_OFF32_LDFLAGS,
+    _CS_XBS5_ILP32_OFF32_LIBS,
+    _CS_XBS5_ILP32_OFF32_LINTFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_CFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LDFLAGS,
+    _CS_XBS5_ILP32_OFFBIG_LIBS,
+    _CS_XBS5_ILP32_OFFBIG_LINTFLAGS,
+    _CS_XBS5_LP64_OFF64_CFLAGS,
+    _CS_XBS5_LP64_OFF64_LDFLAGS,
+    _CS_XBS5_LP64_OFF64_LIBS,
+    _CS_XBS5_LP64_OFF64_LINTFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_CFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LDFLAGS,
+    _CS_XBS5_LPBIG_OFFBIG_LIBS,
+    _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFF32_LIBS,
+    _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V6_LP64_OFF64_LIBS,
+    _CS_POSIX_V6_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFF32_LIBS,
+    _CS_POSIX_V7_ILP32_OFF32_LINTFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+    _CS_POSIX_V7_ILP32_OFFBIG_LINTFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_CFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+    _CS_POSIX_V7_LP64_OFF64_LIBS,
+    _CS_POSIX_V7_LP64_OFF64_LINTFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+    _CS_POSIX_V7_LPBIG_OFFBIG_LINTFLAGS,
+    _CS_V6_ENV,
+    _CS_V7_ENV
+  };
+extern long int pathconf (const char *__path, int __name)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern long int fpathconf (int __fd, int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern long int sysconf (int __name) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t confstr (int __name, char *__buf, size_t __len) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getppid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t __getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getpgid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgid (__pid_t __pid, __pid_t __pgid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setpgrp (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t setsid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __pid_t getsid (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t getuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __uid_t geteuid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getgid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern __gid_t getegid (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getgroups (int __size, __gid_t __list[]) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int group_member (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__));
+extern int setuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setreuid (__uid_t __ruid, __uid_t __euid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int seteuid (__uid_t __uid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setgid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setregid (__gid_t __rgid, __gid_t __egid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setegid (__gid_t __gid) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getresuid (__uid_t *__ruid, __uid_t *__euid, __uid_t *__suid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int getresgid (__gid_t *__rgid, __gid_t *__egid, __gid_t *__sgid)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int setresgid (__gid_t __rgid, __gid_t __egid, __gid_t __sgid)
+     __attribute__ ((__nothrow__ , __leaf__)) ;
+extern __pid_t fork (void) __attribute__ ((__nothrow__));
+extern __pid_t vfork (void) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ttyname (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyname_r (int __fd, char *__buf, size_t __buflen)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2))) ;
+extern int isatty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int ttyslot (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int link (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int linkat (int __fromfd, const char *__from, int __tofd,
+     const char *__to, int __flags)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4))) ;
+extern int symlink (const char *__from, const char *__to)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern ssize_t readlink (const char *__restrict __path,
+    char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) ;
+extern int symlinkat (const char *__from, int __tofd,
+        const char *__to) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3))) ;
+extern ssize_t readlinkat (int __fd, const char *__restrict __path,
+      char *__restrict __buf, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3))) ;
+extern int unlink (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int unlinkat (int __fd, const char *__name, int __flag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int rmdir (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern __pid_t tcgetpgrp (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern int tcsetpgrp (int __fd, __pid_t __pgrp_id) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getlogin (void);
+extern int getlogin_r (char *__name, size_t __name_len) __attribute__ ((__nonnull__ (1)));
+extern int setlogin (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int gethostname (char *__name, size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int sethostname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int sethostid (long int __id) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int getdomainname (char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int setdomainname (const char *__name, size_t __len)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int vhangup (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int revoke (const char *__file) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int profil (unsigned short int *__sample_buffer, size_t __size,
+     size_t __offset, unsigned int __scale)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int acct (const char *__name) __attribute__ ((__nothrow__ , __leaf__));
+extern char *getusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setusershell (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daemon (int __nochdir, int __noclose) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int chroot (const char *__path) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern char *getpass (const char *__prompt) __attribute__ ((__nonnull__ (1)));
+extern int fsync (int __fd);
+extern int syncfs (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern long int gethostid (void);
+extern void sync (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int getpagesize (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int getdtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int truncate (const char *__file, __off_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int truncate64 (const char *__file, __off64_t __length)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
+extern int ftruncate (int __fd, __off_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int ftruncate64 (int __fd, __off64_t __length) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int brk (void *__addr) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void *sbrk (intptr_t __delta) __attribute__ ((__nothrow__ , __leaf__));
+extern long int syscall (long int __sysno, ...) __attribute__ ((__nothrow__ , __leaf__));
+extern int lockf (int __fd, int __cmd, __off_t __len) ;
+extern int lockf64 (int __fd, int __cmd, __off64_t __len) ;
+extern int fdatasync (int __fildes);
+extern char *crypt (const char *__key, const char *__salt)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void encrypt (char *__glibc_block, int __edflag)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern void swab (const void *__restrict __from, void *__restrict __to,
+    ssize_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+
+
+
+struct timezone
+  {
+    int tz_minuteswest;
+    int tz_dsttime;
+  };
+typedef struct timezone *__restrict __timezone_ptr_t;
+extern int gettimeofday (struct timeval *__restrict __tv,
+    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int settimeofday (const struct timeval *__tv,
+    const struct timezone *__tz)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int adjtime (const struct timeval *__delta,
+      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
+enum __itimer_which
+  {
+    ITIMER_REAL = 0,
+    ITIMER_VIRTUAL = 1,
+    ITIMER_PROF = 2
+  };
+struct itimerval
+  {
+    struct timeval it_interval;
+    struct timeval it_value;
+  };
+typedef enum __itimer_which __itimer_which_t;
+extern int getitimer (__itimer_which_t __which,
+        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
+extern int setitimer (__itimer_which_t __which,
+        const struct itimerval *__restrict __new,
+        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
+extern int utimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int lutimes (const char *__file, const struct timeval __tvp[2])
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+extern int futimesat (int __fd, const char *__file,
+        const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
+
+struct lastlog
+  {
+    int32_t ll_time;
+    char ll_line[32];
+    char ll_host[256];
+  };
+struct exit_status
+  {
+    short int e_termination;
+    short int e_exit;
+  };
+struct utmp
+{
+  short int ut_type;
+  pid_t ut_pid;
+  char ut_line[32];
+  char ut_id[4];
+  char ut_user[32];
+  char ut_host[256];
+  struct exit_status ut_exit;
+  int32_t ut_session;
+  struct
+  {
+    int32_t tv_sec;
+    int32_t tv_usec;
+  } ut_tv;
+  int32_t ut_addr_v6[4];
+  char __glibc_reserved[20];
+};
+extern int login_tty (int __fd) __attribute__ ((__nothrow__ , __leaf__));
+extern void login (const struct utmp *__entry) __attribute__ ((__nothrow__ , __leaf__));
+extern int logout (const char *__ut_line) __attribute__ ((__nothrow__ , __leaf__));
+extern void logwtmp (const char *__ut_line, const char *__ut_name,
+       const char *__ut_host) __attribute__ ((__nothrow__ , __leaf__));
+extern void updwtmp (const char *__wtmp_file, const struct utmp *__utmp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int utmpname (const char *__file) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void setutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern void endutent (void) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutid (const struct utmp *__id) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *getutline (const struct utmp *__line) __attribute__ ((__nothrow__ , __leaf__));
+extern struct utmp *pututline (const struct utmp *__utmp_ptr) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutent_r (struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
+        struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+extern int getutline_r (const struct utmp *__line,
+   struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+
+static void bb_perror_msg_and_die(const char *s, ...);
+static void bb_perror_nomsg_and_die(void);
+static void bb_verror_msg(const char *s, va_list p, const char *strerr);
+static signed int fflush_all(void);
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len);
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count);
+static void xfunc_die(void);
+struct libbb_anonymous$7
+{
+  unsigned long int __val[16l];
+};
+static const char *applet_name;
+static signed int bb_errno_location;
+static signed int * const bb_errno = &bb_errno_location;
+static struct __jmp_buf_tag die_jmp[1l];
+static signed int die_sleep;
+static signed char logmode = (signed char)1;
+static const char *msg_eol = "\n";
+static unsigned char xfunc_error_retval = (unsigned char)1;
+static void bb_perror_msg_and_die(const char *s, ...)
+{
+  va_list p;
+  __builtin_va_start(p,s);
+  char *tmp_if_expr$2;
+  char *return_value_strerror$1;
+  if(!(*bb_errno == 0))
+  {
+    return_value_strerror$1=strerror(*bb_errno);
+    tmp_if_expr$2 = return_value_strerror$1;
+  }
+  else
+    tmp_if_expr$2 = (char *)((void *)0);
+  bb_verror_msg(s, p, tmp_if_expr$2);
+  __builtin_va_end(p);
+  abort();
+}
+static void bb_perror_nomsg_and_die(void)
+{
+  bb_perror_msg_and_die((const char *)((void *)0));
+}
+static void bb_verror_msg(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  char *msg1;
+  signed int applet_len;
+  signed int strerr_len;
+  signed int msgeol_len;
+  signed int used;
+  if((signed int)logmode == 0)
+    return;
+  if(s == ((const char *)((void *)0)))
+    s = "";
+  used=vasprintf(&msg, s, p);
+  if(used < 0)
+    return;
+  unsigned long int return_value_strlen$1;
+  return_value_strlen$1=strlen(applet_name);
+  applet_len = (signed int)(return_value_strlen$1 + (unsigned long int)2);
+  unsigned long int tmp_if_expr$3;
+  unsigned long int return_value_strlen$2;
+  if(!(strerr == ((const char *)((void *)0))))
+  {
+    return_value_strlen$2=strlen(strerr);
+    tmp_if_expr$3 = return_value_strlen$2;
+  }
+  else
+    tmp_if_expr$3 = (unsigned long int)0;
+  strerr_len = (signed int)tmp_if_expr$3;
+  unsigned long int return_value_strlen$4;
+  return_value_strlen$4=strlen(msg_eol);
+  msgeol_len = (signed int)return_value_strlen$4;
+  void *return_value_realloc$5;
+  return_value_realloc$5=realloc((void *)msg, (unsigned long int)(applet_len + used + strerr_len + msgeol_len + 3));
+  msg1 = (char *)return_value_realloc$5;
+  signed int tmp_post$6;
+  signed int tmp_post$7;
+  signed int tmp_post$8;
+  if(msg1 == ((char *)((void *)0)))
+  {
+    tmp_post$6 = used;
+    used = used + 1;
+    msg[(signed long int)tmp_post$6] = (char)10;
+    applet_len = 0;
+  }
+  else
+  {
+    msg = msg1;
+    memmove((void *)(msg + (signed long int)applet_len), (const void *)msg, (unsigned long int)used);
+    used = used + applet_len;
+    strcpy(msg, applet_name);
+    msg[(signed long int)(applet_len - 2)] = (char)58;
+    msg[(signed long int)(applet_len - 1)] = (char)32;
+    if(!(strerr == ((const char *)((void *)0))))
+    {
+      if(!((signed int)*s == 0))
+      {
+        tmp_post$7 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$7] = (char)58;
+        tmp_post$8 = used;
+        used = used + 1;
+        msg[(signed long int)tmp_post$8] = (char)32;
+      }
+      strcpy(&msg[(signed long int)used], strerr);
+      used = used + strerr_len;
+    }
+    strcpy(&msg[(signed long int)used], msg_eol);
+    used = used + msgeol_len;
+  }
+  if(!((1 & (signed int)logmode) == 0))
+  {
+    fflush_all();
+    full_write(2, (const void *)msg, (unsigned long int)used);
+  }
+  if(!((2 & (signed int)logmode) == 0))
+    syslog(3, "%s", msg + (signed long int)applet_len);
+  free((void *)msg);
+}
+static signed int fflush_all(void)
+{
+  signed int return_value_fflush$1;
+  return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
+  return return_value_fflush$1;
+}
+static signed long int full_write(signed int fd, const void *buf, unsigned long int len)
+{
+  signed long int cc;
+  signed long int total = (signed long int)0;
+  for( ; !(len == 0ul); len = len - (unsigned long int)cc)
+  {
+    cc=safe_write(fd, buf, len);
+    if(cc < 0l)
+    {
+      if(!(total == 0l))
+        return total;
+      return cc;
+    }
+    total = total + cc;
+    buf = (const void *)((const char *)buf + cc);
+  }
+  return total;
+}
+static signed long int safe_write(signed int fd, const void *buf, unsigned long int count)
+{
+  signed long int n;
+  _Bool tmp_if_expr$1;
+  do
+  {
+    n=write(fd, buf, count);
+    if(n < 0l)
+      tmp_if_expr$1 = (*bb_errno == 4 ? (signed int)(1 != 0) : (signed int)(0 != 0)) != 0;
+    else
+      tmp_if_expr$1 = 0 != 0;
+  }
+  while(tmp_if_expr$1 != (_Bool)0);
+  return n;
+}
+static void xfunc_die(void)
+{
+  if(!(die_sleep == 0))
+  {
+    if(die_sleep < 0)
+      longjmp(die_jmp, (signed int)xfunc_error_retval != 0 ? (signed int)xfunc_error_retval : -2222);
+    sleep((unsigned int)die_sleep);
+  }
+  exit((signed int)xfunc_error_retval);
+}
+signed int __main(signed int argc, char **argv)
+{
+  char **pp;
+  argv[(signed long int)0] = (char *)"y";
+  if(!(*(1l + argv) == ((char *)((void *)0))))
+    argv = argv + 1l;
+  signed int return_value_putchar_unlocked$1;
+  do
+  {
+    pp = argv;
+    while((_Bool)1)
+    {
+      fputs(*pp, stdout);
+      pp = pp + 1l;
+      if(*pp == ((char *)((void *)0)))
+        break;
+      putchar(32);
+    }
+    return_value_putchar_unlocked$1=putchar(10);
+  }
+  while(return_value_putchar_unlocked$1 != -1);
+  bb_perror_nomsg_and_die();
+}
+static struct utmp dummy_utmp;
+struct utmp *getutent(void) {
+  if (__VERIFIER_nondet_int())
+    return (struct utmp *)((void *)0);
+  dummy_utmp.ut_tv.tv_sec = __VERIFIER_nondet_int();
+  dummy_utmp.ut_type = __VERIFIER_nondet_short();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_line); ++i)
+    dummy_utmp.ut_line[i] = __VERIFIER_nondet_char();
+  for (int i = 0; i < sizeof(dummy_utmp.ut_user); ++i)
+    dummy_utmp.ut_user[i] = __VERIFIER_nondet_char();
+  return &dummy_utmp;
+}
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int result = -1;
+  if(optind == 0)
+    optind = 1;
+  if(optind >= argc || argv[optind][0] != '-')
+    return -1;
+  size_t opt_index = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(opt_index < strlen(optstring) && optstring[opt_index] != ':');
+  if(__VERIFIER_nondet_int())
+  {
+    result = optstring[opt_index];
+    if(__VERIFIER_nondet_int())
+      ++optind;
+  }
+  if(result != -1 && optind < argc && optstring[opt_index+1] == ':')
+  {
+    if(__VERIFIER_nondet_int())
+    {
+      optarg = argv[optind];
+      ++optind;
+    }
+    else
+      optarg = ((void *)0);
+  }
+  return result;
+}
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+  (void)*longopts;
+  (void)longindex;
+  return getopt(argc, argv, optstring);
+}
+ssize_t read(int fildes, void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  unsigned long offset=__VERIFIER_nondet_ulong();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  __VERIFIER_assume(offset<nbyte);
+  *((char*)buf+offset)=__VERIFIER_nondet_char();
+  return ret;
+}
+int vasprintf(char **ptr, const char *fmt, va_list ap)
+{
+  (void)*fmt;
+  (void)ap;
+  int result_buffer_size = __VERIFIER_nondet_int();
+  if(result_buffer_size <= 0)
+    return -1;
+  *ptr = malloc(result_buffer_size);
+  int i = 0;
+  while(i<result_buffer_size)
+  {
+    (*ptr)[i] = __VERIFIER_nondet_char();
+    if((*ptr)[i] == 0)
+      break;
+    ++i;
+  }
+  __VERIFIER_assume(i<result_buffer_size);
+  return i;
+}
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+  long ret=__VERIFIER_nondet_long();
+  __VERIFIER_assume(ret>=-1 && ret<=nbyte);
+  return ret;
+}
+int main()
+{
+  char *a = malloc(11);
+  a[10] = 0;
+  for(int i=0; i<10; ++i)
+    a[i]=__VERIFIER_nondet_char();
+  applet_name = a;
+  bb_errno_location = __VERIFIER_nondet_int();
+  optind = 1;
+  int argc = __VERIFIER_nondet_int();
+  __VERIFIER_assume(argc >= 1 && argc <= 10000);
+  char **argv=malloc((argc+1)*sizeof(char*));
+  char **mem_track=malloc((argc+1)*sizeof(char*));
+  argv[argc]=0;
+  for(int i=0; i<argc; ++i)
+  {
+    argv[i]=malloc(11);
+    mem_track[i]=argv[i];
+    argv[i][10] = 0;
+    for(int j=0; j<10; ++j)
+      argv[i][j]=__VERIFIER_nondet_char();
+  }
+  int res = __main(argc, argv);
+  for(int i=0; i<argc; ++i)
+    free(mem_track[i]);
+  free(mem_track);
+  free(argv);
+  free(a);
+  return res;
+}

--- a/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.c
@@ -102,7 +102,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)

--- a/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.i
@@ -2249,7 +2249,7 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
   char *msg;
   char *msg1;
   signed int applet_len;
-  signed int strerr_len;
+  unsigned int strerr_len;
   signed int msgeol_len;
   signed int used;
   if((signed int)logmode == 0)


### PR DESCRIPTION
This PR fixes issue https://github.com/sosy-lab/sv-benchmarks/issues/535.

It will do the following:
- fix the overflow in all affected busybox tasks (except the ones in the busybox todo folder)
- add copies of the original files with updated label (only containing false-no-overflow, no other label)
- add a note that the tasks in the busybox todo folder still need fixing along with the command that will fix them

I took care that the tasks that have the label false-valid-deref tasks are treated specially. Here the overflow is just fixed, no copy is made. This results in three files, for example for the "head" program:
- c/busybox-1.22.0/head_false-no-overflow.i                                               
- c/busybox-1.22.0/head_false-valid-deref.I
- c/busybox-1.22.0/head_true-no-overflow_true-valid-deref.i