### PR TITLE
Improve modelling of function getpwnam for busybox

### DIFF
--- a/c/busybox-1.22.0-todo/id-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0-todo/id-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -3272,6 +3272,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)

--- a/c/busybox-1.22.0/busybox_sv_comp-getpwnam.h
+++ b/c/busybox-1.22.0/busybox_sv_comp-getpwnam.h
@@ -14,6 +14,8 @@ struct passwd *getpwnam(const char *name)
   p.pw_dir = "";        /* home directory */
   p.pw_shell = "";      /* shell program */
 
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 

--- a/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
@@ -2498,6 +2498,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)

--- a/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -2498,6 +2498,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)

--- a/c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
@@ -5256,6 +5256,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -5256,6 +5256,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)

--- a/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
@@ -2439,6 +2439,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)

--- a/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -2439,6 +2439,8 @@ struct passwd *bb_internal_getpwnam(const char *name)
   p.pw_gecos = "";
   p.pw_dir = "";
   p.pw_shell = "";
+  if (__VERIFIER_nondet_uint())
+    return 0;
   return &p;
 }
 struct passwd *bb_internal_getpwuid(uid_t uid)


### PR DESCRIPTION
There are some busybox tasks that have the wrong overflow labels due to the way the getpwnam function is modelled in c/busybox-1.22.0/busybox_sv_comp-getpwnam.h. The affected files are:
```
c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
```
They should be excluded from the corresponding svcomp18 overflow category.
The whoami-incomplete_false-no-overflow.i task brought this issue up because Ultimate correctly classified this tasks as true-no-overflow in the official results for svcomp18 but got a -32 point penalty due to the wrong labeling. CPAchecker is also able to generate a proof for this for the case where the number of argv parameters is reduced from 10000 to 3.

In the real busybox programs, getpwnam may return 0 in case there is no user
with the specified uid or opening of the passwd file fails (I looked it up in the busybox 1.22.0 sources). In c/busybox-1.22.0/busybox_sv_comp-getpwnam.h this function is modelled in a way that it will never return 0. This leads to the fact that the above mentioned three programs never enter the `bb_error_msg_and_die` function that contains the known overflow. 

This pull request will fix this issue by allowing the getpwnam function to return 0 nondeterministically. 
Note: the labels of the files will not be changed / no copies of the original files with updated label are made because this is a bug in modelling (see the https://github.com/sosy-lab/sv-benchmarks/pull/538#issuecomment-346564078 by @tautschnig ). To the best of my knowledge, the labels will be correct again after this pull request is merged
