### PR TITLE
Busybox - define localtime_r

### DIFF
--- a/c/busybox-1.22.0/busybox_sv_comp-localtime_r.h
+++ b/c/busybox-1.22.0/busybox_sv_comp-localtime_r.h
@@ -1,0 +1,34 @@
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result->tm_sec   = __VERIFIER_nondet_int();
+   result->tm_min   = __VERIFIER_nondet_int();
+   result->tm_hour  = __VERIFIER_nondet_int();
+   result->tm_mday  = __VERIFIER_nondet_int();
+   result->tm_mon   = __VERIFIER_nondet_int();
+   result->tm_year  = __VERIFIER_nondet_int();
+   result->tm_wday  = __VERIFIER_nondet_int();
+   result->tm_yday  = __VERIFIER_nondet_int();
+   /* Daylight saving time */
+   result->tm_isdst = __VERIFIER_nondet_int();
+
+   /* Seconds (0-60) */
+   __VERIFIER_assume(result->tm_sec >= 0 && result->tm_sec <= 60);
+   /* Minutes (0-59) */
+   __VERIFIER_assume(result->tm_min >= 0 && result->tm_min < 60);
+   /* Hours (0-23) */
+   __VERIFIER_assume(result->tm_hour >= 0 && result->tm_hour < 24);
+   /* Day of the month (1-31) */
+   __VERIFIER_assume(result->tm_mday > 0 && result->tm_mday < 32);
+   /* Month (0-11) */
+   __VERIFIER_assume(result->tm_mon >= 0 && result->tm_mon < 12);
+   /* Year - 1900 */
+   /* This is just an approximation */
+   __VERIFIER_assume(result->tm_year >= 0 && result->tm_year < 1000);
+   /* Day of the week (0-6, Sunday = 0) */
+   __VERIFIER_assume(result->tm_wday >= 0 && result->tm_wday < 7);
+   /* Day in the year (0-365, 1 Jan = 0) */
+   __VERIFIER_assume(result->tm_yday >= 0 && result->tm_yday <= 365);
+
+   return result;
+};
+

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -31,6 +31,8 @@
 #include <utmp.h>
 #include <stdarg.h>
 
+#include "busybox_sv_comp-localtime_r.h"
+
 // file libbb/getopt32.c line 307
 struct libbb_anonymous$0;
 
@@ -1312,40 +1314,6 @@ static void maybe_set_utc(signed int opt)
   if(!((4 & opt) == 0))
     putenv((char *)"TZ=UTC0");
 
-}
-
-struct tm *localtime_r(const time_t *timep, struct tm* result)
-{
-   result.tm_sec   = __VERIFIER_nondet_int();
-   result.tm_min   = __VERIFIER_nondet_int();
-   result.tm_hour  = __VERIFIER_nondet_int();
-   result.tm_mday  = __VERIFIER_nondet_int();
-   result.tm_mon   = __VERIFIER_nondet_int();
-   result.tm_year  = __VERIFIER_nondet_int();
-   result.tm_wday  = __VERIFIER_nondet_int();
-   result.tm_yday  = __VERIFIER_nondet_int();
-   /* Daylight saving time */
-   result.tm_isdst = __VERIFIER_nondet_int();
-
-   /* Seconds (0-60) */
-   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
-   /* Minutes (0-59) */
-   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
-   /* Hours (0-23) */
-   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
-   /* Day of the month (1-31) */
-   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
-   /* Month (0-11) */
-   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
-   /* Year - 1900 */
-   /* This is just an approximation */
-   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
-   /* Day of the week (0-6, Sunday = 0) */
-   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
-   /* Day in the year (0-365, 1 Jan = 0) */
-   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
-
-   return result;
 }
 
 // file libbb/time.c line 11

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1314,6 +1314,40 @@ static void maybe_set_utc(signed int opt)
 
 }
 
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result.tm_sec   = __VERIFIER_nondet_int();
+   result.tm_min   = __VERIFIER_nondet_int();
+   result.tm_hour  = __VERIFIER_nondet_int();
+   result.tm_mday  = __VERIFIER_nondet_int();
+   result.tm_mon   = __VERIFIER_nondet_int();
+   result.tm_year  = __VERIFIER_nondet_int();
+   result.tm_wday  = __VERIFIER_nondet_int();
+   result.tm_yday  = __VERIFIER_nondet_int();
+   /* Daylight saving time */
+   result.tm_isdst = __VERIFIER_nondet_int();
+
+   /* Seconds (0-60) */
+   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
+   /* Minutes (0-59) */
+   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
+   /* Hours (0-23) */
+   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
+   /* Day of the month (1-31) */
+   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
+   /* Month (0-11) */
+   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
+   /* Year - 1900 */
+   /* This is just an approximation */
+   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
+   /* Day of the week (0-6, Sunday = 0) */
+   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
+   /* Day in the year (0-365, 1 Jan = 0) */
+   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
+
+   return result;
+}
+
 // file libbb/time.c line 11
 static void parse_datestr(const char *date_str, struct tm *ptm)
 {

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2373,7 +2373,28 @@ extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
         struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
 extern int getutline_r (const struct utmp *__line,
    struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result->tm_sec   = __VERIFIER_nondet_int();
+   result->tm_min   = __VERIFIER_nondet_int();
+   result->tm_hour  = __VERIFIER_nondet_int();
+   result->tm_mday  = __VERIFIER_nondet_int();
+   result->tm_mon   = __VERIFIER_nondet_int();
+   result->tm_year  = __VERIFIER_nondet_int();
+   result->tm_wday  = __VERIFIER_nondet_int();
+   result->tm_yday  = __VERIFIER_nondet_int();
+   result->tm_isdst = __VERIFIER_nondet_int();
 
+   __VERIFIER_assume(result->tm_sec >= 0 && result->tm_sec <= 60);
+   __VERIFIER_assume(result->tm_min >= 0 && result->tm_min < 60);
+   __VERIFIER_assume(result->tm_hour >= 0 && result->tm_hour < 24);
+   __VERIFIER_assume(result->tm_mday > 0 && result->tm_mday < 32);
+   __VERIFIER_assume(result->tm_mon >= 0 && result->tm_mon < 12);
+   __VERIFIER_assume(result->tm_year >= 0 && result->tm_year < 1000);
+   __VERIFIER_assume(result->tm_wday >= 0 && result->tm_wday < 7);
+   __VERIFIER_assume(result->tm_yday >= 0 && result->tm_yday <= 365);
+   return result;
+};
 struct libbb_anonymous$0;
 struct llist_t;
 struct suffix_mult;
@@ -3384,27 +3405,6 @@ static void maybe_set_utc(signed int opt)
 {
   if(!((4 & opt) == 0))
     putenv((char *)"TZ=UTC0");
-}
-struct tm *localtime_r(const time_t *timep, struct tm* result)
-{
-   result.tm_sec   = __VERIFIER_nondet_int();
-   result.tm_min   = __VERIFIER_nondet_int();
-   result.tm_hour  = __VERIFIER_nondet_int();
-   result.tm_mday  = __VERIFIER_nondet_int();
-   result.tm_mon   = __VERIFIER_nondet_int();
-   result.tm_year  = __VERIFIER_nondet_int();
-   result.tm_wday  = __VERIFIER_nondet_int();
-   result.tm_yday  = __VERIFIER_nondet_int();
-   result.tm_isdst = __VERIFIER_nondet_int();
-   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
-   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
-   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
-   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
-   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
-   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
-   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
-   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
-   return result;
 }
 static void parse_datestr(const char *date_str, struct tm *ptm)
 {

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3385,6 +3385,27 @@ static void maybe_set_utc(signed int opt)
   if(!((4 & opt) == 0))
     putenv((char *)"TZ=UTC0");
 }
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result.tm_sec   = __VERIFIER_nondet_int();
+   result.tm_min   = __VERIFIER_nondet_int();
+   result.tm_hour  = __VERIFIER_nondet_int();
+   result.tm_mday  = __VERIFIER_nondet_int();
+   result.tm_mon   = __VERIFIER_nondet_int();
+   result.tm_year  = __VERIFIER_nondet_int();
+   result.tm_wday  = __VERIFIER_nondet_int();
+   result.tm_yday  = __VERIFIER_nondet_int();
+   result.tm_isdst = __VERIFIER_nondet_int();
+   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
+   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
+   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
+   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
+   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
+   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
+   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
+   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
+   return result;
+}
 static void parse_datestr(const char *date_str, struct tm *ptm)
 {
   char end = (char)0;

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1207,6 +1207,40 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   return n;
 }
 
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result.tm_sec   = __VERIFIER_nondet_int();
+   result.tm_min   = __VERIFIER_nondet_int();
+   result.tm_hour  = __VERIFIER_nondet_int();
+   result.tm_mday  = __VERIFIER_nondet_int();
+   result.tm_mon   = __VERIFIER_nondet_int();
+   result.tm_year  = __VERIFIER_nondet_int();
+   result.tm_wday  = __VERIFIER_nondet_int();
+   result.tm_yday  = __VERIFIER_nondet_int();
+   /* Daylight saving time */
+   result.tm_isdst = __VERIFIER_nondet_int();
+
+   /* Seconds (0-60) */
+   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
+   /* Minutes (0-59) */
+   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
+   /* Hours (0-23) */
+   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
+   /* Day of the month (1-31) */
+   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
+   /* Month (0-11) */
+   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
+   /* Year - 1900 */
+   /* This is just an approximation */
+   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
+   /* Day of the week (0-6, Sunday = 0) */
+   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
+   /* Day in the year (0-365, 1 Jan = 0) */
+   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
+
+   return result;
+}
+
 // file coreutils/touch.c line 89
 signed int __main(signed int argc, char **argv)
 {

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -33,6 +33,8 @@
 #include <utmp.h>
 #include <stdarg.h>
 
+#include "busybox_sv_comp-localtime_r.h"
+
 // file libbb/getopt32.c line 307
 struct libbb_anonymous$0;
 
@@ -1205,40 +1207,6 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   }
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
-}
-
-struct tm *localtime_r(const time_t *timep, struct tm* result)
-{
-   result.tm_sec   = __VERIFIER_nondet_int();
-   result.tm_min   = __VERIFIER_nondet_int();
-   result.tm_hour  = __VERIFIER_nondet_int();
-   result.tm_mday  = __VERIFIER_nondet_int();
-   result.tm_mon   = __VERIFIER_nondet_int();
-   result.tm_year  = __VERIFIER_nondet_int();
-   result.tm_wday  = __VERIFIER_nondet_int();
-   result.tm_yday  = __VERIFIER_nondet_int();
-   /* Daylight saving time */
-   result.tm_isdst = __VERIFIER_nondet_int();
-
-   /* Seconds (0-60) */
-   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
-   /* Minutes (0-59) */
-   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
-   /* Hours (0-23) */
-   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
-   /* Day of the month (1-31) */
-   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
-   /* Month (0-11) */
-   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
-   /* Year - 1900 */
-   /* This is just an approximation */
-   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
-   /* Day of the week (0-6, Sunday = 0) */
-   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
-   /* Day in the year (0-365, 1 Jan = 0) */
-   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
-
-   return result;
 }
 
 // file coreutils/touch.c line 89

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3390,6 +3390,27 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result.tm_sec   = __VERIFIER_nondet_int();
+   result.tm_min   = __VERIFIER_nondet_int();
+   result.tm_hour  = __VERIFIER_nondet_int();
+   result.tm_mday  = __VERIFIER_nondet_int();
+   result.tm_mon   = __VERIFIER_nondet_int();
+   result.tm_year  = __VERIFIER_nondet_int();
+   result.tm_wday  = __VERIFIER_nondet_int();
+   result.tm_yday  = __VERIFIER_nondet_int();
+   result.tm_isdst = __VERIFIER_nondet_int();
+   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
+   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
+   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
+   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
+   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
+   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
+   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
+   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
+   return result;
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int fd;

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2451,6 +2451,27 @@ extern int getutid_r (const struct utmp *__id, struct utmp *__buffer,
 extern int getutline_r (const struct utmp *__line,
    struct utmp *__buffer, struct utmp **__result) __attribute__ ((__nothrow__ , __leaf__));
 
+struct tm *localtime_r(const time_t *timep, struct tm* result)
+{
+   result->tm_sec   = __VERIFIER_nondet_int();
+   result->tm_min   = __VERIFIER_nondet_int();
+   result->tm_hour  = __VERIFIER_nondet_int();
+   result->tm_mday  = __VERIFIER_nondet_int();
+   result->tm_mon   = __VERIFIER_nondet_int();
+   result->tm_year  = __VERIFIER_nondet_int();
+   result->tm_wday  = __VERIFIER_nondet_int();
+   result->tm_yday  = __VERIFIER_nondet_int();
+   result->tm_isdst = __VERIFIER_nondet_int();
+   __VERIFIER_assume(result->tm_sec >= 0 && result->tm_sec <= 60);
+   __VERIFIER_assume(result->tm_min >= 0 && result->tm_min < 60);
+   __VERIFIER_assume(result->tm_hour >= 0 && result->tm_hour < 24);
+   __VERIFIER_assume(result->tm_mday > 0 && result->tm_mday < 32);
+   __VERIFIER_assume(result->tm_mon >= 0 && result->tm_mon < 12);
+   __VERIFIER_assume(result->tm_year >= 0 && result->tm_year < 1000);
+   __VERIFIER_assume(result->tm_wday >= 0 && result->tm_wday < 7);
+   __VERIFIER_assume(result->tm_yday >= 0 && result->tm_yday <= 365);
+   return result;
+}
 struct libbb_anonymous$0;
 struct llist_t;
 struct suffix_mult;
@@ -3389,27 +3410,6 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   }
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
-}
-struct tm *localtime_r(const time_t *timep, struct tm* result)
-{
-   result.tm_sec   = __VERIFIER_nondet_int();
-   result.tm_min   = __VERIFIER_nondet_int();
-   result.tm_hour  = __VERIFIER_nondet_int();
-   result.tm_mday  = __VERIFIER_nondet_int();
-   result.tm_mon   = __VERIFIER_nondet_int();
-   result.tm_year  = __VERIFIER_nondet_int();
-   result.tm_wday  = __VERIFIER_nondet_int();
-   result.tm_yday  = __VERIFIER_nondet_int();
-   result.tm_isdst = __VERIFIER_nondet_int();
-   __VERIFIER_assume(result.tm_sec >= 0 && result.tm_sec <= 60);
-   __VERIFIER_assume(result.tm_min >= 0 && result.tm_min < 60);
-   __VERIFIER_assume(result.tm_hour >= 0 && result.tm_hour < 24);
-   __VERIFIER_assume(result.tm_mday > 0 && result.tm_mday < 32);
-   __VERIFIER_assume(result.tm_mon >= 0 && result.tm_mon < 12);
-   __VERIFIER_assume(result.tm_year >= 0 && result.tm_year < 1000);
-   __VERIFIER_assume(result.tm_wday >= 0 && result.tm_wday < 7);
-   __VERIFIER_assume(result.tm_yday >= 0 && result.tm_yday <= 365);
-   return result;
 }
 signed int __main(signed int argc, char **argv)
 {


### PR DESCRIPTION
Add a definition of `localtime_r` which is a POSIX function.
This prevents reading uninitialized values.
As the argument of this function is always unbounded value,
ignore it and just fill the result struct with non-deterministic
values that represent "some valid time".

This PR depends on (or supersede) #525 as it contains also the commit from #525.