### PR TITLE
Fixed signatures of VERIFIER functions

### DIFF
--- a/c/ldv-sets/test_add_false-unreach-call_true-termination.i
+++ b/c/ldv-sets/test_add_false-unreach-call_true-termination.i
@@ -548,8 +548,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_add_true-unreach-call_true-termination.i
+++ b/c/ldv-sets/test_add_true-unreach-call_true-termination.i
@@ -548,8 +548,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_mutex_double_lock_false-unreach-call_true-termination.i
+++ b/c/ldv-sets/test_mutex_double_lock_false-unreach-call_true-termination.i
@@ -548,8 +548,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_mutex_double_unlock_false-unreach-call.i
+++ b/c/ldv-sets/test_mutex_double_unlock_false-unreach-call.i
@@ -548,8 +548,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_mutex_true-unreach-call.i
+++ b/c/ldv-sets/test_mutex_true-unreach-call.i
@@ -548,8 +548,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_mutex_unbounded_false-unreach-call.i
+++ b/c/ldv-sets/test_mutex_unbounded_false-unreach-call.i
@@ -552,8 +552,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_mutex_unbounded_true-unreach-call.i
+++ b/c/ldv-sets/test_mutex_unbounded_true-unreach-call.i
@@ -552,8 +552,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {

--- a/c/ldv-sets/test_mutex_unlock_at_exit_false-unreach-call.i
+++ b/c/ldv-sets/test_mutex_unlock_at_exit_false-unreach-call.i
@@ -548,8 +548,8 @@ extern int getsubopt (char **__restrict __optionp,
 extern int getloadavg (double __loadavg[], int __nelem)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
 
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 void *ldv_malloc(size_t size) {


### PR DESCRIPTION
Several signatures of VERIFIER functions (namely `__VERIFIER_error` and `__VERIFIER_assume`) were wrong, since they were returning `int` instead of being `void`.