### PR TITLE
ldv benchmarks: define input_allocate_device function

### DIFF
--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-rc-imon_true-unreach-call.cil.c
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-rc-imon_true-unreach-call.cil.c
@@ -4218,7 +4218,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
 extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/ldv-challenges/linux-3.14__complex_emg__linux-usb-dev__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
+++ b/c/ldv-challenges/linux-3.14__complex_emg__linux-usb-dev__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
@@ -21102,7 +21102,10 @@ __inline static void usb_fill_int_urb(struct urb *urb , struct usb_device *dev ,
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-challenges/linux-3.14__linux-usb-dev__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
+++ b/c/ldv-challenges/linux-3.14__linux-usb-dev__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
@@ -19893,7 +19893,10 @@ __inline static void usb_fill_int_urb(struct urb *urb , struct usb_device *dev ,
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-commit-tester/m0_false-unreach-call_drivers-media-rc-imon--32_7a--a9e7fb5-1.c
+++ b/c/ldv-commit-tester/m0_false-unreach-call_drivers-media-rc-imon--32_7a--a9e7fb5-1.c
@@ -3484,7 +3484,10 @@ __inline static unsigned int iminor(struct inode  const  *inode )
 }
 }
 extern loff_t noop_llseek(struct file * , loff_t  , int  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/ldv-commit-tester/m0_true-unreach-call_drivers-media-rc-imon--32_7a--a9e7fb5.c
+++ b/c/ldv-commit-tester/m0_true-unreach-call_drivers-media-rc-imon--32_7a--a9e7fb5.c
@@ -3509,7 +3509,10 @@ __inline static unsigned int iminor(struct inode  const  *inode )
 }
 }
 extern loff_t noop_llseek(struct file * , loff_t  , int  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/ldv-commit-tester/main0_false-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.c
+++ b/c/ldv-commit-tester/main0_false-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335-1.c
@@ -6620,7 +6620,10 @@ extern void ieee80211_stop_tx_ba_cb_irqsafe(struct ieee80211_vif * , u8 const   
                                             u16  ) ;
 extern void ieee80211_sta_block_awake(struct ieee80211_hw * , struct ieee80211_sta * ,
                                       bool  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-commit-tester/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.c
+++ b/c/ldv-commit-tester/main0_true-unreach-call_drivers-net-wireless-ath-carl9170-carl9170-ko--32_7a--8a9f335.c
@@ -6621,7 +6621,10 @@ extern void ieee80211_stop_tx_ba_cb_irqsafe(struct ieee80211_vif * , u8 const   
                                             u16  ) ;
 extern void ieee80211_sta_block_awake(struct ieee80211_hw * , struct ieee80211_sta * ,
                                       bool  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-consumption/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--media--rc--rc-core.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_false-unreach-call_linux-3.8-rc1-drivers--media--rc--rc-core.ko-main.cil.out.c
@@ -3377,7 +3377,10 @@ extern void device_del(struct device * ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { void *tmp ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--staging--speakup--speakup.ko-ldv_main4_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-32_7a-drivers--staging--speakup--speakup.ko-ldv_main4_sequence_infinite_withcheck_stateful.cil.out.c
@@ -5386,7 +5386,10 @@ __inline static struct thread_info *current_thread_info(void)
 }
 }
 extern void __bad_size_call_parameter(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--firewire--firedtv.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--media--firewire--firedtv.ko-main.cil.out.c
@@ -10037,7 +10037,10 @@ void ldv_mutex_lock_135(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_lock_137(struct mutex *ldv_func_arg1 ) ;
 void ldv_mutex_lock_140(struct mutex *ldv_func_arg1 ) ;
 extern bool cancel_work_sync(struct work_struct * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--platform--x86--ideapad-laptop.ko-main.cil.out.c
+++ b/c/ldv-consumption/32_7a_cilled_true-unreach-call_linux-3.8-rc1-drivers--platform--x86--ideapad-laptop.ko-main.cil.out.c
@@ -3986,7 +3986,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--input--misc--uinput.ko-ldv_main0_true-unreach-call.cil.out.c
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--input--misc--uinput.ko-ldv_main0_true-unreach-call.cil.out.c
@@ -3393,7 +3393,10 @@ extern int misc_register(struct miscdevice * ) ;
 extern int misc_deregister(struct miscdevice * ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-ldv_main0_true-unreach-call.cil.out.c
+++ b/c/ldv-consumption/linux-3.8-rc1-32_7a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-ldv_main0_true-unreach-call.cil.out.c
@@ -6527,7 +6527,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
 extern int request_firmware(struct firmware  const  ** , char const   * , struct device * ) ;
 extern void release_firmware(struct firmware  const  * ) ;
 extern u32 crc32_le(u32  , unsigned char const   * , size_t  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-hid-usbhid-usbmouse.ko_false-unreach-call.cil.out.i.pp.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-hid-usbhid-usbmouse.ko_false-unreach-call.cil.out.i.pp.i
@@ -3595,7 +3595,10 @@ __inline static __u16 usb_maxpacket(struct usb_device *udev , int pipe , int is_
   return (ep->desc.wMaxPacketSize);
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )
 { void *tmp___7 ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-input-misc-keyspan_remote.ko_false-unreach-call.cil.out.i.pp.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-input-misc-keyspan_remote.ko_false-unreach-call.cil.out.i.pp.i
@@ -3608,7 +3608,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )
 { void *tmp___7 ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-input-tablet-kbtab.ko_true-unreach-call.cil.out.i.pp.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-input-tablet-kbtab.ko_true-unreach-call.cil.out.i.pp.i
@@ -3509,7 +3509,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )
 { void *tmp___7 ;

--- a/c/ldv-linux-3.0/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko_false-unreach-call.cil.out.i.pp.i
+++ b/c/ldv-linux-3.0/usb_urb-drivers-media-dvb-ttusb-dec-ttusb_dec.ko_false-unreach-call.cil.out.i.pp.i
@@ -6800,7 +6800,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
 extern int request_firmware(struct firmware const **fw , char const *name , struct device *device ) ;
 extern void release_firmware(struct firmware const *fw ) ;
 extern u32 crc32_le(u32 crc , unsigned char const *p , size_t len ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__)) input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--misc--ims-pcu.ko-entry_point_false-unreach-call.cil.out.c
@@ -4231,7 +4231,10 @@ __inline static int request_ihex_firmware(struct firmware  const  **fw , char co
   return (0);
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--tablet--gtco.ko-entry_point_false-unreach-call.cil.out.c
@@ -3779,7 +3779,10 @@ struct usb_interface *gtco_driverinfo_table_group1  ;
 int ref_cnt  ;
 int ldv_state_variable_0  ;
 void ldv_usb_driver_1(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--input--touchscreen--usbtouchscreen.ko-entry_point_false-unreach-call.cil.out.c
@@ -3852,7 +3852,10 @@ int ref_cnt  ;
 int ldv_state_variable_0  ;
 struct usb_interface *usbtouch_driver_group1  ;
 void ldv_usb_driver_1(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--rc--imon.ko-entry_point_false-unreach-call.cil.out.c
@@ -4184,7 +4184,10 @@ int reg_timer_1(struct timer_list *timer ) ;
 void ldv_initialize_device_attribute_3(void) ;
 void ldv_usb_driver_4(void) ;
 void disable_suitable_timer_1(struct timer_list *timer ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--gspca--gspca_main.ko-entry_point_false-unreach-call.cil.out.c
@@ -5494,7 +5494,10 @@ void gspca_frame_add(struct gspca_dev *gspca_dev , enum gspca_packet_type packet
                      u8 const   *data , int len ) ;
 int gspca_suspend(struct usb_interface *intf , pm_message_t message ) ;
 int gspca_resume(struct usb_interface *intf ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.12-rc1/linux-3.12-rc1.tar.xz-144_2a-drivers--media--usb--ttusb-dec--ttusb_dec.ko-entry_point_false-unreach-call.cil.out.c
@@ -7038,7 +7038,10 @@ __inline static void pci_free_consistent(struct pci_dev *hwdev , size_t size , v
 extern int request_firmware(struct firmware  const  ** , char const   * , struct device * ) ;
 extern void release_firmware(struct firmware  const  * ) ;
 extern u32 crc32_le(u32  , unsigned char const   * , size_t  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
@@ -21278,7 +21278,10 @@ __inline static void usb_fill_int_urb(struct urb *urb , struct usb_device *dev ,
 static struct urb *ldv_usb_alloc_urb_61(int ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_usb_submit_urb_60(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_usb_submit_urb_62(struct urb *ldv_func_arg1 , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-rc-imon_true-unreach-call.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-rc-imon_true-unreach-call.cil.c
@@ -4205,7 +4205,10 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 }
 }
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-usb-pwc-pwc_true-unreach-call.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-mutex__drivers-media-usb-pwc-pwc_true-unreach-call.cil.c
@@ -5482,7 +5482,10 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 }
 }
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-usb-pwc-pwc_true-unreach-call.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-usb-pwc-pwc_true-unreach-call.cil.c
@@ -5477,7 +5477,10 @@ __inline static void *kmalloc(size_t size , gfp_t flags )
 }
 }
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
+++ b/c/ldv-linux-3.14/linux-3.14__complex_emg__linux-kernel-locking-spinlock__drivers-media-usb-uvc-uvcvideo_true-unreach-call.cil.c
@@ -21204,7 +21204,10 @@ __inline static void usb_fill_int_urb(struct urb *urb , struct usb_device *dev ,
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--input--joystick--analog.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--input--joystick--analog.ko-entry_point_true-unreach-call.cil.out.c
@@ -2966,7 +2966,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pwc--pwc.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--media--usb--pwc--pwc.ko-entry_point_true-unreach-call.cil.out.c
@@ -5714,7 +5714,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--magellan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--magellan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1842,7 +1842,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--spaceball.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--spaceball.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1813,7 +1813,10 @@ int init_module(void) ;
 void cleanup_module(void) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--spaceorb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--spaceorb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1843,7 +1843,10 @@ int init_module(void) ;
 void cleanup_module(void) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--stinger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--stinger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1811,7 +1811,10 @@ __inline static void *( __attribute__((__always_inline__)) kmalloc)(size_t size 
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--twidjoy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--twidjoy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1847,7 +1847,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--warrior.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--warrior.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1825,7 +1825,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--zhenhua.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--joystick--zhenhua.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1824,7 +1824,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--keyboard--newtonkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--keyboard--newtonkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1864,7 +1864,10 @@ int init_module(void) ;
 void cleanup_module(void) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--keyboard--stowaway.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--keyboard--stowaway.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1866,7 +1866,10 @@ int init_module(void) ;
 void cleanup_module(void) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--keyboard--xtkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--keyboard--xtkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1851,7 +1851,10 @@ int init_module(void) ;
 void cleanup_module(void) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--misc--atlas_btns.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--misc--atlas_btns.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3122,7 +3122,10 @@ extern int acpi_disabled ;
 extern struct module __this_module ;
 int init_module(void) ;
 void cleanup_module(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--misc--xen-kbdfront.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--misc--xen-kbdfront.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2127,7 +2127,10 @@ int init_module(void) ;
 void cleanup_module(void) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--mouse--vsxxxaa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--mouse--vsxxxaa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1844,7 +1844,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--dynapro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--dynapro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1838,7 +1838,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--egalax_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--egalax_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3127,7 +3127,10 @@ extern int __attribute__((__warn_unused_result__))  request_threaded_irq(unsigne
                                                                          char const   *name ,
                                                                          void *dev ) ;
 extern void free_irq(unsigned int  , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data )  __attribute__((__no_instrument_function__)) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--fujitsu_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--fujitsu_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1827,7 +1827,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--gunze.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--gunze.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1829,7 +1829,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--hampshire.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--hampshire.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1838,7 +1838,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--inexio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--inexio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1828,7 +1828,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--mtouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--mtouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1828,7 +1828,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--penmount.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--penmount.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1837,7 +1837,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--touchit213.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--touchit213.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1838,7 +1838,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--touchright.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--touchright.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1827,7 +1827,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--touchwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--touchwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1828,7 +1828,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern struct device *get_device(struct device *dev ) ;
 extern void put_device(struct device *dev ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--tsc40.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--tsc40.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1846,7 +1846,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--wacom_w8001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--input--touchscreen--wacom_w8001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1909,7 +1909,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1838,7 +1838,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 extern int proc_dointvec(struct ctl_table * , int  , void * , size_t * , loff_t * ) ;
 extern struct ctl_table_header *register_sysctl_table(struct ctl_table *table ) ;
 extern void unregister_sysctl_table(struct ctl_table_header *table ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3360,7 +3360,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3216,7 +3216,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 }
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3.4-32_1-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3178,7 +3178,10 @@ int atomic_dec_and_mutex_lock(atomic_t *cnt , struct mutex *lock ) ;
 int init_module(void) ;
 void cleanup_module(void) ;
 extern int device_set_wakeup_enable(struct device *dev , bool enable ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--ab8500-ponkey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--ab8500-ponkey.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1857,7 +1857,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--mpu3050.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--mpu3050.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3136,7 +3136,10 @@ __inline static void *i2c_get_clientdata(struct i2c_client  const  *dev )
 }
 extern int i2c_register_driver(struct module * , struct i2c_driver * ) ;
 extern void i2c_del_driver(struct i2c_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcap_keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcap_keys.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1872,7 +1872,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcf50633-input.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcf50633-input.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3242,7 +3242,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcspkr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--pcspkr.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2063,7 +2063,10 @@ void cleanup_module(void) ;
 extern raw_spinlock_t i8253_lock ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--rotary_encoder.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--rotary_encoder.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1878,7 +1878,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern int ( /* format attribute */  dev_err)(struct device  const  *dev , char const   *fmt 
                                               , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--wm831x-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--misc--wm831x-on.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1885,7 +1885,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern int ( /* format attribute */  dev_err)(struct device  const  *dev , char const   *fmt 
                                               , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--touchscreen--eeti_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--touchscreen--eeti_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3121,7 +3121,10 @@ extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
 extern int ( /* format attribute */  dev_err)(struct device  const  *dev , char const   *fmt 
                                               , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--touchscreen--max11801_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--touchscreen--max11801_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3111,7 +3111,10 @@ extern int __attribute__((__warn_unused_result__))  request_threaded_irq(unsigne
                                                                          char const   *name ,
                                                                          void *dev ) ;
 extern void free_irq(unsigned int  , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data )  __attribute__((__no_instrument_function__)) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--touchscreen--stmpe-ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_false-termination.4-32_1-drivers--input--touchscreen--stmpe-ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3139,7 +3139,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--joystick--turbografx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--joystick--turbografx.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2027,7 +2027,10 @@ extern int parport_claim(struct pardevice *dev ) ;
 extern void parport_release(struct pardevice *dev ) ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern int dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--touchscreen--mk712.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--input--touchscreen--mk712.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1848,7 +1848,10 @@ __inline static int __attribute__((__warn_unused_result__))  request_irq(unsigne
 }
 }
 extern void free_irq(unsigned int  , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_1_cilled_true-unreach-call_ok_nondet_linux-3_true-termination.4-32_1-drivers--platform--x86--dell-wmi-aio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2981,7 +2981,10 @@ void mutex_unlock(struct mutex *lock ) ;
 int atomic_dec_and_mutex_lock(atomic_t *cnt , struct mutex *lock ) ;
 int init_module(void) ;
 void cleanup_module(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int __attribute__((__warn_unused_result__))  input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--input--mouse--synaptics_usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/32_7_cilled_false-unreach-call_const_ok_linux-32_1-drivers--input--mouse--synaptics_usb_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3716,7 +3716,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   }
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev )  __attribute__((__no_instrument_function__)) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--magellan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--magellan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1796,7 +1796,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--spaceball.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--spaceball.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1799,7 +1799,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--spaceorb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--spaceorb.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1797,7 +1797,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--stinger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--stinger.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1797,7 +1797,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--turbografx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--turbografx_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1969,7 +1969,10 @@ extern int parport_claim(struct pardevice * ) ;
 extern void parport_release(struct pardevice * ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--twidjoy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--twidjoy.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1801,7 +1801,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--warrior.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--warrior.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1788,7 +1788,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--zhenhua.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--joystick--zhenhua.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1787,7 +1787,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--newtonkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--newtonkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1808,7 +1808,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--stowaway.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--stowaway.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1807,7 +1807,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--xtkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--keyboard--xtkbd.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1818,7 +1818,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ab8500-ponkey_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--ab8500-ponkey_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1817,7 +1817,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_event(struct input_dev * , unsigned int  , unsigned int  , int  ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--atlas_btns.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--atlas_btns.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3087,7 +3087,10 @@ void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t ldv_func_
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--mpu3050_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--mpu3050_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3088,7 +3088,10 @@ extern int dev_err(struct device  const  * , char const   *  , ...) ;
 extern int i2c_transfer(struct i2c_adapter * , struct i2c_msg * , int  ) ;
 extern s32 i2c_smbus_read_byte_data(struct i2c_client  const  * , u8  ) ;
 extern s32 i2c_smbus_write_byte_data(struct i2c_client  const  * , u8  , u8  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcap_keys_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcap_keys_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1826,7 +1826,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcf50633-input_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcf50633-input_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3170,7 +3170,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_event(struct input_dev * , unsigned int  , unsigned int  , int  ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcspkr_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--pcspkr_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2076,7 +2076,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern raw_spinlock_t i8253_lock ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 __inline static void platform_set_drvdata(struct platform_device *pdev , void *data ) 

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--rotary_encoder_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--rotary_encoder_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1845,7 +1845,10 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int  ,
 extern void free_irq(unsigned int  , void * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern int dev_err(struct device  const  * , char const   *  , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--wm831x-on_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--wm831x-on_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1835,7 +1835,10 @@ struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern int dev_err(struct device  const  * , char const   *  , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_event(struct input_dev * , unsigned int  , unsigned int  , int  ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--xen-kbdfront.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--misc--xen-kbdfront.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2101,7 +2101,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--mouse--vsxxxaa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--mouse--vsxxxaa.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1806,7 +1806,10 @@ struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void __const_udelay(unsigned long  ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--dynapro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--dynapro.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1800,7 +1800,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--eeti_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--eeti_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3059,7 +3059,10 @@ extern int device_init_wakeup(struct device * , bool  ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern int dev_err(struct device  const  * , char const   *  , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--egalax_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--egalax_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3070,7 +3070,10 @@ extern int request_threaded_irq(unsigned int  , irqreturn_t (*)(int  , void * ) 
                                 irqreturn_t (*)(int  , void * ) , unsigned long  ,
                                 char const   * , void * ) ;
 extern void free_irq(unsigned int  , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { unsigned long __cil_tmp3 ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--fujitsu_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--fujitsu_ts.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1790,7 +1790,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--gunze.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--gunze.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1792,7 +1792,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--hampshire.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--hampshire.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1800,7 +1800,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--inexio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--inexio.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1791,7 +1791,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--max11801_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--max11801_ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3059,7 +3059,10 @@ extern int request_threaded_irq(unsigned int  , irqreturn_t (*)(int  , void * ) 
                                 irqreturn_t (*)(int  , void * ) , unsigned long  ,
                                 char const   * , void * ) ;
 extern void free_irq(unsigned int  , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { unsigned long __cil_tmp3 ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mk712_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mk712_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1830,7 +1830,10 @@ __inline static int request_irq(unsigned int irq , irqreturn_t (*handler)(int  ,
 }
 }
 extern void free_irq(unsigned int  , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mtouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--mtouch.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1791,7 +1791,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--penmount.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--penmount.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1800,7 +1800,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--stmpe-ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--stmpe-ts_false-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3082,7 +3082,10 @@ __inline static void platform_set_drvdata(struct platform_device *pdev , void *d
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchit213.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchit213.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1800,7 +1800,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchright.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchright.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1790,7 +1790,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--touchwin.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1791,7 +1791,10 @@ extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
 extern struct device *get_device(struct device * ) ;
 extern void put_device(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { struct device  const  *__mptr ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--tsc40.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--tsc40.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1807,7 +1807,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--wacom_w8001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--input--touchscreen--wacom_w8001.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1862,7 +1862,10 @@ void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { void *tmp ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--macintosh--mac_hid.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -1807,7 +1807,10 @@ extern void *__VERIFIER_nondet_pointer(void) ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--dell-wmi-aio_true-termination.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -2956,7 +2956,10 @@ void *ldv_kmem_cache_alloc_16(struct kmem_cache *ldv_func_arg1 , gfp_t ldv_func_
 void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--panasonic-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3287,7 +3287,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--topstar-laptop.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3162,7 +3162,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 }
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
+++ b/c/ldv-linux-3.4-simple/43_1a_cilled_true-unreach-call_ok_nondet_linux-43_1a-drivers--platform--x86--xo15-ebook.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c
@@ -3143,7 +3143,10 @@ void ldv_check_alloc_flags(gfp_t flags ) ;
 void ldv_check_alloc_nonatomic(void) ;
 struct page *ldv_check_alloc_flags_and_return_some_page(gfp_t flags ) ;
 extern int device_set_wakeup_enable(struct device * , bool  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -4517,7 +4517,10 @@ extern void dev_warn(struct device  const  * , char const   *  , ...) ;
 extern void _dev_info(struct device  const  * , char const   *  , ...) ;
 extern void kfree(void const   * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -4890,7 +4890,10 @@ __inline static int request_ihex_firmware(struct firmware  const  **fw , char co
   return (0);
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -4556,7 +4556,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
 extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -6181,7 +6181,10 @@ void gspca_frame_add(struct gspca_dev *gspca_dev , enum gspca_packet_type packet
                      u8 const   *data , int len ) ;
 int gspca_suspend(struct usb_interface *intf , pm_message_t message ) ;
 int gspca_resume(struct usb_interface *intf ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -23656,7 +23656,10 @@ static struct urb *ldv_usb_alloc_urb_97(int ldv_func_arg1 , gfp_t flags ) ;
 static void ldv_usb_free_urb_98(struct urb *urb ) ;
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_usb_submit_urb_99(struct urb *ldv_func_arg1 , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--platform--x86--thinkpad_acpi.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--platform--x86--thinkpad_acpi.ko-entry_point_true-unreach-call.cil.out.c
@@ -5058,7 +5058,10 @@ void ldv_platform_driver_unregister_15(struct platform_driver *ldv_func_arg1 ) ;
 void ldv_platform_driver_unregister_16(struct platform_driver *ldv_func_arg1 ) ;
 extern struct device *hwmon_device_register(struct device * ) ;
 extern void hwmon_device_unregister(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point_true-unreach-call.cil.out.c
@@ -22740,7 +22740,10 @@ __inline static char const   *dev_name(struct device  const  *dev )
   return (tmp);
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--platform--x86--thinkpad_acpi.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--platform--x86--thinkpad_acpi.ko-entry_point_true-unreach-call.cil.out.c
@@ -5162,7 +5162,10 @@ void ldv_platform_driver_unregister_83(struct platform_driver *ldv_func_arg1 ) ;
 void ldv_platform_driver_unregister_84(struct platform_driver *ldv_func_arg1 ) ;
 extern struct device *hwmon_device_register(struct device * ) ;
 extern void hwmon_device_unregister(struct device * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--input--mouse--psmouse.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--input--mouse--psmouse.ko-entry_point_true-unreach-call.cil.out.c
@@ -4185,7 +4185,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
 extern void dev_warn(struct device  const  * , char const   *  , ...) ;
 extern void dev_notice(struct device  const  * , char const   *  , ...) ;
 extern void _dev_info(struct device  const  * , char const   *  , ...) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--media--pci--ttpci--dvb-ttpci.ko-entry_point_true-unreach-call.cil.out.c
@@ -22439,7 +22439,10 @@ struct sk_buff *ldv___netdev_alloc_skb_239(struct net_device *ldv_func_arg1 , un
                                            gfp_t flags ) ;
 struct sk_buff *ldv___netdev_alloc_skb_240(struct net_device *ldv_func_arg1 , unsigned int ldv_func_arg2 ,
                                            gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--staging--speakup--speakup.ko-entry_point_true-unreach-call.cil.out.c
@@ -5774,7 +5774,10 @@ __inline static void __preempt_count_sub(int val )
 }
 }
 void *ldv_kmem_cache_alloc_90(struct kmem_cache *ldv_func_arg1 , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--hid--hid-wiimote.ko_false-unreach-call.cil.c
@@ -4517,7 +4517,10 @@ extern void dev_warn(struct device  const  * , char const   *  , ...) ;
 extern void _dev_info(struct device  const  * , char const   *  , ...) ;
 extern void kfree(void const   * ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static struct input_dev *input_get_device(struct input_dev *dev ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--misc--ims-pcu.ko_false-unreach-call.cil.c
@@ -4890,7 +4890,10 @@ __inline static int request_ihex_firmware(struct firmware  const  **fw , char co
   return (0);
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--input--touchscreen--usbtouchscreen.ko_false-unreach-call.cil.c
@@ -4556,7 +4556,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
 extern void kfree(void const   * ) ;
 __inline static void *kmalloc(size_t size , gfp_t flags ) ;
 __inline static void *kzalloc(size_t size , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--gspca--gspca_main.ko_false-unreach-call.cil.c
@@ -6181,7 +6181,10 @@ void gspca_frame_add(struct gspca_dev *gspca_dev , enum gspca_packet_type packet
                      u8 const   *data , int len ) ;
 int gspca_suspend(struct usb_interface *intf , pm_message_t message ) ;
 int gspca_resume(struct usb_interface *intf ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
+++ b/c/ldv-multiproperty/linux-4.0-rc1---drivers--media--usb--uvc--uvcvideo.ko_false-unreach-call.cil.c
@@ -23656,7 +23656,10 @@ static struct urb *ldv_usb_alloc_urb_97(int ldv_func_arg1 , gfp_t flags ) ;
 static void ldv_usb_free_urb_98(struct urb *urb ) ;
 static int ldv_usb_submit_urb_96(struct urb *ldv_func_arg1 , gfp_t flags ) ;
 static int ldv_usb_submit_urb_99(struct urb *ldv_func_arg1 , gfp_t flags ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-validator-v0.6/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_false-unreach-call.cil.out.c
@@ -6757,7 +6757,10 @@ extern void ieee80211_sta_block_awake(struct ieee80211_hw * , struct ieee80211_s
 extern int usb_register_driver(struct usb_driver * , struct module * , char const   * ) ;
 int ldv_usb_register_driver_6(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,
                               char const   *ldv_func_arg3 ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-validator-v0.6/linux-stable-a9e7fb5-1-32_7a-drivers--media--rc--imon.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-validator-v0.6/linux-stable-a9e7fb5-1-32_7a-drivers--media--rc--imon.ko-entry_point_false-unreach-call.cil.out.c
@@ -3630,7 +3630,10 @@ __inline static unsigned int iminor(struct inode  const  *inode )
 }
 }
 extern loff_t noop_llseek(struct file * , loff_t  , int  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/ldv-validator-v0.8/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-8a9f335-1-32_7a-drivers--net--wireless--ath--carl9170--carl9170.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
@@ -6838,7 +6838,10 @@ extern void ieee80211_sta_block_awake(struct ieee80211_hw * , struct ieee80211_s
 extern int usb_register_driver(struct usb_driver * , struct module * , char const   * ) ;
 int ldv_usb_register_driver_13(struct usb_driver *ldv_func_arg1 , struct module *ldv_func_arg2 ,
                                char const   *ldv_func_arg3 ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_1a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_1a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
@@ -3566,7 +3566,10 @@ int usb_counter  ;
 struct usb_interface *usb_acecad_driver_group1  ;
 int ldv_state_variable_0  ;
 void ldv_usb_driver_1(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-a450319-1-144_2a-drivers--input--tablet--acecad.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
@@ -3563,7 +3563,10 @@ int usb_counter  ;
 struct usb_interface *usb_acecad_driver_group1  ;
 int ldv_state_variable_0  ;
 void ldv_usb_driver_1(void) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/ldv-validator-v0.8/linux-stable-a9e7fb5-1-32_7a-drivers--media--rc--imon.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
+++ b/c/ldv-validator-v0.8/linux-stable-a9e7fb5-1-32_7a-drivers--media--rc--imon.ko-entry_point_ldv-val-v0.8_false-unreach-call.cil.out.c
@@ -3625,7 +3625,10 @@ __inline static unsigned int iminor(struct inode  const  *inode )
 }
 }
 extern loff_t noop_llseek(struct file * , loff_t  , int  ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void input_set_drvdata(struct input_dev *dev , void *data ) 
 { 

--- a/c/regression/drivers--input--joystick--magellan.ko_009.d1659fc.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--magellan.ko_009.d1659fc.08_1a.cil_true-unreach-call.i
@@ -2605,7 +2605,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--magellan.ko_009.d1659fc.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--magellan.ko_009.d1659fc.32_7a.cil_true-unreach-call.i
@@ -2628,7 +2628,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--magellan.ko_009.d1659fc.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--magellan.ko_009.d1659fc.39_7a.cil_true-unreach-call.i
@@ -2644,7 +2644,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--magellan.ko_010.65ac9f7.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--magellan.ko_010.65ac9f7.08_1a.cil_true-unreach-call.i
@@ -1744,7 +1744,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--magellan.ko_010.65ac9f7.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--magellan.ko_010.65ac9f7.32_7a.cil_true-unreach-call.i
@@ -1751,7 +1751,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--magellan.ko_010.65ac9f7.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--magellan.ko_010.65ac9f7.39_7a.cil_true-unreach-call.i
@@ -1745,7 +1745,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--spaceorb.ko_011.d1659fc.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--spaceorb.ko_011.d1659fc.08_1a.cil_true-unreach-call.i
@@ -2606,7 +2606,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--spaceorb.ko_011.d1659fc.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--spaceorb.ko_011.d1659fc.32_7a.cil_true-unreach-call.i
@@ -2629,7 +2629,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--spaceorb.ko_011.d1659fc.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--spaceorb.ko_011.d1659fc.39_7a.cil_true-unreach-call.i
@@ -2645,7 +2645,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--spaceorb.ko_012.65ac9f7.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--spaceorb.ko_012.65ac9f7.08_1a.cil_true-unreach-call.i
@@ -1745,7 +1745,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--spaceorb.ko_012.65ac9f7.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--spaceorb.ko_012.65ac9f7.32_7a.cil_true-unreach-call.i
@@ -1752,7 +1752,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--spaceorb.ko_012.65ac9f7.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--spaceorb.ko_012.65ac9f7.39_7a.cil_true-unreach-call.i
@@ -1746,7 +1746,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--twidjoy.ko_010.d1659fc.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--twidjoy.ko_010.d1659fc.08_1a.cil_true-unreach-call.i
@@ -2610,7 +2610,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--twidjoy.ko_010.d1659fc.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--twidjoy.ko_010.d1659fc.32_7a.cil_true-unreach-call.i
@@ -2633,7 +2633,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--twidjoy.ko_010.d1659fc.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--twidjoy.ko_010.d1659fc.39_7a.cil_true-unreach-call.i
@@ -2649,7 +2649,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--twidjoy.ko_011.65ac9f7.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--twidjoy.ko_011.65ac9f7.08_1a.cil_true-unreach-call.i
@@ -1749,7 +1749,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--twidjoy.ko_011.65ac9f7.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--twidjoy.ko_011.65ac9f7.32_7a.cil_true-unreach-call.i
@@ -1756,7 +1756,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--joystick--twidjoy.ko_011.65ac9f7.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--joystick--twidjoy.ko_011.65ac9f7.39_7a.cil_true-unreach-call.i
@@ -1750,7 +1750,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.08_1a.cil_true-unreach-call.i
@@ -2866,7 +2866,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.32_1.cil_true-unreach-call.i
@@ -2867,7 +2867,10 @@ __inline static unsigned int ( __attribute__((__always_inline__)) __create_pipe)
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *( __attribute__((__always_inline__)) input_get_drvdata)(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.32_7a.cil_true-unreach-call.i
@@ -2866,7 +2866,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.43_1a.cil_true-unreach-call.i
@@ -2861,7 +2861,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.68_1.cil_false-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_002.1953ea2.68_1.cil_false-unreach-call.i
@@ -2937,7 +2937,10 @@ __inline static unsigned int ( __attribute__((__always_inline__)) __create_pipe)
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *( __attribute__((__always_inline__)) input_get_drvdata)(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.08_1a.cil_true-unreach-call.i
@@ -2866,7 +2866,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.32_1.cil_true-unreach-call.i
@@ -2867,7 +2867,10 @@ __inline static unsigned int ( __attribute__((__always_inline__)) __create_pipe)
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *( __attribute__((__always_inline__)) input_get_drvdata)(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.32_7a.cil_true-unreach-call.i
@@ -2866,7 +2866,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.43_1a.cil_true-unreach-call.i
@@ -2861,7 +2861,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.68_1.cil_false-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_003.3b04a61.68_1.cil_false-unreach-call.i
@@ -2937,7 +2937,10 @@ __inline static unsigned int ( __attribute__((__always_inline__)) __create_pipe)
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *( __attribute__((__always_inline__)) input_get_drvdata)(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.08_1a.cil_true-unreach-call.i
@@ -3009,7 +3009,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.32_1.cil_true-unreach-call.i
@@ -3033,7 +3033,10 @@ __inline static unsigned int ( __attribute__((__always_inline__)) __create_pipe)
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *( __attribute__((__always_inline__)) input_get_drvdata)(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.32_7a.cil_true-unreach-call.i
@@ -3010,7 +3010,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.39_7a.cil_true-unreach-call.i
@@ -3044,7 +3044,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.43_1a.cil_true-unreach-call.i
@@ -3005,7 +3005,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.68_1.cil_unknown.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_004.ea3e6c5.68_1.cil_unknown.i
@@ -3103,7 +3103,10 @@ __inline static unsigned int ( __attribute__((__always_inline__)) __create_pipe)
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *( __attribute__((__always_inline__)) input_get_drvdata)(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_005.997ea58.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_005.997ea58.08_1a.cil_true-unreach-call.i
@@ -3509,7 +3509,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_005.997ea58.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_005.997ea58.32_7a.cil_true-unreach-call.i
@@ -3502,7 +3502,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_005.997ea58.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_005.997ea58.39_7a.cil_true-unreach-call.i
@@ -3506,7 +3506,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_006.25985ed.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_006.25985ed.08_1a.cil_true-unreach-call.i
@@ -3302,7 +3302,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_006.25985ed.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_006.25985ed.32_7a.cil_true-unreach-call.i
@@ -3305,7 +3305,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_006.25985ed.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_006.25985ed.39_7a.cil_true-unreach-call.i
@@ -3299,7 +3299,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_007.08642e7.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_007.08642e7.08_1a.cil_true-unreach-call.i
@@ -3326,7 +3326,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_007.08642e7.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_007.08642e7.32_7a.cil_true-unreach-call.i
@@ -3326,7 +3326,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_007.08642e7.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_007.08642e7.39_7a.cil_true-unreach-call.i
@@ -3322,7 +3322,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_008.4efeca5.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_008.4efeca5.08_1a.cil_true-unreach-call.i
@@ -3333,7 +3333,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_008.4efeca5.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_008.4efeca5.32_7a.cil_true-unreach-call.i
@@ -3337,7 +3337,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_008.4efeca5.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_008.4efeca5.39_7a.cil_true-unreach-call.i
@@ -3329,7 +3329,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_009.3b449fe.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_009.3b449fe.08_1a.cil_true-unreach-call.i
@@ -3330,7 +3330,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_009.3b449fe.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_009.3b449fe.32_7a.cil_true-unreach-call.i
@@ -3334,7 +3334,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_009.3b449fe.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_009.3b449fe.39_7a.cil_true-unreach-call.i
@@ -3326,7 +3326,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_010.419b1a1.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_010.419b1a1.08_1a.cil_true-unreach-call.i
@@ -3330,7 +3330,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_010.419b1a1.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_010.419b1a1.32_7a.cil_true-unreach-call.i
@@ -3334,7 +3334,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--misc--keyspan_remote.ko_010.419b1a1.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--misc--keyspan_remote.ko_010.419b1a1.39_7a.cil_true-unreach-call.i
@@ -3326,7 +3326,10 @@ __inline static unsigned int __create_pipe(struct usb_device *dev , unsigned int
   return ((unsigned int )(dev->devnum << 8) | (endpoint << 15));
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.08_1a.cil_true-unreach-call.i
@@ -3052,7 +3052,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.32_1.cil_true-unreach-call.i
@@ -3443,7 +3443,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int ( __attribute__((__warn_unused_result__)) input_register_device)(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.32_7a.cil_true-unreach-call.i
@@ -3064,7 +3064,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.39_7a.cil_true-unreach-call.i
@@ -3092,7 +3092,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.43_1a.cil_true-unreach-call.i
@@ -2798,7 +2798,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_011.dd0d544.68_1.cil_true-unreach-call.i
@@ -3791,7 +3791,10 @@ __inline static void dev_set_drvdata(struct device *dev , void *data )
   return;
 }
 }
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int ( __attribute__((__warn_unused_result__)) input_register_device)(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.08_1a.cil_true-unreach-call.i
@@ -1914,7 +1914,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 extern struct module __this_module ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.32_1.cil_true-unreach-call.i
@@ -2316,7 +2316,10 @@ void cleanup_module(void) ;
 extern struct module __this_module ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern void dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int ( __attribute__((__warn_unused_result__)) input_register_device)(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.32_7a.cil_true-unreach-call.i
@@ -1933,7 +1933,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 extern struct module __this_module ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.39_7a.cil_true-unreach-call.i
@@ -1952,7 +1952,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 extern struct module __this_module ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.43_1a.cil_true-unreach-call.i
@@ -1650,7 +1650,10 @@ extern struct module __this_module ;
 void ldv_check_alloc_flags(gfp_t flags ) ;
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_012.21602325.68_1.cil_true-unreach-call.i
@@ -3803,7 +3803,10 @@ void cleanup_module(void) ;
 extern struct module __this_module ;
 extern void *dev_get_drvdata(struct device  const  *dev ) ;
 extern void dev_set_drvdata(struct device *dev , void *data ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 extern int ( __attribute__((__warn_unused_result__)) input_register_device)(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_013.25985ed.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_013.25985ed.08_1a.cil_true-unreach-call.i
@@ -1772,7 +1772,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_013.25985ed.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_013.25985ed.32_7a.cil_true-unreach-call.i
@@ -1782,7 +1782,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_013.25985ed.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_013.25985ed.39_7a.cil_true-unreach-call.i
@@ -1774,7 +1774,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern void dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_014.65ac9f7.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_014.65ac9f7.08_1a.cil_true-unreach-call.i
@@ -1754,7 +1754,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_014.65ac9f7.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_014.65ac9f7.32_7a.cil_true-unreach-call.i
@@ -1761,7 +1761,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--input--mouse--vsxxxaa.ko_014.65ac9f7.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--input--mouse--vsxxxaa.ko_014.65ac9f7.39_7a.cil_true-unreach-call.i
@@ -1755,7 +1755,10 @@ __inline static void *kzalloc(size_t size , gfp_t flags )
 }
 extern void *dev_get_drvdata(struct device  const  * ) ;
 extern int dev_set_drvdata(struct device * , void * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.08_1a.cil_true-unreach-call.i
@@ -3066,7 +3066,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.32_1.cil_true-unreach-call.i
@@ -3087,7 +3087,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.32_7a.cil_true-unreach-call.i
@@ -3085,7 +3085,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.39_7a.cil_true-unreach-call.i
@@ -3101,7 +3101,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.43_1a.cil_true-unreach-call.i
@@ -3059,7 +3059,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_000.41b16dc.68_1.cil_true-unreach-call.i
@@ -3409,7 +3409,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.08_1a.cil_true-unreach-call.i
@@ -3131,7 +3131,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.32_1.cil_true-unreach-call.i
@@ -3112,7 +3112,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.32_7a.cil_true-unreach-call.i
@@ -3113,7 +3113,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.39_7a.cil_true-unreach-call.i
@@ -3129,7 +3129,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.43_1a.cil_true-unreach-call.i
@@ -3124,7 +3124,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_003.c542aad.68_1.cil_true-unreach-call.i
@@ -3479,7 +3479,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.08_1a.cil_true-unreach-call.i
@@ -3131,7 +3131,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.32_1.cil_true-unreach-call.i
@@ -3113,7 +3113,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.32_7a.cil_true-unreach-call.i
@@ -3113,7 +3113,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.39_7a.cil_true-unreach-call.i
@@ -3129,7 +3129,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.43_1a.cil_true-unreach-call.i
@@ -3124,7 +3124,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_004.ba256b4.68_1.cil_true-unreach-call.i
@@ -3480,7 +3480,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.08_1a.cil_true-unreach-call.i
@@ -3643,7 +3643,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.32_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.32_1.cil_true-unreach-call.i
@@ -3772,7 +3772,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.32_7a.cil_true-unreach-call.i
@@ -3355,7 +3355,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.39_7a.cil_true-unreach-call.i
@@ -3383,7 +3383,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.43_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.43_1a.cil_true-unreach-call.i
@@ -3123,7 +3123,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.68_1.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_007.8897c18.68_1.cil_true-unreach-call.i
@@ -4296,7 +4296,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device *device , u8 type , int data ) ;
 extern int acpi_bus_register_driver(struct acpi_driver *driver ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver *driver ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev *dev ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_008.58b9399.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_008.58b9399.08_1a.cil_true-unreach-call.i
@@ -3357,7 +3357,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_008.58b9399.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_008.58b9399.32_7a.cil_true-unreach-call.i
@@ -3356,7 +3356,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_008.58b9399.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_008.58b9399.39_7a.cil_true-unreach-call.i
@@ -3354,7 +3354,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_009.a19a6ee.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_009.a19a6ee.08_1a.cil_true-unreach-call.i
@@ -3385,7 +3385,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_009.a19a6ee.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_009.a19a6ee.32_7a.cil_true-unreach-call.i
@@ -3384,7 +3384,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_009.a19a6ee.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_009.a19a6ee.39_7a.cil_true-unreach-call.i
@@ -3382,7 +3382,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_010.ec57af9.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_010.ec57af9.08_1a.cil_true-unreach-call.i
@@ -3393,7 +3393,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_010.ec57af9.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_010.ec57af9.32_7a.cil_true-unreach-call.i
@@ -3392,7 +3392,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_010.ec57af9.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_010.ec57af9.39_7a.cil_true-unreach-call.i
@@ -3390,7 +3390,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_011.5a0e3ad.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_011.5a0e3ad.08_1a.cil_true-unreach-call.i
@@ -3383,7 +3383,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_011.5a0e3ad.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_011.5a0e3ad.32_7a.cil_true-unreach-call.i
@@ -3382,7 +3382,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_011.5a0e3ad.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_011.5a0e3ad.39_7a.cil_true-unreach-call.i
@@ -3380,7 +3380,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_012.9fab10c.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_012.9fab10c.08_1a.cil_true-unreach-call.i
@@ -3375,7 +3375,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_012.9fab10c.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_012.9fab10c.32_7a.cil_true-unreach-call.i
@@ -3382,7 +3382,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_012.9fab10c.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_012.9fab10c.39_7a.cil_true-unreach-call.i
@@ -3372,7 +3372,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 __inline static void *input_get_drvdata(struct input_dev *dev ) 
 { 

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_013.1a765ca.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_013.1a765ca.08_1a.cil_true-unreach-call.i
@@ -3360,7 +3360,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_013.1a765ca.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_013.1a765ca.32_7a.cil_true-unreach-call.i
@@ -3367,7 +3367,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_013.1a765ca.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_013.1a765ca.39_7a.cil_true-unreach-call.i
@@ -3357,7 +3357,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_014.aa13857.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_014.aa13857.08_1a.cil_true-unreach-call.i
@@ -3360,7 +3360,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_014.aa13857.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_014.aa13857.32_7a.cil_true-unreach-call.i
@@ -3367,7 +3367,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_014.aa13857.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_014.aa13857.39_7a.cil_true-unreach-call.i
@@ -3357,7 +3357,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_015.e253fb9.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_015.e253fb9.08_1a.cil_true-unreach-call.i
@@ -3360,7 +3360,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_015.e253fb9.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_015.e253fb9.32_7a.cil_true-unreach-call.i
@@ -3367,7 +3367,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_015.e253fb9.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_015.e253fb9.39_7a.cil_true-unreach-call.i
@@ -3357,7 +3357,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_016.bb7ca74.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_016.bb7ca74.08_1a.cil_true-unreach-call.i
@@ -3154,7 +3154,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_016.bb7ca74.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_016.bb7ca74.32_7a.cil_true-unreach-call.i
@@ -3161,7 +3161,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_016.bb7ca74.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_016.bb7ca74.39_7a.cil_true-unreach-call.i
@@ -3151,7 +3151,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_017.e424fb8.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_017.e424fb8.08_1a.cil_true-unreach-call.i
@@ -3189,7 +3189,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_017.e424fb8.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_017.e424fb8.32_7a.cil_true-unreach-call.i
@@ -3197,7 +3197,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_017.e424fb8.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_017.e424fb8.39_7a.cil_true-unreach-call.i
@@ -3185,7 +3185,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_018.a737741.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_018.a737741.08_1a.cil_true-unreach-call.i
@@ -3252,7 +3252,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_018.a737741.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_018.a737741.32_7a.cil_true-unreach-call.i
@@ -3260,7 +3260,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_018.a737741.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_018.a737741.39_7a.cil_true-unreach-call.i
@@ -3248,7 +3248,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_019.3567a4e.08_1a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_019.3567a4e.08_1a.cil_true-unreach-call.i
@@ -3279,7 +3279,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_019.3567a4e.32_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_019.3567a4e.32_7a.cil_true-unreach-call.i
@@ -3287,7 +3287,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;

--- a/c/regression/drivers--platform--x86--panasonic-laptop.ko_019.3567a4e.39_7a.cil_true-unreach-call.i
+++ b/c/regression/drivers--platform--x86--panasonic-laptop.ko_019.3567a4e.39_7a.cil_true-unreach-call.i
@@ -3275,7 +3275,10 @@ __inline static void *acpi_driver_data(struct acpi_device *d )
 extern int acpi_bus_generate_proc_event(struct acpi_device * , u8  , int  ) ;
 extern int acpi_bus_register_driver(struct acpi_driver * ) ;
 extern void acpi_bus_unregister_driver(struct acpi_driver * ) ;
-extern struct input_dev *input_allocate_device(void) ;
+struct input_dev *input_allocate_device(void) {
+       return kzalloc(sizeof(struct input_dev), 0x10u | 0x40u | 0x80u);
+}
+
 extern void input_free_device(struct input_dev * ) ;
 extern int input_register_device(struct input_dev * ) ;
 extern void input_unregister_device(struct input_dev * ) ;


### PR DESCRIPTION
This funcion uses kzalloc to allocate memory for a new device
(https://elixir.free-electrons.com/linux/v3.5/source/drivers/input/input.c#L1647)

This is to fix a part of #554 .