### PR TITLE
New MemSafety benchmarks

### DIFF
--- a/c/MemSafety-Other.set
+++ b/c/MemSafety-Other.set
@@ -2,4 +2,6 @@ loop-acceleration/*_false-valid-deref*.i
 ntdrivers/*_false-valid-deref*.i.cil.c
 ntdrivers-simplified/*_true-valid-memsafety*.cil.c
 locks/*_true-valid-memsafety*.c
-
+memsafety-ext3/*_false-valid-deref*.c
+memsafety-ext3/*_false-valid-free*.c
+memsafety-ext3/*_true-valid-memsafety*.c

--- a/c/memsafety-ext3/LICENSE.txt
+++ b/c/memsafety-ext3/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.GPLv3.txt

--- a/c/memsafety-ext3/Makefile
+++ b/c/memsafety-ext3/Makefile
@@ -1,0 +1,6 @@
+GCC_WARNINGS := -Wno-error=return-local-addr
+CLANG_WARNINGS := -Wno-error=return-stack-address
+
+LEVEL := ../
+
+include $(LEVEL)/Makefile.config

--- a/c/memsafety-ext3/README.txt
+++ b/c/memsafety-ext3/README.txt
@@ -1,0 +1,2 @@
+Additional benchmarks for MemSafety category contributed by the team of
+Symbiotic verification tool.

--- a/c/memsafety-ext3/derefAfterFree1_false-valid-deref.c
+++ b/c/memsafety-ext3/derefAfterFree1_false-valid-deref.c
@@ -1,0 +1,17 @@
+typedef unsigned int size_t;
+extern  void free(void*);
+extern void* malloc(size_t);
+
+void freePointer(int* p) {
+    free(p);
+}
+
+int main(void) {
+    int* p = malloc(10 * sizeof(int));
+
+    freePointer(p);
+
+    p[0] = 1;
+
+    return 0;
+}

--- a/c/memsafety-ext3/derefAfterFree2_false-valid-deref.c
+++ b/c/memsafety-ext3/derefAfterFree2_false-valid-deref.c
@@ -1,0 +1,16 @@
+typedef unsigned int size_t;
+extern  void free(void*);
+extern void* malloc(size_t);
+
+int main(void) {
+    int* p = malloc(10 * sizeof(int));
+
+    for(int i = 0; i < 10; i++) {
+        p[i] = 1;
+        if(i == 5) {
+            free(p);
+        }
+    }
+
+    return 0;
+}

--- a/c/memsafety-ext3/derefInLoop1_false-valid-deref.c
+++ b/c/memsafety-ext3/derefInLoop1_false-valid-deref.c
@@ -1,0 +1,12 @@
+int main(void) {
+    int* p;
+    for(int i = 0; i < 2; i++) {
+        int a[10];
+        if(i == 0) {
+            p = a;
+        } else {
+            p[0] = 1;
+        }
+    }
+    return 0;
+}

--- a/c/memsafety-ext3/freeAlloca_false-valid-free.c
+++ b/c/memsafety-ext3/freeAlloca_false-valid-free.c
@@ -1,0 +1,16 @@
+extern void *alloca(unsigned long size);
+extern void free(void*);
+extern char __VERIFIER_nondet_char(void);
+
+int main(void){
+    char *p = alloca(10 * sizeof(char));
+
+    for (int i = 0; i < 10; i++) {
+        p[i] = __VERIFIER_nondet_char();
+    }
+
+    if (p[2] == 'a')
+        free(p);
+
+    return 0;
+}

--- a/c/memsafety-ext3/getNumbers1_false-valid-deref.c
+++ b/c/memsafety-ext3/getNumbers1_false-valid-deref.c
@@ -1,0 +1,26 @@
+typedef long unsigned int size_t;
+extern int printf (const char* format, ...);
+extern void* alloca(size_t size);
+
+// function returns array of numbers
+int * getNumbers(void) {
+
+   int *array = alloca(10 * sizeof(int)); // array should be static
+
+   for (int i = 0; i < 10; ++i) {
+      array[i] = i;
+   }
+
+   return array;
+}
+
+int main(void) {
+
+   int *numbers = getNumbers();
+
+   for (int i = 0; i < 10; i++ ) {
+      printf( "%d\n", *(numbers + i));
+   }
+
+   return 0;
+}

--- a/c/memsafety-ext3/getNumbers1_true-valid-memsafety.c
+++ b/c/memsafety-ext3/getNumbers1_true-valid-memsafety.c
@@ -1,0 +1,24 @@
+extern int printf (const char* format, ...);
+
+// function returns array of numbers
+int* getNumbers(void) {
+
+    static int array[10]; // array is static, which is correct
+
+    for (int i = 0; i < 10; ++i) {
+       array[i] = i;
+    }
+
+    return array;
+}
+
+int main(void) {
+
+    int *numbers = getNumbers();
+
+    for (int i = 0; i < 10; i++ ) {
+       printf( "%d\n", *(numbers + i));
+    }
+
+    return 0;
+}

--- a/c/memsafety-ext3/getNumbers2_false-valid-deref.c
+++ b/c/memsafety-ext3/getNumbers2_false-valid-deref.c
@@ -1,0 +1,29 @@
+int array[10];
+
+// function returns array of numbers
+int* getNumbers(void) {
+    for (int i = 0; i < 10; ++i) {
+       array[i] = i;
+    }
+
+    return array;
+}
+
+int* getNumbers2(void) {
+    int* numbers = getNumbers();
+    // numbers2 is local
+    int numbers2[10];
+
+    for (int i = 0; i < 10; ++i) {
+        numbers2[i] = numbers[i];
+    }
+
+    return numbers2;
+}
+
+int main(void) {
+   int *numbers = getNumbers2();
+   numbers[0] = 100;
+
+   return 0;
+}

--- a/c/memsafety-ext3/getNumbers3_true-valid-memsafety.c
+++ b/c/memsafety-ext3/getNumbers3_true-valid-memsafety.c
@@ -1,0 +1,16 @@
+int array[10];
+
+// function returns array of numbers
+int* getNumbers() {
+    for (int i = 0; i < 10; ++i) {
+        array[i] = i;
+    }
+
+    return array;
+}
+
+int main (void) {
+    int *numbers = getNumbers();
+    numbers[0] = 100;
+    return 0;
+}

--- a/c/memsafety-ext3/getNumbers4_false-valid-deref.c
+++ b/c/memsafety-ext3/getNumbers4_false-valid-deref.c
@@ -1,0 +1,52 @@
+extern int printf (const char* format, ...);
+
+// function returns array of numbers
+int* getNumbers() {
+
+    static int array[10];
+
+    for (int i = 0; i < 10; ++i) {
+       array[i] = i;
+    }
+
+    return array;
+}
+
+int* getNumbers2() {
+    int* numbers = getNumbers();
+    static int numbers2[10];
+    for (int i = 0; i < 10; ++i) {
+        numbers2[i] = numbers[i];
+    }
+    return numbers2;
+}
+
+int* getNumbers3() {
+    int* numbers = getNumbers2();
+    int numbers3[10];
+    for (int i = 0; i < 10; ++i) {
+        numbers3[i] = numbers[i];
+    }
+
+    return numbers3;
+}
+
+int* getNumbers4() {
+    int* numbers = getNumbers3();
+    static int numbers4[10];
+    for (int i = 0; i < 10; ++i) {
+        numbers4[i] = numbers[i];
+    }
+    return numbers4;
+}
+
+int main (void) {
+
+    int *numbers = getNumbers4();
+
+    for (int i = 0; i < 10; i++ ) {
+       printf( "%d\n", *(numbers + i));
+    }
+
+    return 0;
+}

--- a/c/memsafety-ext3/getNumbers4_true-valid-memsafety.c
+++ b/c/memsafety-ext3/getNumbers4_true-valid-memsafety.c
@@ -1,0 +1,51 @@
+extern int printf (const char* format, ...);
+
+// function returns array of numbers
+int* getNumbers() {
+
+    static int array[10]; // array is static, which is correct
+
+    for (int i = 0; i < 10; ++i) {
+       array[i] = i;
+    }
+
+    return array;
+}
+
+int* getNumbers2() {
+    int* numbers = getNumbers();
+    static int numbers2[10];
+    for (int i = 0; i < 10; ++i) {
+        numbers2[i] = numbers[i];
+    }
+    return numbers2;
+}
+
+int* getNumbers3() {
+    int* numbers = getNumbers2();
+    static int numbers3[10];
+    for (int i = 0; i < 10; ++i) {
+        numbers3[i] = numbers[i];
+    }
+
+    return numbers3;
+}
+
+int* getNumbers4() {
+    int* numbers = getNumbers3();
+    static int numbers4[10];
+    for (int i = 0; i < 10; ++i) {
+        numbers4[i] = numbers[i];
+    }
+    return numbers4;
+}
+
+int main (void) {
+
+    int *numbers = getNumbers4();
+    for (int i = 0; i < 10; i++ ) {
+       printf( "%d\n", *(numbers + i));
+    }
+
+    return 0;
+}

--- a/c/memsafety-ext3/naturalNumbers1_false-valid-deref.c
+++ b/c/memsafety-ext3/naturalNumbers1_false-valid-deref.c
@@ -1,0 +1,17 @@
+int areNatural(int *numbers){
+    int i = 0;
+    while(i < 10) {
+        if(numbers[i] <= 0){
+            return 0;
+        }
+        i++;
+    }
+    return 1;
+}
+
+int main(void) {
+    char numbers[] = {0,1,2,3,4,5,6,7,8,9};
+    // numbers is array of chars, but should be integers
+    int result = areNatural((int*) numbers);
+    return 0;
+}

--- a/c/memsafety-ext3/realloc1_false-valid-deref.c
+++ b/c/memsafety-ext3/realloc1_false-valid-deref.c
@@ -1,0 +1,20 @@
+typedef unsigned int size_t;
+extern  void free(void*);
+extern void* malloc(size_t);
+extern void* realloc( void *ptr, size_t new_size );
+extern char __VERIFIER_nondet_char(void);
+
+int main(void) {
+    char* p = malloc(10 * sizeof(int));
+
+    for (int i = 0; i < 10; i++) {
+        p[i] = __VERIFIER_nondet_char();
+    }
+
+    free(p);
+
+    if (p[2] == 'a')
+        p = realloc(p, 20 * sizeof(int));
+
+    return 0;
+}

--- a/c/memsafety-ext3/scopes1_false-valid-deref.c
+++ b/c/memsafety-ext3/scopes1_false-valid-deref.c
@@ -1,0 +1,20 @@
+extern int printf ( const char * format, ... );
+
+int main(void) {
+    int *myPointerA = ((void*) 0);
+    int *myPointerB = ((void*) 0);
+
+    {
+        int myNumberA = 7;
+        myPointerA = &myNumberA;
+        // scope of myNumber ends here
+    }
+
+    int myNumberB = 3;
+    myPointerB = &myNumberB;
+
+    int sumOfMyNumbers = *myPointerA + *myPointerB; // myPointerA is out of scope
+    printf("%d", sumOfMyNumbers);
+
+    return 0;
+}

--- a/c/memsafety-ext3/scopes2_false-valid-deref.c
+++ b/c/memsafety-ext3/scopes2_false-valid-deref.c
@@ -1,0 +1,22 @@
+extern int printf ( const char * format, ... );
+extern int __VERIFIER_nondet_int();
+
+int main(void) {
+    int *myPointerA = ((void*) 0);
+    int *myPointerB = ((void*) 0);
+
+    if(__VERIFIER_nondet_int())
+    {
+        int myNumberA = 7;
+        myPointerA = &myNumberA;
+        // scope of myNumber ends here
+    }
+
+    int myNumberB = 3;
+    myPointerB = &myNumberB;
+
+    int sumOfMyNumbers = *myPointerA + *myPointerB; // myPointerA is out of scope
+    printf("%d", sumOfMyNumbers);
+
+    return 0;
+}

--- a/c/memsafety-ext3/scopes3_false-valid-deref.c
+++ b/c/memsafety-ext3/scopes3_false-valid-deref.c
@@ -1,0 +1,11 @@
+int main(void) {
+    int* p;
+    for (int i = 0; i < 10; i++) {
+        int a[10];
+        p = a;
+        p[0] = 1;
+    }
+    p[0] = 2;
+
+    return 0;
+}

--- a/c/memsafety-ext3/scopes4_false-valid-deref.c
+++ b/c/memsafety-ext3/scopes4_false-valid-deref.c
@@ -1,0 +1,20 @@
+extern int printf ( const char * format, ... );
+
+int *foo2(void)
+{
+    int arr[1024];
+    arr[194] = 13;
+    return arr + 1;
+}
+
+int *foo(void)
+{
+    int arr[123];
+    return foo2();
+}
+
+int main(void) {
+    int *a = foo();
+    printf("%d\n", *a);
+    return 0;
+}

--- a/c/memsafety-ext3/scopes4_true-valid-memsafety.c
+++ b/c/memsafety-ext3/scopes4_true-valid-memsafety.c
@@ -1,0 +1,20 @@
+extern int printf ( const char * format, ... );
+
+int *foo2(void)
+{
+    static int arr[1024];
+    arr[194] = 13;
+    return arr + 1;
+}
+
+int *foo(void)
+{
+    static int arr[123];
+    return foo2();
+}
+
+int main(void) {
+    int *a = foo();
+    printf("%d\n", *a);
+    return 0;
+}

--- a/c/memsafety-ext3/scopes5_false-valid-deref.c
+++ b/c/memsafety-ext3/scopes5_false-valid-deref.c
@@ -1,0 +1,8 @@
+int main(void) {
+    int* p;
+    if(1) {
+        int a[10];
+        p = a;
+    }
+    p[0] = 1;
+}


### PR DESCRIPTION
New benchmarks for MemSafety category that were used by Symbiotic during testing and revealed some new errors in the tool that did not appear when testing on SV-COMP benchmarks.

<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [ ] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [ ] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings

Preprocessed files are not present as no file contains any preprocessor directives.
