### PR TITLE
replace '__inline' by 'inline static' to eliminate unspecified behavior

### DIFF
--- a/c/product-lines/elevator_spec13_product23_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product23_true-unreach-call_false-termination.cil.c
@@ -70,7 +70,7 @@ int maximumWeight  =    100;
 int executiveFloor  =    4;
 int prevDir  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification13_spec__1(void) 
+inline static void __utac_acc__Specification13_spec__1(void) 
 { 
 
   {
@@ -81,7 +81,7 @@ __inline void __utac_acc__Specification13_spec__1(void)
 }
 }
 int existInLiftCallsInDirection(int d ) ;
-__inline void __utac_acc__Specification13_spec__2(void) 
+inline static void __utac_acc__Specification13_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec13_product30_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product30_true-unreach-call_false-termination.cil.c
@@ -831,7 +831,7 @@ int maximumWeight  =    100;
 int blocked  =    0;
 int prevDir  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification13_spec__1(void) 
+inline static void __utac_acc__Specification13_spec__1(void) 
 { 
 
   {
@@ -842,7 +842,7 @@ __inline void __utac_acc__Specification13_spec__1(void)
 }
 }
 int existInLiftCallsInDirection(int d ) ;
-__inline void __utac_acc__Specification13_spec__2(void) 
+inline static void __utac_acc__Specification13_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec13_product31_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product31_true-unreach-call_false-termination.cil.c
@@ -416,7 +416,7 @@ int maximumWeight  =    100;
 int executiveFloor  =    4;
 int prevDir  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification13_spec__1(void) 
+inline static void __utac_acc__Specification13_spec__1(void) 
 { 
 
   {
@@ -427,7 +427,7 @@ __inline void __utac_acc__Specification13_spec__1(void)
 }
 }
 int existInLiftCallsInDirection(int d ) ;
-__inline void __utac_acc__Specification13_spec__2(void) 
+inline static void __utac_acc__Specification13_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec13_product32_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_product32_true-unreach-call_false-termination.cil.c
@@ -150,7 +150,7 @@ void spec14(void)
 #pragma merger(0,"Specification13_spec.i","")
 int prevDir  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification13_spec__1(void) 
+inline static void __utac_acc__Specification13_spec__1(void) 
 { 
 
   {
@@ -161,7 +161,7 @@ __inline void __utac_acc__Specification13_spec__1(void)
 }
 }
 int existInLiftCallsInDirection(int d ) ;
-__inline void __utac_acc__Specification13_spec__2(void) 
+inline static void __utac_acc__Specification13_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec13_productSimulator_true-unreach-call_false-termination.cil.c
+++ b/c/product-lines/elevator_spec13_productSimulator_true-unreach-call_false-termination.cil.c
@@ -776,7 +776,7 @@ int executiveFloor  =    4;
 int blocked  =    0;
 int prevDir  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification13_spec__1(void) 
+inline static void __utac_acc__Specification13_spec__1(void) 
 { 
 
   {
@@ -787,7 +787,7 @@ __inline void __utac_acc__Specification13_spec__1(void)
 }
 }
 int existInLiftCallsInDirection(int d ) ;
-__inline void __utac_acc__Specification13_spec__2(void) 
+inline static void __utac_acc__Specification13_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_product03_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product03_true-unreach-call_true-termination.cil.c
@@ -928,7 +928,7 @@ int areDoorsOpen(void) ;
 int getCurrentFloorID(void) ;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product11_true-unreach-call_true-termination.cil.c
@@ -307,7 +307,7 @@ int areDoorsOpen(void) ;
 int getCurrentFloorID(void) ;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product20_false-unreach-call_true-termination.cil.c
@@ -510,7 +510,7 @@ int areDoorsOpen(void) ;
 int getCurrentFloorID(void) ;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product23_true-unreach-call_true-termination.cil.c
@@ -496,7 +496,7 @@ int areDoorsOpen(void) ;
 int getCurrentFloorID(void) ;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product24_false-unreach-call_true-termination.cil.c
@@ -419,7 +419,7 @@ int executiveFloor  =    4;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
 int blocked  =    0;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_product28_false-unreach-call_true-termination.cil.c
@@ -83,7 +83,7 @@ int executiveFloor  =    4;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
 int blocked  =    0;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec14_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec14_productSimulator_false-unreach-call_true-termination.cil.c
@@ -52,7 +52,7 @@ int executiveFloor  =    4;
 int isExecutiveFloorCalling(void) ;
 int isExecutiveFloor(int floorID ) ;
 int blocked  =    0;
-__inline void __utac_acc__Specification14_spec__1(void) 
+inline static void __utac_acc__Specification14_spec__1(void) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/elevator_spec1_product03_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product03_true-unreach-call_true-termination.cil.c
@@ -2072,7 +2072,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -2084,7 +2084,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -2209,7 +2209,7 @@ void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product09_true-unreach-call_true-termination.cil.c
@@ -829,7 +829,7 @@ void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -857,7 +857,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec1_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product11_true-unreach-call_true-termination.cil.c
@@ -182,7 +182,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -194,7 +194,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -222,7 +222,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -319,7 +319,7 @@ __inline void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product17_true-unreach-call_true-termination.cil.c
@@ -2597,7 +2597,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -2734,7 +2734,7 @@ void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product18_false-unreach-call_true-termination.cil.c
@@ -1094,7 +1094,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -1134,7 +1134,7 @@ void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -1231,7 +1231,7 @@ __inline void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product19_true-unreach-call_true-termination.cil.c
@@ -1293,7 +1293,7 @@ void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec1_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product23_true-unreach-call_true-termination.cil.c
@@ -512,7 +512,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -524,7 +524,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -552,7 +552,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -649,7 +649,7 @@ __inline void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product25_true-unreach-call_true-termination.cil.c
@@ -923,7 +923,7 @@ void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -951,7 +951,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec1_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product26_false-unreach-call_true-termination.cil.c
@@ -2202,7 +2202,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -2214,7 +2214,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -2339,7 +2339,7 @@ void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product27_true-unreach-call_true-termination.cil.c
@@ -1665,7 +1665,7 @@ void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec1_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product28_false-unreach-call_true-termination.cil.c
@@ -579,7 +579,7 @@ void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -607,7 +607,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec1_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product29_true-unreach-call_true-termination.cil.c
@@ -175,7 +175,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -187,7 +187,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -215,7 +215,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -312,7 +312,7 @@ __inline void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product31_true-unreach-call_true-termination.cil.c
@@ -2275,7 +2275,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -2287,7 +2287,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -2412,7 +2412,7 @@ void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_product32_false-unreach-call_true-termination.cil.c
@@ -2268,7 +2268,7 @@ void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {

--- a/c/product-lines/elevator_spec1_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec1_productSimulator_false-unreach-call_true-termination.cil.c
@@ -516,7 +516,7 @@ int landingButtons_spc1_1  ;
 int landingButtons_spc1_2  ;
 int landingButtons_spc1_3  ;
 int landingButtons_spc1_4  ;
-__inline void __utac_acc__Specification1_spec__1(void) 
+inline static void __utac_acc__Specification1_spec__1(void) 
 { 
 
   {
@@ -528,7 +528,7 @@ __inline void __utac_acc__Specification1_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__2(int floor ) 
+inline static void __utac_acc__Specification1_spec__2(int floor ) 
 { 
 
   {
@@ -556,7 +556,7 @@ __inline void __utac_acc__Specification1_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__3(void) 
+inline static void __utac_acc__Specification1_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -653,7 +653,7 @@ __inline void __utac_acc__Specification1_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification1_spec__4(void) 
+inline static void __utac_acc__Specification1_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product01_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product01_true-unreach-call_true-termination.cil.c
@@ -187,7 +187,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -199,7 +199,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -227,7 +227,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -324,7 +324,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product09_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product09_true-unreach-call_true-termination.cil.c
@@ -540,7 +540,7 @@ void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -568,7 +568,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec2_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product19_true-unreach-call_true-termination.cil.c
@@ -2274,7 +2274,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -2411,7 +2411,7 @@ void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product20_false-unreach-call_true-termination.cil.c
@@ -48,7 +48,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -60,7 +60,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -88,7 +88,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -185,7 +185,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product21_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product21_true-unreach-call_true-termination.cil.c
@@ -1714,7 +1714,7 @@ void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -1742,7 +1742,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec2_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product23_true-unreach-call_true-termination.cil.c
@@ -47,7 +47,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -59,7 +59,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -87,7 +87,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -184,7 +184,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product24_false-unreach-call_true-termination.cil.c
@@ -2368,7 +2368,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -2505,7 +2505,7 @@ void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product25_true-unreach-call_true-termination.cil.c
@@ -98,7 +98,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -110,7 +110,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -138,7 +138,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -235,7 +235,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product27_true-unreach-call_true-termination.cil.c
@@ -413,7 +413,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -425,7 +425,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -453,7 +453,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -550,7 +550,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product30_false-unreach-call_true-termination.cil.c
@@ -1357,7 +1357,7 @@ void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -1385,7 +1385,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec2_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product31_true-unreach-call_true-termination.cil.c
@@ -836,7 +836,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -848,7 +848,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -876,7 +876,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -973,7 +973,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_product32_false-unreach-call_true-termination.cil.c
@@ -48,7 +48,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -60,7 +60,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -88,7 +88,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -185,7 +185,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec2_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec2_productSimulator_false-unreach-call_true-termination.cil.c
@@ -949,7 +949,7 @@ int floorButtons_spc2_1  ;
 int floorButtons_spc2_2  ;
 int floorButtons_spc2_3  ;
 int floorButtons_spc2_4  ;
-__inline void __utac_acc__Specification2_spec__1(void) 
+inline static void __utac_acc__Specification2_spec__1(void) 
 { 
 
   {
@@ -961,7 +961,7 @@ __inline void __utac_acc__Specification2_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__2(int floor ) 
+inline static void __utac_acc__Specification2_spec__2(int floor ) 
 { 
 
   {
@@ -989,7 +989,7 @@ __inline void __utac_acc__Specification2_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__3(void) 
+inline static void __utac_acc__Specification2_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -1086,7 +1086,7 @@ __inline void __utac_acc__Specification2_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification2_spec__4(void) 
+inline static void __utac_acc__Specification2_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec3_product01_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product01_true-unreach-call_true-termination.cil.c
@@ -1280,7 +1280,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -1428,7 +1428,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product03_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product03_false-unreach-call_true-termination.cil.c
@@ -507,7 +507,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -655,7 +655,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product11_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product11_false-unreach-call_true-termination.cil.c
@@ -635,7 +635,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -783,7 +783,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product17_true-unreach-call_true-termination.cil.c
@@ -62,7 +62,7 @@ int weight  =    0;
 int maximumWeight  =    100;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -210,7 +210,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product22_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product22_true-unreach-call_true-termination.cil.c
@@ -555,7 +555,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -703,7 +703,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product23_false-unreach-call_true-termination.cil.c
@@ -63,7 +63,7 @@ int maximumWeight  =    100;
 int executiveFloor  =    4;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -211,7 +211,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product28_false-unreach-call_true-termination.cil.c
@@ -45,7 +45,7 @@ int executiveFloor  =    4;
 int blocked  =    0;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -193,7 +193,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product29_true-unreach-call_true-termination.cil.c
@@ -1351,7 +1351,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -1499,7 +1499,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product30_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product30_true-unreach-call_true-termination.cil.c
@@ -616,7 +616,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -764,7 +764,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product31_false-unreach-call_true-termination.cil.c
@@ -90,7 +90,7 @@ int maximumWeight  =    100;
 int executiveFloor  =    4;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -238,7 +238,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec3_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec3_product32_false-unreach-call_true-termination.cil.c
@@ -556,7 +556,7 @@ int buttonForFloorIsPressed(int floorID ) ;
 int getCurrentFloorID(void) ;
 int expectedDirection  =    0;
 int getCurrentHeading(void) ;
-__inline void __utac_acc__Specification3_spec__1(void) 
+inline static void __utac_acc__Specification3_spec__1(void) 
 { int currentFloorID___0 ;
   int tmp ;
   int tmp___0 ;
@@ -704,7 +704,7 @@ __inline void __utac_acc__Specification3_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification3_spec__2(void) 
+inline static void __utac_acc__Specification3_spec__2(void) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/elevator_spec9_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product11_true-unreach-call_true-termination.cil.c
@@ -880,7 +880,7 @@ void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -908,7 +908,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/elevator_spec9_product25_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product25_true-unreach-call_true-termination.cil.c
@@ -47,7 +47,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -59,7 +59,7 @@ __inline void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -87,7 +87,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -162,7 +162,7 @@ __inline void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product26_false-unreach-call_true-termination.cil.c
@@ -428,7 +428,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -440,7 +440,7 @@ __inline void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -468,7 +468,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -543,7 +543,7 @@ __inline void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product28_false-unreach-call_true-termination.cil.c
@@ -2843,7 +2843,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -2958,7 +2958,7 @@ void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product29_true-unreach-call_true-termination.cil.c
@@ -69,7 +69,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -81,7 +81,7 @@ __inline void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -109,7 +109,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -184,7 +184,7 @@ __inline void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product30_false-unreach-call_true-termination.cil.c
@@ -460,7 +460,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -472,7 +472,7 @@ __inline void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -500,7 +500,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -575,7 +575,7 @@ __inline void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_product31_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product31_true-unreach-call_true-termination.cil.c
@@ -956,7 +956,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -968,7 +968,7 @@ __inline void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -996,7 +996,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -1071,7 +1071,7 @@ __inline void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_product32_false-unreach-call_true-termination.cil.c
@@ -739,7 +739,7 @@ int floorButtons_spc9_1  ;
 int floorButtons_spc9_2  ;
 int floorButtons_spc9_3  ;
 int floorButtons_spc9_4  ;
-__inline void __utac_acc__Specification9_spec__1(void) 
+inline static void __utac_acc__Specification9_spec__1(void) 
 { 
 
   {
@@ -751,7 +751,7 @@ __inline void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -779,7 +779,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;
@@ -854,7 +854,7 @@ __inline void __utac_acc__Specification9_spec__3(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__4(void) 
+inline static void __utac_acc__Specification9_spec__4(void) 
 { 
 
   {

--- a/c/product-lines/elevator_spec9_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/elevator_spec9_productSimulator_false-unreach-call_true-termination.cil.c
@@ -1557,7 +1557,7 @@ void __utac_acc__Specification9_spec__1(void)
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__2(int floor ) 
+inline static void __utac_acc__Specification9_spec__2(int floor ) 
 { 
 
   {
@@ -1585,7 +1585,7 @@ __inline void __utac_acc__Specification9_spec__2(int floor )
   return;
 }
 }
-__inline void __utac_acc__Specification9_spec__3(void) 
+inline static void __utac_acc__Specification9_spec__3(void) 
 { int floor ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec0_product05_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product05_true-unreach-call_true-termination.cil.c
@@ -1170,7 +1170,7 @@ char const   *__utac__get_this_argtype(int i , struct JoinPoint *this )
 }
 #pragma merger(0,"DecryptForward_spec.i","")
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product10_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product10_true-unreach-call_true-termination.cil.c
@@ -114,7 +114,7 @@ void __automaton_fail(void)
 #pragma merger(0,"DecryptForward_spec.i","")
 int isReadable(int msg ) ;
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product11_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product11_true-unreach-call_true-termination.cil.c
@@ -865,7 +865,7 @@ void rjhEnableForwarding(void)
 }
 #pragma merger(0,"DecryptForward_spec.i","")
 void __automaton_fail(void) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product16_false-unreach-call_true-termination.cil.c
@@ -2566,7 +2566,7 @@ void setEmailIsSignatureVerified(int handle , int value )
 }
 }
 #pragma merger(0,"DecryptForward_spec.i","")
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product21_false-unreach-call_true-termination.cil.c
@@ -2201,7 +2201,7 @@ void test(void)
 #pragma merger(0,"DecryptForward_spec.i","")
 int isReadable(int msg ) ;
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product27_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product27_true-unreach-call_true-termination.cil.c
@@ -283,7 +283,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product33_false-unreach-call_true-termination.cil.c
@@ -1324,7 +1324,7 @@ void __automaton_fail(void)
 }
 #pragma merger(0,"DecryptForward_spec.i","")
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product34_false-unreach-call_true-termination.cil.c
@@ -2616,7 +2616,7 @@ void setEmailIsSignatureVerified(int handle , int value )
 }
 }
 #pragma merger(0,"DecryptForward_spec.i","")
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product35_false-unreach-call_true-termination.cil.c
@@ -589,7 +589,7 @@ char const   *__utac__get_this_argtype(int i , struct JoinPoint *this )
 }
 #pragma merger(0,"DecryptForward_spec.i","")
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec0_product38_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec0_product38_true-unreach-call_true-termination.cil.c
@@ -2444,7 +2444,7 @@ void setClientId(int handle , int value )
 }
 #pragma merger(0,"DecryptForward_spec.i","")
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptForward_spec__1(int msg ) 
+inline static void __utac_acc__DecryptForward_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product15_false-unreach-call_true-termination.cil.c
@@ -462,7 +462,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product20_false-unreach-call_true-termination.cil.c
@@ -1848,7 +1848,7 @@ char const   *__utac__get_this_argtype(int i , struct JoinPoint *this )
 }
 #pragma merger(0,"DecryptAutoResponder_spec.i","")
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product22_false-unreach-call_true-termination.cil.c
@@ -68,7 +68,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product23_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product23_true-unreach-call_true-termination.cil.c
@@ -578,7 +578,7 @@ int createEmail(int from , int to )
 #pragma merger(0,"DecryptAutoResponder_spec.i","")
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product24_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product24_true-unreach-call_true-termination.cil.c
@@ -2372,7 +2372,7 @@ int prompt(char *msg )
 }
 }
 #pragma merger(0,"DecryptAutoResponder_spec.i","")
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product26_false-unreach-call_true-termination.cil.c
@@ -605,7 +605,7 @@ int valid_product(void)
 #pragma merger(0,"DecryptAutoResponder_spec.i","")
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product35_false-unreach-call_true-termination.cil.c
@@ -1542,7 +1542,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product37_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product37_true-unreach-call_true-termination.cil.c
@@ -1781,7 +1781,7 @@ int valid_product(void)
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product39_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product39_true-unreach-call_true-termination.cil.c
@@ -405,7 +405,7 @@ int valid_product(void)
 #pragma merger(0,"DecryptAutoResponder_spec.i","")
 void __automaton_fail(void) ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec11_product40_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec11_product40_true-unreach-call_true-termination.cil.c
@@ -50,7 +50,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
+inline static void __utac_acc__DecryptAutoResponder_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product14_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product14_false-unreach-call_true-termination.cil.c
@@ -1131,7 +1131,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product15_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product15_false-unreach-call_true-termination.cil.c
@@ -2531,7 +2531,7 @@ char const   *__utac__get_this_argtype(int i , struct JoinPoint *this )
 }
 #pragma merger(0,"AddressBookEncrypt_spec.i","")
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product16_false-unreach-call_true-termination.cil.c
@@ -2197,7 +2197,7 @@ void test(void)
 #pragma merger(0,"AddressBookEncrypt_spec.i","")
 extern int puts(char const   *__s ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product21_false-unreach-call_true-termination.cil.c
@@ -51,7 +51,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product22_false-unreach-call_true-termination.cil.c
@@ -1218,7 +1218,7 @@ int valid_product(void)
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product28_true-unreach-call_true-termination.cil.c
@@ -1553,7 +1553,7 @@ void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product29_false-unreach-call_true-termination.cil.c
@@ -2602,7 +2602,7 @@ int valid_product(void)
 }
 #pragma merger(0,"AddressBookEncrypt_spec.i","")
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product30_false-unreach-call_true-termination.cil.c
@@ -199,7 +199,7 @@ int createEmail(int from , int to )
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product31_false-unreach-call_true-termination.cil.c
@@ -69,7 +69,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product34_false-unreach-call_true-termination.cil.c
@@ -51,7 +51,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_product35_false-unreach-call_true-termination.cil.c
@@ -749,7 +749,7 @@ char const   *__utac__get_this_argtype(int i , struct JoinPoint *this )
 void __automaton_fail(void) ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec1_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec1_productSimulator_false-unreach-call_true-termination.cil.c
@@ -50,7 +50,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int isEncrypted(int handle ) ;
 int mail_is_sensitive  =    -1;
-__inline void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
+inline static void __utac_acc__AddressBookEncrypt_spec__1(int client , int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec27_product19_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product19_false-unreach-call_true-termination.cil.c
@@ -418,7 +418,7 @@ int __GUIDSL_NON_TERMINAL_main  ;
 int getEmailFrom(int handle ) ;
 int isVerified(int handle ) ;
 int findPublicKey(int handle , int userid ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product23_false-unreach-call_true-termination.cil.c
@@ -372,7 +372,7 @@ void __automaton_fail(void) ;
 int getEmailFrom(int handle ) ;
 int isVerified(int handle ) ;
 int findPublicKey(int handle , int userid ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product24_false-unreach-call_true-termination.cil.c
@@ -562,7 +562,7 @@ void setEmailIsSignatureVerified(int handle , int value )
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int findPublicKey(int handle , int userid ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product27_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product27_false-unreach-call_true-termination.cil.c
@@ -2590,7 +2590,7 @@ void __automaton_fail(void)
 }
 }
 #pragma merger(0,"VerifyForward_spec.i","")
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product28_true-unreach-call_true-termination.cil.c
@@ -52,7 +52,7 @@ int __GUIDSL_NON_TERMINAL_main  ;
 int getEmailFrom(int handle ) ;
 int isVerified(int handle ) ;
 int findPublicKey(int handle , int userid ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product30_false-unreach-call_true-termination.cil.c
@@ -1412,7 +1412,7 @@ void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int getEmailFrom(int handle ) ;
 int isVerified(int handle ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product31_false-unreach-call_true-termination.cil.c
@@ -2087,7 +2087,7 @@ void test(void)
 }
 #pragma merger(0,"VerifyForward_spec.i","")
 void __automaton_fail(void) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product32_false-unreach-call_true-termination.cil.c
@@ -1131,7 +1131,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int getEmailFrom(int handle ) ;
 int isVerified(int handle ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_product33_false-unreach-call_true-termination.cil.c
@@ -1123,7 +1123,7 @@ void test(void)
 }
 #pragma merger(0,"VerifyForward_spec.i","")
 int findPublicKey(int handle , int userid ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec27_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec27_productSimulator_false-unreach-call_true-termination.cil.c
@@ -1909,7 +1909,7 @@ void test(void)
 extern int puts(char const   *__s ) ;
 int getEmailFrom(int handle ) ;
 int isVerified(int handle ) ;
-__inline void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__VerifyForward_spec__1(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec3_product13_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product13_false-unreach-call_true-termination.cil.c
@@ -94,7 +94,7 @@ int getEmailSignKey(int handle ) ;
 int findPublicKey(int handle , int userid ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_signed  =    -1;
-__inline void __utac_acc__SignVerify_spec__1(int msg ) 
+inline static void __utac_acc__SignVerify_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -107,7 +107,7 @@ __inline void __utac_acc__SignVerify_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__SignVerify_spec__2(int client , int msg ) 
+inline static void __utac_acc__SignVerify_spec__2(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec3_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product23_false-unreach-call_true-termination.cil.c
@@ -1528,7 +1528,7 @@ int createEmail(int from , int to )
 int findPublicKey(int handle , int userid ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_signed  =    -1;
-__inline void __utac_acc__SignVerify_spec__1(int msg ) 
+inline static void __utac_acc__SignVerify_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1541,7 +1541,7 @@ __inline void __utac_acc__SignVerify_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__SignVerify_spec__2(int client , int msg ) 
+inline static void __utac_acc__SignVerify_spec__2(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec3_product27_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product27_false-unreach-call_true-termination.cil.c
@@ -543,7 +543,7 @@ extern int puts(char const   *__s ) ;
 int findPublicKey(int handle , int userid ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_signed  =    -1;
-__inline void __utac_acc__SignVerify_spec__1(int msg ) 
+inline static void __utac_acc__SignVerify_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -556,7 +556,7 @@ __inline void __utac_acc__SignVerify_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__SignVerify_spec__2(int client , int msg ) 
+inline static void __utac_acc__SignVerify_spec__2(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec3_product28_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product28_false-unreach-call_true-termination.cil.c
@@ -201,7 +201,7 @@ extern int puts(char const   *__s ) ;
 int findPublicKey(int handle , int userid ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_signed  =    -1;
-__inline void __utac_acc__SignVerify_spec__1(int msg ) 
+inline static void __utac_acc__SignVerify_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -214,7 +214,7 @@ __inline void __utac_acc__SignVerify_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__SignVerify_spec__2(int client , int msg ) 
+inline static void __utac_acc__SignVerify_spec__2(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec3_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec3_product34_false-unreach-call_true-termination.cil.c
@@ -56,7 +56,7 @@ int getEmailSignKey(int handle ) ;
 int findPublicKey(int handle , int userid ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_signed  =    -1;
-__inline void __utac_acc__SignVerify_spec__1(int msg ) 
+inline static void __utac_acc__SignVerify_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -69,7 +69,7 @@ __inline void __utac_acc__SignVerify_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__SignVerify_spec__2(int client , int msg ) 
+inline static void __utac_acc__SignVerify_spec__2(int client , int msg ) 
 { int pubkey ;
   int tmp ;
   int tmp___0 ;

--- a/c/product-lines/email_spec4_product13_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product13_true-unreach-call_true-termination.cil.c
@@ -51,7 +51,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isSigned(int handle ) ;
 int getClientPrivateKey(int handle ) ;
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec4_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product17_true-unreach-call_true-termination.cil.c
@@ -51,7 +51,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isSigned(int handle ) ;
 int getClientPrivateKey(int handle ) ;
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec4_product18_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product18_false-unreach-call_true-termination.cil.c
@@ -2552,7 +2552,7 @@ int valid_product(void)
 }
 #pragma merger(0,"SignForward_spec.i","")
 void __automaton_fail(void) ;
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec4_product19_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product19_false-unreach-call_true-termination.cil.c
@@ -59,7 +59,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isSigned(int handle ) ;
 int getClientPrivateKey(int handle ) ;
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec4_product23_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product23_false-unreach-call_true-termination.cil.c
@@ -1496,7 +1496,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isSigned(int handle ) ;
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec4_product24_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product24_false-unreach-call_true-termination.cil.c
@@ -2491,7 +2491,7 @@ void rjhEnableForwarding(void)
 }
 }
 #pragma merger(0,"SignForward_spec.i","")
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec4_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec4_product29_true-unreach-call_true-termination.cil.c
@@ -2619,7 +2619,7 @@ void __automaton_fail(void)
 }
 }
 #pragma merger(0,"SignForward_spec.i","")
-__inline void __utac_acc__SignForward_spec__1(int client , int msg ) 
+inline static void __utac_acc__SignForward_spec__1(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
 

--- a/c/product-lines/email_spec6_product14_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product14_false-unreach-call_true-termination.cil.c
@@ -362,7 +362,7 @@ int getEmailEncryptionKey(int handle ) ;
 int getClientPrivateKey(int handle ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -375,7 +375,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product16_false-unreach-call_true-termination.cil.c
@@ -2585,7 +2585,7 @@ int prompt(char *msg )
 #pragma merger(0,"EncryptDecrypt_spec.i","")
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -2598,7 +2598,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product20_false-unreach-call_true-termination.cil.c
@@ -2177,7 +2177,7 @@ int isKeyPairValid(int publicKey , int privateKey ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -2190,7 +2190,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product21_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product21_false-unreach-call_true-termination.cil.c
@@ -72,7 +72,7 @@ int getClientPrivateKey(int handle ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 extern int puts(char const   *__s ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -85,7 +85,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product22_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product22_false-unreach-call_true-termination.cil.c
@@ -886,7 +886,7 @@ int getClientPrivateKey(int handle ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 extern int puts(char const   *__s ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -899,7 +899,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product26_false-unreach-call_true-termination.cil.c
@@ -2264,7 +2264,7 @@ void setEmailIsSignatureVerified(int handle , int value )
 void __automaton_fail(void) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -2277,7 +2277,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product29_false-unreach-call_true-termination.cil.c
@@ -728,7 +728,7 @@ int getEmailEncryptionKey(int handle ) ;
 int getClientPrivateKey(int handle ) ;
 int isKeyPairValid(int publicKey , int privateKey ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -741,7 +741,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product30_false-unreach-call_true-termination.cil.c
@@ -1807,7 +1807,7 @@ int isKeyPairValid(int publicKey , int privateKey ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1820,7 +1820,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_product34_false-unreach-call_true-termination.cil.c
@@ -93,7 +93,7 @@ int isKeyPairValid(int publicKey , int privateKey ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -106,7 +106,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec6_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec6_productSimulator_false-unreach-call_true-termination.cil.c
@@ -54,7 +54,7 @@ int isKeyPairValid(int publicKey , int privateKey ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int sent_encrypted  =    -1;
-__inline void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -67,7 +67,7 @@ __inline void __utac_acc__EncryptDecrypt_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
+inline static void __utac_acc__EncryptDecrypt_spec__2(int client , int msg ) 
 { int tmp ;
   int tmp___0 ;
   int tmp___1 ;

--- a/c/product-lines/email_spec7_product13_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product13_true-unreach-call_true-termination.cil.c
@@ -49,7 +49,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product17_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product17_true-unreach-call_true-termination.cil.c
@@ -49,7 +49,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product19_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product19_true-unreach-call_true-termination.cil.c
@@ -49,7 +49,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product29_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product29_false-unreach-call_true-termination.cil.c
@@ -948,7 +948,7 @@ void test(void)
 }
 #pragma merger(0,"EncryptVerify_spec.i","")
 int isReadable(int msg ) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product30_false-unreach-call_true-termination.cil.c
@@ -1052,7 +1052,7 @@ int __SELECTED_FEATURE_Decrypt  ;
 int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product31_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product31_false-unreach-call_true-termination.cil.c
@@ -353,7 +353,7 @@ void rjhEnableForwarding(void)
 #pragma merger(0,"EncryptVerify_spec.i","")
 void __automaton_fail(void) ;
 int isReadable(int msg ) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product33_false-unreach-call_true-termination.cil.c
@@ -563,7 +563,7 @@ char const   *__utac__get_this_argtype(int i , struct JoinPoint *this )
 }
 #pragma merger(0,"EncryptVerify_spec.i","")
 void __automaton_fail(void) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec7_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec7_product34_false-unreach-call_true-termination.cil.c
@@ -517,7 +517,7 @@ int createEmail(int from , int to )
 }
 #pragma merger(0,"EncryptVerify_spec.i","")
 void __automaton_fail(void) ;
-__inline void __utac_acc__EncryptVerify_spec__1(int msg ) 
+inline static void __utac_acc__EncryptVerify_spec__1(int msg ) 
 { int tmp ;
 
   {

--- a/c/product-lines/email_spec8_product12_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product12_true-unreach-call_true-termination.cil.c
@@ -1375,7 +1375,7 @@ void setEmailIsSignatureVerified(int handle , int value )
 }
 #pragma merger(0,"EncryptAutoResponder_spec.i","")
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1388,7 +1388,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product16_false-unreach-call_true-termination.cil.c
@@ -2316,7 +2316,7 @@ void __automaton_fail(void)
 }
 #pragma merger(0,"EncryptAutoResponder_spec.i","")
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -2329,7 +2329,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product20_false-unreach-call_true-termination.cil.c
@@ -1934,7 +1934,7 @@ int __GUIDSL_ROOT_PRODUCTION  ;
 int __GUIDSL_NON_TERMINAL_main  ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1947,7 +1947,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product26_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product26_false-unreach-call_true-termination.cil.c
@@ -383,7 +383,7 @@ void rjhEnableForwarding(void)
 void __automaton_fail(void) ;
 int isEncrypted(int handle ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -396,7 +396,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product28_true-unreach-call_true-termination.cil.c
@@ -475,7 +475,7 @@ int prompt(char *msg )
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -488,7 +488,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product29_true-unreach-call_true-termination.cil.c
@@ -639,7 +639,7 @@ int createEmail(int from , int to )
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -652,7 +652,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product30_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product30_false-unreach-call_true-termination.cil.c
@@ -354,7 +354,7 @@ void rjhSetAutoRespond(void)
 void __automaton_fail(void) ;
 int isEncrypted(int handle ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -367,7 +367,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product32_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product32_false-unreach-call_true-termination.cil.c
@@ -1978,7 +1978,7 @@ void bobSetAddressBook(void)
 }
 #pragma merger(0,"EncryptAutoResponder_spec.i","")
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1991,7 +1991,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product33_false-unreach-call_true-termination.cil.c
@@ -1670,7 +1670,7 @@ int createEmail(int from , int to )
 #pragma merger(0,"EncryptAutoResponder_spec.i","")
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1683,7 +1683,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_product34_false-unreach-call_true-termination.cil.c
@@ -1195,7 +1195,7 @@ void __automaton_fail(void)
 int isEncrypted(int handle ) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1208,7 +1208,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec8_productSimulator_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec8_productSimulator_false-unreach-call_true-termination.cil.c
@@ -2312,7 +2312,7 @@ void setEmailIsSignatureVerified(int handle , int value )
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -2325,7 +2325,7 @@ __inline void __utac_acc__EncryptAutoResponder_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
+inline static void __utac_acc__EncryptAutoResponder_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product12_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product12_true-unreach-call_true-termination.cil.c
@@ -52,7 +52,7 @@ int isEncrypted(int handle ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -65,7 +65,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product14_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product14_true-unreach-call_true-termination.cil.c
@@ -359,7 +359,7 @@ void bobSetAddressBook(void)
 void __automaton_fail(void) ;
 int isEncrypted(int handle ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -372,7 +372,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product16_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product16_false-unreach-call_true-termination.cil.c
@@ -52,7 +52,7 @@ int isEncrypted(int handle ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -65,7 +65,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product20_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product20_false-unreach-call_true-termination.cil.c
@@ -406,7 +406,7 @@ void bobSetAddressBook(void)
 void __automaton_fail(void) ;
 int isEncrypted(int handle ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -419,7 +419,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product28_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product28_true-unreach-call_true-termination.cil.c
@@ -52,7 +52,7 @@ int isEncrypted(int handle ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -65,7 +65,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product29_true-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product29_true-unreach-call_true-termination.cil.c
@@ -237,7 +237,7 @@ int createEmail(int from , int to )
 void __automaton_fail(void) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -250,7 +250,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product33_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product33_false-unreach-call_true-termination.cil.c
@@ -732,7 +732,7 @@ void test(void)
 #pragma merger(0,"EncryptForward_spec.i","")
 void __automaton_fail(void) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -745,7 +745,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product34_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product34_false-unreach-call_true-termination.cil.c
@@ -281,7 +281,7 @@ int isEncrypted(int handle ) ;
 extern int printf(char const   * __restrict  __format  , ...) ;
 extern int puts(char const   *__s ) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -294,7 +294,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 

--- a/c/product-lines/email_spec9_product35_false-unreach-call_true-termination.cil.c
+++ b/c/product-lines/email_spec9_product35_false-unreach-call_true-termination.cil.c
@@ -1633,7 +1633,7 @@ int createEmail(int from , int to )
 #pragma merger(0,"EncryptForward_spec.i","")
 void __automaton_fail(void) ;
 int in_encrypted  =    0;
-__inline void __utac_acc__EncryptForward_spec__1(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__1(int msg ) 
 { char const   * __restrict  __cil_tmp2 ;
 
   {
@@ -1646,7 +1646,7 @@ __inline void __utac_acc__EncryptForward_spec__1(int msg )
   return;
 }
 }
-__inline void __utac_acc__EncryptForward_spec__2(int msg ) 
+inline static void __utac_acc__EncryptForward_spec__2(int msg ) 
 { int tmp ;
   char const   * __restrict  __cil_tmp3 ;
 


### PR DESCRIPTION
The keyword "__inline" is implementation specific and should be replaced by "inline".

Moreover, C99 says:

"An inline definition does not provide an external definition for the function, and does not forbid an external definition in another translation unit. An inline definition provides an alternative to an external definition, which a translator may use to implement any call to the function in the same translation unit. It is unspecified whether a call to the function uses the inline definition or the external definition."

(For example, I get errors when compiling these programs with clang: without optimizations, clang uses the external version of the function and therefore produces undefined references. More info: http://clang.llvm.org/compatibility.html#inline)

By adding "static" we make sure that the function definition is specified by the given inline definition.