### PR TITLE
Fixed signature of __VERIFIER_nondet_int

### DIFF
--- a/c/array-tiling/poly2_true-unreach-call.c
+++ b/c/array-tiling/poly2_true-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-extern short __VERIFIER_nondet_int(void);
+extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 

--- a/c/array-tiling/poly2_true-unreach-call.i
+++ b/c/array-tiling/poly2_true-unreach-call.i
@@ -3,7 +3,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 extern void __VERIFIER_assume(int);
 void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
-extern short __VERIFIER_nondet_int(void);
+extern int __VERIFIER_nondet_int(void);
 
 int SIZE;
 


### PR DESCRIPTION
It returns int and not short, and so I changed it to int.