### PR TITLE
Fix uninitialized variables

### DIFF
--- a/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.02_false-no-overflow.c
+++ b/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.02_false-no-overflow.c
@@ -22,6 +22,7 @@ extern int __VERIFIER_nondet_int(void);
 int main() {
     int x, oldx;
     x = __VERIFIER_nondet_int();
+    oldx = __VERIFIER_nondet_int();
     while (x > 0 && x < 100 && x >= 2*oldx + 10) {
         oldx = x;
         x = __VERIFIER_nondet_int();

--- a/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.03_false-no-overflow.c
+++ b/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.03_false-no-overflow.c
@@ -22,6 +22,7 @@ extern int __VERIFIER_nondet_int(void);
 int main() {
     int x, oldx;
     x = __VERIFIER_nondet_int();
+    oldx = __VERIFIER_nondet_int();
     while (x > 1 && -2*x == oldx) {
         oldx = x;
         x = __VERIFIER_nondet_int();

--- a/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.04_false-no-overflow.c
+++ b/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.04_false-no-overflow.c
@@ -22,6 +22,7 @@ extern int __VERIFIER_nondet_int(void);
 int main() {
     int x, oldx;
     x = __VERIFIER_nondet_int();
+    oldx = __VERIFIER_nondet_int();
     while (x > 1 && 2*x <= oldx) {
         oldx = x;
         x = __VERIFIER_nondet_int();

--- a/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.05_false-no-overflow.c
+++ b/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex1.05_false-no-overflow.c
@@ -22,6 +22,7 @@ extern int __VERIFIER_nondet_int(void);
 int main() {
     int x, oldx;
     x = __VERIFIER_nondet_int();
+    oldx = __VERIFIER_nondet_int();
     while (x > 0 && 2*x <= oldx) {
         oldx = x;
         x = __VERIFIER_nondet_int();

--- a/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex2.22_false-no-overflow.c
+++ b/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex2.22_false-no-overflow.c
@@ -23,6 +23,7 @@ int main() {
     int x, y, oldy;
     x = __VERIFIER_nondet_int();
     y = __VERIFIER_nondet_int();
+    oldy = __VERIFIER_nondet_int();
     while (x > 0 && y <= -oldy) {
         x = y;
         oldy = y;

--- a/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex3.09_false-no-overflow.c
+++ b/c/termination-crafted-lit/ChenFlurMukhopadhyay-SAS2012-Ex3.09_false-no-overflow.c
@@ -24,6 +24,7 @@ int main() {
     x = __VERIFIER_nondet_int();
     y = __VERIFIER_nondet_int();
     z = __VERIFIER_nondet_int();
+    oldx = __VERIFIER_nondet_int();
     while (x > 0 && x < y && x > 2*oldx) {
         oldx = x;
         x = __VERIFIER_nondet_int();


### PR DESCRIPTION
Some variables in benchmarks from termination-crafted-lit were
uninitialized, initialize them with __VERIFIER_nondet_int().