### PR TITLE
Fix wrong definitions

### DIFF
--- a/c/ldv-sets/model/ldv.h
+++ b/c/ldv-sets/model/ldv.h
@@ -1,5 +1,5 @@
-int __VERIFIER_error(void);
-int __VERIFIER_assume(int);
+void __VERIFIER_error(void);
+void __VERIFIER_assume(int);
 int __VERIFIER_nondet_int(void);
 void *__VERIFIER_nondet_pointer(void);
 


### PR DESCRIPTION
Same as PR #569, but fixes the header instead of the preprocessed files.