### PR TITLE
Fix undefined behavior due to dereferencing null pointer in 4 ldvs

### DIFF
--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point_true-unreach-call.cil.out.c
@@ -5289,6 +5289,11 @@ extern unsigned short __VERIFIER_nondet_ushort(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
 extern void __VERIFIER_assume(int expression ) ;
+void *ldv_successful_zalloc(size_t __size) {
+  void *p = calloc(1UL, __size);
+  __VERIFIER_assume(p != (void *)0);
+  return p;
+}
 void *ldv_malloc(size_t size ) 
 { 
   void *p ;
@@ -5675,9 +5680,9 @@ void ldv_initialize_ArcProto_1(void)
   void *tmp___0 ;
 
   {
-  tmp = ldv_zalloc(20UL);
+  tmp = ldv_successful_zalloc(20UL);
   capmode_proto_group0 = (struct archdr *)tmp;
-  tmp___0 = ldv_zalloc(3264UL);
+  tmp___0 = ldv_successful_zalloc(3264UL);
   capmode_proto_group1 = (struct net_device *)tmp___0;
   return;
 }
@@ -5706,7 +5711,7 @@ int main(void)
   {
   tmp = __VERIFIER_nondet_int();
   ldvarg7 = tmp;
-  tmp___0 = ldv_zalloc(232UL);
+  tmp___0 = ldv_successful_zalloc(232UL);
   ldvarg3 = (struct sk_buff *)tmp___0;
   tmp___1 = __VERIFIER_nondet_int();
   ldvarg0 = tmp___1;
@@ -6068,7 +6073,7 @@ struct sk_buff___0 *ldv_skb_alloc(void)
   void *tmp___7 ;
 
   {
-  tmp___7 = ldv_zalloc(sizeof(struct sk_buff___0 ));
+  tmp___7 = ldv_successful_zalloc(sizeof(struct sk_buff___0 ));
   skb = (struct sk_buff___0 *)tmp___7;
   if (! skb) {
     return ((void *)0);

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point_true-unreach-call.cil.out.c
@@ -5510,6 +5510,7 @@ static int build_header(struct sk_buff *skb , struct net_device *dev , unsigned 
   } else {
 
   }
+  __VERIFIER_assume(((void*)(dev->dev_addr)) != ((void*) 0));
   pkt->hard.source = *(dev->dev_addr);
   if ((dev->flags & 136U) != 0U) {
     pkt->hard.dest = 0U;
@@ -5564,6 +5565,7 @@ static int prepare_tx(struct net_device *dev , struct archdr *pkt , int length ,
     ofs = 256 - length;
     hard->offset[0] = (__u8 )ofs;
   }
+  __VERIFIER_assume(((void*)((*(lp->hw.copy_to_card)))) != ((void*)0));
   (*(lp->hw.copy_to_card))(dev, bufnum, 0, (void *)hard, 4);
   (*(lp->hw.copy_to_card))(dev, bufnum, ofs, (void *)(& pkt->soft.cap.proto), 1);
   (*(lp->hw.copy_to_card))(dev, bufnum, ofs + 1, (void *)(& pkt->soft.cap.mes), length + -1);

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point_true-unreach-call.cil.out.c
@@ -5525,6 +5525,7 @@ static int build_header(struct sk_buff *skb , struct net_device *dev , unsigned 
   soft = & pkt->soft.rfc1051;
   switch ((int )type) {
   case 2048: 
+  __VERIFIER_assume(((void*)(soft)) != ((void*) 0));
   soft->proto = 240U;
   goto ldv_42969;
   case 2054: 
@@ -5589,6 +5590,7 @@ static int prepare_tx(struct net_device *dev , struct archdr *pkt , int length ,
     ofs = 256 - length;
     hard->offset[0] = (__u8 )ofs;
   }
+  __VERIFIER_assume(((void*)(*(lp->hw.copy_to_card))) != ((void*)0));
   (*(lp->hw.copy_to_card))(dev, bufnum, 0, (void *)hard, 4);
   (*(lp->hw.copy_to_card))(dev, bufnum, ofs, (void *)(& pkt->soft), length);
   lp->lastload_dest = (int )hard->dest;

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point_true-unreach-call.cil.out.c
@@ -5264,6 +5264,11 @@ extern unsigned short __VERIFIER_nondet_ushort(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
 extern void __VERIFIER_assume(int expression ) ;
+void *ldv_successful_zalloc(size_t __size) {
+  void *p = calloc(1UL, __size);
+  __VERIFIER_assume(p != (void *)0);
+  return p;
+}
 void *ldv_malloc(size_t size ) 
 { 
   void *p ;
@@ -5599,9 +5604,9 @@ void ldv_initialize_ArcProto_1(void)
   void *tmp___0 ;
 
   {
-  tmp = ldv_zalloc(20UL);
+  tmp = ldv_successful_zalloc(20UL);
   rfc1051_proto_group0 = (struct archdr *)tmp;
-  tmp___0 = ldv_zalloc(3264UL);
+  tmp___0 = ldv_successful_zalloc(3264UL);
   rfc1051_proto_group1 = (struct net_device *)tmp___0;
   return;
 }
@@ -5630,7 +5635,7 @@ int main(void)
   ldvarg1 = tmp;
   tmp___0 = __VERIFIER_nondet_ushort();
   ldvarg4 = tmp___0;
-  tmp___1 = ldv_zalloc(232UL);
+  tmp___1 = ldv_successful_zalloc(232UL);
   ldvarg3 = (struct sk_buff *)tmp___1;
   tmp___2 = __VERIFIER_nondet_int();
   ldvarg0 = tmp___2;
@@ -5971,7 +5976,7 @@ struct sk_buff___0 *ldv_skb_alloc(void)
   void *tmp___7 ;
 
   {
-  tmp___7 = ldv_zalloc(sizeof(struct sk_buff___0 ));
+  tmp___7 = ldv_successful_zalloc(sizeof(struct sk_buff___0 ));
   skb = (struct sk_buff___0 *)tmp___7;
   if (! skb) {
     return ((void *)0);

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point_true-unreach-call.cil.out.c
@@ -6218,6 +6218,8 @@ __inline static struct net_device *netdev_notifier_info_to_dev(struct netdev_not
 
 
   {
+  __VERIFIER_assume(((void*)(&info)) != ((void*) 0));
+  __VERIFIER_assume(((void*)((struct net_device *)info->dev)) != ((void*) 0));
   return ((struct net_device *)info->dev);
 }
 }

--- a/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point_true-unreach-call.cil.out.c
@@ -6061,6 +6061,11 @@ extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
 extern void __VERIFIER_assume(int expression ) ;
+void *ldv_successful_zalloc(size_t __size) {
+  void *p = calloc(1UL, __size);
+  __VERIFIER_assume(p != (void *)0);
+  return p;
+}
 void *ldv_malloc(size_t size ) 
 { 
   void *p ;
@@ -7308,7 +7313,7 @@ void ldv_net_device_ops_3(void)
   void *tmp ;
 
   {
-  tmp = ldv_zalloc(3264UL);
+  tmp = ldv_successful_zalloc(3264UL);
   lapbeth_netdev_ops_group1 = (struct net_device *)tmp;
   return;
 }
@@ -7319,9 +7324,9 @@ void ldv_initialize_lapb_register_struct_4(void)
   void *tmp___0 ;
 
   {
-  tmp = ldv_zalloc(3264UL);
+  tmp = ldv_successful_zalloc(3264UL);
   lapbeth_callbacks_group1 = (struct net_device *)tmp;
-  tmp___0 = ldv_zalloc(232UL);
+  tmp___0 = ldv_successful_zalloc(232UL);
   lapbeth_callbacks_group0 = (struct sk_buff *)tmp___0;
   return;
 }
@@ -7370,23 +7375,23 @@ int main(void)
   ldvarg0 = tmp___1;
   tmp___2 = __VERIFIER_nondet_int();
   ldvarg2 = tmp___2;
-  tmp___3 = ldv_zalloc(24UL);
+  tmp___3 = ldv_successful_zalloc(24UL);
   ldvarg4 = (struct notifier_block *)tmp___3;
-  tmp___4 = ldv_zalloc(1UL);
+  tmp___4 = ldv_successful_zalloc(1UL);
   ldvarg5 = tmp___4;
   tmp___5 = __VERIFIER_nondet_ulong();
   ldvarg6 = tmp___5;
-  tmp___6 = ldv_zalloc(232UL);
+  tmp___6 = ldv_successful_zalloc(232UL);
   ldvarg8 = (struct sk_buff *)tmp___6;
-  tmp___7 = ldv_zalloc(1UL);
+  tmp___7 = ldv_successful_zalloc(1UL);
   ldvarg7 = tmp___7;
-  tmp___8 = ldv_zalloc(56UL);
+  tmp___8 = ldv_successful_zalloc(56UL);
   ldvarg11 = (struct packet_type *)tmp___8;
-  tmp___9 = ldv_zalloc(232UL);
+  tmp___9 = ldv_successful_zalloc(232UL);
   ldvarg10 = (struct sk_buff *)tmp___9;
-  tmp___10 = ldv_zalloc(3264UL);
+  tmp___10 = ldv_successful_zalloc(3264UL);
   ldvarg12 = (struct net_device *)tmp___10;
-  tmp___11 = ldv_zalloc(3264UL);
+  tmp___11 = ldv_successful_zalloc(3264UL);
   ldvarg9 = (struct net_device *)tmp___11;
   ldv_initialize();
   ldv_state_variable_4 = 0;
@@ -7958,7 +7963,7 @@ struct sk_buff___0 *ldv_skb_alloc(void)
   void *tmp___7 ;
 
   {
-  tmp___7 = ldv_zalloc(sizeof(struct sk_buff___0 ));
+  tmp___7 = ldv_successful_zalloc(sizeof(struct sk_buff___0 ));
   skb = (struct sk_buff___0 *)tmp___7;
   if (! skb) {
     return ((void *)0);

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_x25.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_x25.ko-entry_point_true-unreach-call.cil.out.c
@@ -5520,6 +5520,8 @@ static netdev_tx_t x25_xmit(struct sk_buff *skb , struct net_device *dev )
   int result ;
 
   {
+  __VERIFIER_assume(((void*)(skb)) != ((void*) 0));
+  __VERIFIER_assume(((void*)((skb->data))) != ((void*) 0));
   switch ((int )*(skb->data)) {
   case 0: 
   skb_pull(skb, 1U);

--- a/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_x25.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_x25.ko-entry_point_true-unreach-call.cil.out.c
@@ -5268,6 +5268,11 @@ extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
 extern void *__VERIFIER_nondet_pointer(void) ;
 extern void __VERIFIER_assume(int expression ) ;
+void *ldv_successful_zalloc(size_t __size) {
+  void *p = calloc(1UL, __size);
+  __VERIFIER_assume(p != (void *)0);
+  return p;
+}
 void *ldv_malloc(size_t size ) 
 { 
   void *p ;
@@ -5703,9 +5708,9 @@ void ldv_initialize_hdlc_proto_1(void)
   void *tmp___0 ;
 
   {
-  tmp = ldv_zalloc(3264UL);
+  tmp = ldv_successful_zalloc(3264UL);
   proto_group1 = (struct net_device *)tmp;
-  tmp___0 = ldv_zalloc(232UL);
+  tmp___0 = ldv_successful_zalloc(232UL);
   proto_group0 = (struct sk_buff *)tmp___0;
   return;
 }
@@ -5719,7 +5724,7 @@ int main(void)
   int tmp___2 ;
 
   {
-  tmp = ldv_zalloc(40UL);
+  tmp = ldv_successful_zalloc(40UL);
   ldvarg0 = (struct ifreq *)tmp;
   ldv_initialize();
   ldv_state_variable_1 = 0;
@@ -6092,7 +6097,7 @@ struct sk_buff___0 *ldv_skb_alloc(void)
   void *tmp___7 ;
 
   {
-  tmp___7 = ldv_zalloc(sizeof(struct sk_buff___0 ));
+  tmp___7 = ldv_successful_zalloc(sizeof(struct sk_buff___0 ));
   skb = (struct sk_buff___0 *)tmp___7;
   if (! skb) {
     return ((void *)0);


### PR DESCRIPTION
Four benchmarks from ``ldv-linux-3.16-rc1`` contained undefined behaviour (they dereference null pointers). This PR tries to fix all of these occurrences as far as Ultimate can detect them.  

Similar to sosy-lab/sv-benchmarks/pull/536 , we do this by replacing calls to ``ldv_zalloc`` with calls to a new function ``ldv_successful_zalloc`` that never returns a null pointer and additionally add ``__VERIFIER_assume`` statements in various places. 

The files in question are
  * ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--capmode.ko-entry_point_true-unreach-call.cil.out.c
  * ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--arcnet--rfc1051.ko-entry_point_true-unreach-call.cil.out.c
  * ldv-linux-3.16-rc1/205_9a_array_safes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--lapbether.ko-entry_point_true-unreach-call.cil.out.c
  * ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_x25.ko-entry_point_true-unreach-call.cil.out.c

@mutilin, can you have a look? 

Just for completion: we also believe that contrary to the label, the error location in ``205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--wan--hdlc_x25.ko-entry_point_true-unreach-call.cil.out.c`` is reachable. 

We will open a separate pull request when we have an executable witness (normal witness is not enough as CPAChecker disagrees and does not validate our witness)
