### PR TITLE
Replace memcpy with memmove for overlapping memory

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-dw2102.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-dw2102.ko-entry_point_false-unreach-call.cil.out.c
@@ -7727,7 +7727,7 @@ static int dw210x_op_rw(struct usb_device *dev , u8 request , u16 value , u16 in
 
   }
   if (flags == 1) {
-    memcpy((void *)u8buf, (void const   *)data, (size_t )len);
+    memmove((void *)u8buf, (void const   *)data, (size_t )len);
   } else {
 
   }
@@ -10537,7 +10537,7 @@ static int dw2102_load_firmware(struct usb_device *dev , struct firmware  const 
   dw210x_op_rw(dev, 160, 32658, 0, & reset, 1, 1);
   dw210x_op_rw(dev, 160, 58880, 0, & reset, 1, 1);
   if ((unsigned long )p != (unsigned long )((u8 *)0U)) {
-    memcpy((void *)p, (void const   *)fw->data, fw->size);
+    memmove((void *)p, (void const   *)fw->data, fw->size);
     i = 0;
     goto ldv_49014;
     ldv_49013: 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
@@ -47968,19 +47968,19 @@ static int i40e_dcbnl_ieee_getets(struct net_device *dev , struct ieee_ets *ets 
   ets->willing = dcbxcfg->etscfg.willing;
   ets->ets_cap = dcbxcfg->etscfg.maxtcs;
   ets->cbs = dcbxcfg->etscfg.cbs;
-  memcpy((void *)(& ets->tc_tx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
+  memmove((void *)(& ets->tc_tx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
            8UL);
-  memcpy((void *)(& ets->tc_rx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
+  memmove((void *)(& ets->tc_rx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
            8UL);
-  memcpy((void *)(& ets->tc_tsa), (void const   *)(& dcbxcfg->etscfg.tsatable),
+  memmove((void *)(& ets->tc_tsa), (void const   *)(& dcbxcfg->etscfg.tsatable),
            8UL);
-  memcpy((void *)(& ets->prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
+  memmove((void *)(& ets->prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
            8UL);
-  memcpy((void *)(& ets->tc_reco_bw), (void const   *)(& dcbxcfg->etsrec.tcbwtable),
+  memmove((void *)(& ets->tc_reco_bw), (void const   *)(& dcbxcfg->etsrec.tcbwtable),
            8UL);
-  memcpy((void *)(& ets->tc_reco_tsa), (void const   *)(& dcbxcfg->etsrec.tsatable),
+  memmove((void *)(& ets->tc_reco_tsa), (void const   *)(& dcbxcfg->etsrec.tsatable),
            8UL);
-  memcpy((void *)(& ets->reco_prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
+  memmove((void *)(& ets->reco_prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
            8UL);
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
@@ -12711,7 +12711,7 @@ static int mwifiex_set_mac_address(struct net_device *dev , void *addr )
   tmp = mwifiex_netdev_get_priv(dev);
   priv = tmp;
   hw_addr = (struct sockaddr *)addr;
-  memcpy((void *)(& priv->curr_addr), (void const   *)(& hw_addr->sa_data), 6UL);
+  memmove((void *)(& priv->curr_addr), (void const   *)(& hw_addr->sa_data), 6UL);
   ret = mwifiex_send_cmd(priv, 77, 1, 0U, (void *)0, 1);
   if (ret == 0) {
     memcpy((void *)(priv->netdev)->dev_addr, (void const   *)(& priv->curr_addr),
@@ -12727,7 +12727,7 @@ static int mwifiex_set_mac_address(struct net_device *dev , void *addr )
   } else {
 
   }
-  memcpy((void *)dev->dev_addr, (void const   *)(& priv->curr_addr), 6UL);
+  memmove((void *)dev->dev_addr, (void const   *)(& priv->curr_addr), 6UL);
   return (ret);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point_true-unreach-call.cil.out.c
@@ -7255,7 +7255,7 @@ static int opera1_xilinx_rw(struct usb_device *dev , u8 request , u16 value , u8
   }
   if (flags == 1) {
     memcpy_guard((void *)buf, (void const   *)data, (size_t )len);
-    memcpy((void *)buf, (void const   *)data, (size_t )len);
+    memmove((void *)buf, (void const   *)data, (size_t )len);
   } else {
 
   }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb-v2--dvb-usb-lmedm04.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb-v2--dvb-usb-lmedm04.ko-entry_point_true-unreach-call.cil.out.c
@@ -7522,13 +7522,13 @@ static int lme2510_usb_talk(struct dvb_usb_device *d , u8 *wbuf , int wlen , u8 
   } else {
 
   }
-  memcpy((void *)buff, (void const   *)wbuf, (size_t )(64 < wlen ? 64 : wlen));
+  memmove((void *)buff, (void const   *)wbuf, (size_t )(64 < wlen ? 64 : wlen));
   tmp = lme2510_bulk_write(d->udev, buff, wlen, 1);
   ret = tmp | ret;
   tmp___0 = lme2510_bulk_read(d->udev, buff, 64 < rlen ? 64 : rlen, 1);
   ret = tmp___0 | ret;
   if (rlen > 0) {
-    memcpy((void *)rbuf, (void const   *)buff, (size_t )rlen);
+    memmove((void *)rbuf, (void const   *)buff, (size_t )rlen);
   } else {
 
   }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
@@ -49650,19 +49650,19 @@ static int i40e_dcbnl_ieee_getets(struct net_device *dev , struct ieee_ets *ets 
   ets->willing = dcbxcfg->etscfg.willing;
   ets->ets_cap = dcbxcfg->etscfg.maxtcs;
   ets->cbs = dcbxcfg->etscfg.cbs;
-  memcpy((void *)(& ets->tc_tx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
+  memmove((void *)(& ets->tc_tx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
            8UL);
-  memcpy((void *)(& ets->tc_rx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
+  memmove((void *)(& ets->tc_rx_bw), (void const   *)(& dcbxcfg->etscfg.tcbwtable),
            8UL);
-  memcpy((void *)(& ets->tc_tsa), (void const   *)(& dcbxcfg->etscfg.tsatable),
+  memmove((void *)(& ets->tc_tsa), (void const   *)(& dcbxcfg->etscfg.tsatable),
            8UL);
-  memcpy((void *)(& ets->prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
+  memmove((void *)(& ets->prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
            8UL);
-  memcpy((void *)(& ets->tc_reco_bw), (void const   *)(& dcbxcfg->etsrec.tcbwtable),
+  memmove((void *)(& ets->tc_reco_bw), (void const   *)(& dcbxcfg->etsrec.tcbwtable),
            8UL);
-  memcpy((void *)(& ets->tc_reco_tsa), (void const   *)(& dcbxcfg->etsrec.tsatable),
+  memmove((void *)(& ets->tc_reco_tsa), (void const   *)(& dcbxcfg->etsrec.tsatable),
            8UL);
-  memcpy((void *)(& ets->reco_prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
+  memmove((void *)(& ets->reco_prio_tc), (void const   *)(& dcbxcfg->etscfg.prioritytable),
            8UL);
   return (0);
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
@@ -12721,7 +12721,7 @@ static int mwifiex_set_mac_address(struct net_device *dev , void *addr )
   tmp = mwifiex_netdev_get_priv(dev);
   priv = tmp;
   hw_addr = (struct sockaddr *)addr;
-  memcpy((void *)(& priv->curr_addr), (void const   *)(& hw_addr->sa_data), 6UL);
+  memmove((void *)(& priv->curr_addr), (void const   *)(& hw_addr->sa_data), 6UL);
   ret = mwifiex_send_cmd(priv, 77, 1, 0U, (void *)0, 1);
   if (ret == 0) {
     memcpy((void *)(priv->netdev)->dev_addr, (void const   *)(& priv->curr_addr),
@@ -12737,7 +12737,7 @@ static int mwifiex_set_mac_address(struct net_device *dev , void *addr )
   } else {
 
   }
-  memcpy((void *)dev->dev_addr, (void const   *)(& priv->curr_addr), 6UL);
+  memmove((void *)dev->dev_addr, (void const   *)(& priv->curr_addr), 6UL);
   return (ret);
 }
 }

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point_true-unreach-call.cil.out.c
@@ -9050,7 +9050,7 @@ static int h4_enqueue(struct hci_uart *hu , struct sk_buff *skb )
 
   }
   tmp___0 = skb_push(skb, 1U);
-  memcpy((void *)tmp___0, (void const   *)(& ((struct bt_skb_cb *)(& skb->cb))->pkt_type),
+  memmove((void *)tmp___0, (void const   *)(& ((struct bt_skb_cb *)(& skb->cb))->pkt_type),
            1UL);
   skb_queue_tail(& h4->txq, skb);
   return (0);
@@ -12677,7 +12677,7 @@ static int ath_enqueue(struct hci_uart *hu , struct sk_buff *skb )
 
   }
   tmp___0 = skb_push(skb, 1U);
-  memcpy((void *)tmp___0, (void const   *)(& ((struct bt_skb_cb *)(& skb->cb))->pkt_type),
+  memmove((void *)tmp___0, (void const   *)(& ((struct bt_skb_cb *)(& skb->cb))->pkt_type),
            1UL);
   skb_queue_tail(& ath->txq, skb);
   set_bit(1L, (unsigned long volatile   *)(& hu->tx_state));
@@ -14239,7 +14239,7 @@ static void h5_slip_delim(struct sk_buff *skb )
   {
   delim = -64;
   tmp = skb_put(skb, 1U);
-  memcpy((void *)tmp, (void const   *)(& delim), 1UL);
+  memmove((void *)tmp, (void const   *)(& delim), 1UL);
   return;
 }
 }
@@ -14259,7 +14259,7 @@ static void h5_slip_one_byte(struct sk_buff *skb , u8 c )
   switch ((int )c) {
   case 192: 
   tmp = skb_put(skb, 2U);
-  memcpy((void *)tmp, (void const   *)(& esc_delim), 2UL);
+  memmove((void *)tmp, (void const   *)(& esc_delim), 2UL);
   goto ldv_50458;
   case 219: 
   tmp___0 = skb_put(skb, 2U);
@@ -14267,7 +14267,7 @@ static void h5_slip_one_byte(struct sk_buff *skb , u8 c )
   goto ldv_50458;
   default: 
   tmp___1 = skb_put(skb, 1U);
-  memcpy((void *)tmp___1, (void const   *)(& c), 1UL);
+  memmove((void *)tmp___1, (void const   *)(& c), 1UL);
   }
   ldv_50458: ;
   return;
@@ -15549,7 +15549,7 @@ static int bcm_enqueue(struct hci_uart *hu , struct sk_buff *skb )
 
   }
   tmp___0 = skb_push(skb, 1U);
-  memcpy((void *)tmp___0, (void const   *)(& ((struct bt_skb_cb *)(& skb->cb))->pkt_type),
+  memmove((void *)tmp___0, (void const   *)(& ((struct bt_skb_cb *)(& skb->cb))->pkt_type),
            1UL);
   skb_queue_tail(& bcm->txq, skb);
   return (0);

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--xgbe--amd-xgbe.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--xgbe--amd-xgbe.ko-entry_point_true-unreach-call.cil.out.c
@@ -24694,10 +24694,10 @@ static int xgbe_dcb_ieee_getets(struct net_device *netdev , struct ieee_ets *ets
   ets->ets_cap = (__u8 )pdata->hw_feat.tc_cnt;
   if ((unsigned long )pdata->ets != (unsigned long )((struct ieee_ets *)0)) {
     ets->cbs = (pdata->ets)->cbs;
-    memcpy((void *)(& ets->tc_tx_bw), (void const   *)(& (pdata->ets)->tc_tx_bw),
+    memmove((void *)(& ets->tc_tx_bw), (void const   *)(& (pdata->ets)->tc_tx_bw),
              8UL);
-    memcpy((void *)(& ets->tc_tsa), (void const   *)(& (pdata->ets)->tc_tsa), 8UL);
-    memcpy((void *)(& ets->prio_tc), (void const   *)(& (pdata->ets)->prio_tc),
+    memmove((void *)(& ets->tc_tsa), (void const   *)(& (pdata->ets)->tc_tsa), 8UL);
+    memmove((void *)(& ets->prio_tc), (void const   *)(& (pdata->ets)->prio_tc),
              8UL);
   } else {
 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point_true-unreach-call.cil.out.c
@@ -9389,7 +9389,7 @@ static int get_eeprom(struct net_device *dev , struct ethtool_eeprom *eeprom , u
   res = netdev_get_eeprom(dev, eebuf);
   spin_unlock_irq(& np->lock);
   if (res == 0) {
-    memcpy((void *)data, (void const   *)eebuf + (unsigned long )eeprom->offset,
+    memmove((void *)data, (void const   *)eebuf + (unsigned long )eeprom->offset,
              (size_t )eeprom->len);
   } else {
 

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.c
@@ -7587,7 +7587,7 @@ static int dfx_driver_init(struct net_device *dev , char const   *print_name , r
 
   }
   le32 = data;
-  memcpy((void *)(& bp->factory_mac_addr), (void const   *)(& le32), 4UL);
+  memmove((void *)(& bp->factory_mac_addr), (void const   *)(& le32), 4UL);
   tmp___1 = dfx_hw_port_ctrl_req(bp, 8U, 1U, 0U, & data);
   if (tmp___1 != 0) {
     printk("%s: Could not read adapter factory MAC address!\n", print_name);
@@ -7596,8 +7596,8 @@ static int dfx_driver_init(struct net_device *dev , char const   *print_name , r
 
   }
   le32 = data;
-  memcpy((void *)(& bp->factory_mac_addr) + 4U, (void const   *)(& le32), 2UL);
-  memcpy((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr), 6UL);
+  memmove((void *)(& bp->factory_mac_addr) + 4U, (void const   *)(& le32), 2UL);
+  memmove((void *)dev->dev_addr, (void const   *)(& bp->factory_mac_addr), 6UL);
   if (dfx_bus_tc != 0) {
     board_name = (char *)"DEFTA";
   } else {

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point_true-unreach-call.cil.out.c
@@ -9034,7 +9034,7 @@ int bnx2i_get_stats(void *handle )
 
   }
   strlcpy((char *)(& stats->version), "2.7.10.1", 12UL);
-  memcpy((void *)(& stats->mac_add1) + 2U, (void const   *)(& (hba->cnic)->mac_addr),
+  memmove((void *)(& stats->mac_add1) + 2U, (void const   *)(& (hba->cnic)->mac_addr),
            6UL);
   stats->max_frame_size = (hba->netdev)->mtu;
   stats->txq_size = hba->max_sqes;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.c
@@ -11735,7 +11735,7 @@ static struct slgt_info *alloc_dev(int adapter_num , int port_num , struct pci_d
     spinlock_check(& info->netlock);
     __raw_spin_lock_init(& info->netlock.__annonCompField18.rlock, "&(&info->netlock)->rlock",
                          & __key___2);
-    memcpy((void *)(& info->params), (void const   *)(& default_params), 48UL);
+    memmove((void *)(& info->params), (void const   *)(& default_params), 48UL);
     info->idle_mode = 0U;
     info->adapter_num = adapter_num;
     info->port_num = port_num;
@@ -11803,7 +11803,7 @@ static void device_init(int adapter_num , struct pci_dev *pdev )
   i = 0;
   goto ldv_48370;
   ldv_48369: 
-  memcpy((void *)(& (port_array[i])->port_array), (void const   *)(& port_array),
+  memmove((void *)(& (port_array[i])->port_array), (void const   *)(& port_array),
            32UL);
   add_device(port_array[i]);
   (port_array[i])->port_count = port_count;

--- a/c/ntdrivers/cdaudio_true-unreach-call.i.cil.c
+++ b/c/ntdrivers/cdaudio_true-unreach-call.i.cil.c
@@ -2643,6 +2643,7 @@ struct _SCSI_REQUEST_BLOCK;
 #pragma warning(disable:4035)
 #pragma warning(pop)
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int memcmp(void const   * , void const   * ,
                                                 size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
@@ -7377,7 +7378,7 @@ NTSTATUS CdAudioHPCdrDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
     {
     irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
     nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
-    memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+    memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
     nextIrpSp->Control = 0;
     }
     if (s != NP) {
@@ -7429,7 +7430,7 @@ NTSTATUS CdAudioForwardIrpSynchronous(PDEVICE_OBJECT DeviceObject , PIRP Irp )
   deviceExtension = (struct _CD_DEVICE_EXTENSION *)DeviceObject->DeviceExtension;
   irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (s != NP) {

--- a/c/ntdrivers/diskperf_false-unreach-call.i.cil.c
+++ b/c/ntdrivers/diskperf_false-unreach-call.i.cil.c
@@ -1482,6 +1482,7 @@ struct _SCSI_REQUEST_BLOCK;
 #pragma warning(disable:4035)
 #pragma warning(pop)
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 PCCHAR KeNumberProcessors ;
 #pragma warning(disable:4103)
@@ -2321,7 +2322,7 @@ NTSTATUS DiskPerfForwardIrpSynchronous(PDEVICE_OBJECT DeviceObject , PIRP Irp )
   deviceExtension = (struct _DEVICE_EXTENSION *)DeviceObject->DeviceExtension;
   irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (s != NP) {

--- a/c/ntdrivers/diskperf_true-unreach-call.i.cil.c
+++ b/c/ntdrivers/diskperf_true-unreach-call.i.cil.c
@@ -1492,6 +1492,7 @@ struct _SCSI_REQUEST_BLOCK;
 #pragma warning(disable:4035)
 #pragma warning(pop)
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 PCCHAR KeNumberProcessors ;
 #pragma warning(disable:4103)
@@ -2332,7 +2333,7 @@ NTSTATUS DiskPerfForwardIrpSynchronous(PDEVICE_OBJECT DeviceObject , PIRP Irp )
   irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
   memcpy_guard(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (s != NP) {
@@ -2608,7 +2609,7 @@ NTSTATUS DiskPerfDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
       {
       totalCounters->StorageDeviceNumber = deviceExtension->DiskNumber;
       memcpy_guard(& totalCounters->StorageManagerName[0], & deviceExtension->StorageManagerName[0], 8U * sizeof(WCHAR ));
-      memcpy(& totalCounters->StorageManagerName[0], & deviceExtension->StorageManagerName[0],
+      memmove(& totalCounters->StorageManagerName[0], & deviceExtension->StorageManagerName[0],
              8U * sizeof(WCHAR ));
       status = 0L;
       Irp->IoStatus.Information = sizeof(DISK_PERFORMANCE );
@@ -2753,7 +2754,7 @@ NTSTATUS DiskPerfRegisterDevice(PDEVICE_OBJECT DeviceObject )
              number.DeviceNumber, number.PartitionNumber);
 /*     RtlInitUnicodeString(& deviceExtension->PhysicalDeviceName, & deviceExtension->PhysicalDeviceNameBuffer[0]); */ /* INLINED */
     memcpy_guard(& deviceExtension->StorageManagerName[0], "P\000h\000y\000s\000D\000i\000s\000k\000", 8U * sizeof(WCHAR ));
-    memcpy(& deviceExtension->StorageManagerName[0], "P\000h\000y\000s\000D\000i\000s\000k\000",
+    memmove(& deviceExtension->StorageManagerName[0], "P\000h\000y\000s\000D\000i\000s\000k\000",
            8U * sizeof(WCHAR ));
     }
   } else {
@@ -2854,7 +2855,7 @@ NTSTATUS DiskPerfRegisterDevice(PDEVICE_OBJECT DeviceObject )
     deviceExtension->PhysicalDeviceName.Length = output->NameLength;
     deviceExtension->PhysicalDeviceName.MaximumLength = (unsigned int )output->NameLength + sizeof(WCHAR );
     memcpy_guard(deviceExtension->PhysicalDeviceName.Buffer, output->Name, output->NameLength);
-    memcpy(deviceExtension->PhysicalDeviceName.Buffer, output->Name, output->NameLength);
+    memmove(deviceExtension->PhysicalDeviceName.Buffer, output->Name, output->NameLength);
     *(deviceExtension->PhysicalDeviceName.Buffer + (unsigned int )deviceExtension->PhysicalDeviceName.Length / sizeof(WCHAR )) = 0;
 /*     ExFreePool(output); */ /* INLINED */
     outputSize = sizeof(VOLUME_NUMBER );
@@ -2890,7 +2891,7 @@ NTSTATUS DiskPerfRegisterDevice(PDEVICE_OBJECT DeviceObject )
         _L: /* CIL Label */ 
         {
         memcpy_guard(& deviceExtension->StorageManagerName[0], "L\000o\000g\000i\000D\000i\000s\000k\000", 8U * sizeof(WCHAR ));
-        memcpy(& deviceExtension->StorageManagerName[0], "L\000o\000g\000i\000D\000i\000s\000k\000",
+        memmove(& deviceExtension->StorageManagerName[0], "L\000o\000g\000i\000D\000i\000s\000k\000",
                8U * sizeof(WCHAR ));
         }
         if (status >= 0L) {
@@ -2938,7 +2939,7 @@ void DiskPerfLogError(PDEVICE_OBJECT DeviceObject , ULONG UniqueId , NTSTATUS Er
     errorLogEntry->UniqueErrorValue = UniqueId;
     errorLogEntry->FinalStatus = Status;
     memcpy_guard(& errorLogEntry->DumpData[0], & DeviceObject, sizeof(DEVICE_OBJECT ));
-    memcpy(& errorLogEntry->DumpData[0], & DeviceObject, sizeof(DEVICE_OBJECT ));
+    memmove(& errorLogEntry->DumpData[0], & DeviceObject, sizeof(DEVICE_OBJECT ));
     errorLogEntry->DumpDataSize = sizeof(DEVICE_OBJECT );
     IoWriteErrorLogEntry(errorLogEntry);
     }

--- a/c/ntdrivers/floppy2_true-unreach-call_true-termination.i.cil.c
+++ b/c/ntdrivers/floppy2_true-unreach-call_true-termination.i.cil.c
@@ -5799,7 +5799,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                             __cil_tmp121 = *mem_511;
                             __cil_tmp122 = (unsigned int )__cil_tmp121;
                             memcpy_guard(__cil_tmp115, __cil_tmp120, __cil_tmp122);
-                            memcpy(__cil_tmp115, __cil_tmp120, __cil_tmp122);
+                            memmove(__cil_tmp115, __cil_tmp120, __cil_tmp122);
                             ntStatus = 0L;
                             __cil_tmp123 = 24 + 4;
                             __cil_tmp124 = (unsigned int )Irp;
@@ -5894,7 +5894,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                             __cil_tmp163 = *mem_523;
                             __cil_tmp164 = (unsigned int )__cil_tmp163;
                             memcpy_guard(__cil_tmp157, __cil_tmp162, __cil_tmp164);
-                            memcpy(__cil_tmp157, __cil_tmp162, __cil_tmp164);
+                            memmove(__cil_tmp157, __cil_tmp162, __cil_tmp164);
                             ntStatus = 0L;
                             __cil_tmp165 = 24 + 4;
                             __cil_tmp166 = (unsigned int )Irp;
@@ -6353,7 +6353,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                               __cil_tmp357 = *mem_558;
                               __cil_tmp358 = (unsigned int )__cil_tmp357;
                               memcpy_guard(__cil_tmp349, __cil_tmp354, __cil_tmp358);
-                              memcpy(__cil_tmp349, __cil_tmp354, __cil_tmp358);
+                              memmove(__cil_tmp349, __cil_tmp354, __cil_tmp358);
                               __cil_tmp359 = (unsigned int )(& driveLetterName) + 4;
                               __cil_tmp360 = 0 * 2U;
                               __cil_tmp361 = (unsigned int )(driveLetterNameBuffer) + __cil_tmp360;
@@ -7545,7 +7545,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                     __cil_tmp163 = (long )__cil_tmp162;
                     __cil_tmp164 = (unsigned int )__cil_tmp163;
                     memcpy_guard(__cil_tmp157, __cil_tmp158, __cil_tmp164);
-                    memcpy(__cil_tmp157, __cil_tmp158, __cil_tmp164);
+                    memmove(__cil_tmp157, __cil_tmp158, __cil_tmp164);
                     __cil_tmp165 = (unsigned int )nextIrpSp;
                     __cil_tmp166 = __cil_tmp165 + 3;
                     mem_384 = (UCHAR *)__cil_tmp166;
@@ -8253,7 +8253,7 @@ NTSTATUS FloppyStartDevice(PDEVICE_OBJECT DeviceObject , PIRP Irp )
   __cil_tmp43 = (long )__cil_tmp42;
   __cil_tmp44 = (unsigned int )__cil_tmp43;
   memcpy_guard(__cil_tmp37, __cil_tmp38, __cil_tmp44);
-  memcpy(__cil_tmp37, __cil_tmp38, __cil_tmp44);
+  memmove(__cil_tmp37, __cil_tmp38, __cil_tmp44);
   __cil_tmp45 = (unsigned int )nextIrpSp;
   __cil_tmp46 = __cil_tmp45 + 3;
   mem_194 = (UCHAR *)__cil_tmp46;

--- a/c/ntdrivers/floppy_true-unreach-call_true-valid-memsafety.i.cil.c
+++ b/c/ntdrivers/floppy_true-unreach-call_true-valid-memsafety.i.cil.c
@@ -2817,7 +2817,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                             {
                             memcpy_guard(mountName->Name, disketteExtension->DeviceName.Buffer,
                                          mountName->NameLength);
-                            memcpy(mountName->Name, disketteExtension->DeviceName.Buffer,
+                            memmove(mountName->Name, disketteExtension->DeviceName.Buffer,
                                    mountName->NameLength);
                             ntStatus = 0L;
                             Irp->IoStatus.Information = sizeof(USHORT ) + (unsigned int )mountName->NameLength;
@@ -2849,7 +2849,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                             {
                             memcpy_guard(uniqueId->UniqueId, disketteExtension->InterfaceString.Buffer,
                                          uniqueId->UniqueIdLength);
-                            memcpy(uniqueId->UniqueId, disketteExtension->InterfaceString.Buffer,
+                            memmove(uniqueId->UniqueId, disketteExtension->InterfaceString.Buffer,
                                    uniqueId->UniqueIdLength);
                             ntStatus = 0L;
                             Irp->IoStatus.Information = sizeof(USHORT ) + (unsigned int )uniqueId->UniqueIdLength;
@@ -2994,7 +2994,7 @@ NTSTATUS FloppyDeviceControl(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                               memset(valueName, 0, sizeof(WCHAR ) * 64U);
                               memcpy_guard(valueName, disketteExtension->DeviceName.Buffer,
                                            disketteExtension->DeviceName.Length);
-                              memcpy(valueName, disketteExtension->DeviceName.Buffer,
+                              memmove(valueName, disketteExtension->DeviceName.Buffer,
                                      disketteExtension->DeviceName.Length);
                               driveLetterName.Buffer = driveLetterNameBuffer;
                               driveLetterName.MaximumLength = 20;
@@ -3351,7 +3351,7 @@ NTSTATUS FloppyPnp(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                     irpSp___0 = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
                     nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
                     memcpy_guard(nextIrpSp, irpSp___0, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
-                    memcpy(nextIrpSp, irpSp___0, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+                    memmove(nextIrpSp, irpSp___0, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
                     nextIrpSp->Control = 0;
 /*                     KeInitializeEvent(& doneEvent, 1, 0); */ /* INLINED */
                     }
@@ -3546,7 +3546,7 @@ NTSTATUS FloppyStartDevice(PDEVICE_OBJECT DeviceObject , PIRP Irp )
   irpSp___0 = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
   memcpy_guard(nextIrpSp, irpSp___0, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
-  memcpy(nextIrpSp, irpSp___0, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp___0, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (s != NP) {

--- a/c/ntdrivers/kbfiltr_false-unreach-call.i.cil.c
+++ b/c/ntdrivers/kbfiltr_false-unreach-call.i.cil.c
@@ -1432,6 +1432,7 @@ struct _SCSI_REQUEST_BLOCK;
 #pragma warning(disable:4035)
 #pragma warning(pop)
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 #pragma warning(disable:4103)
 #pragma warning(disable:4103)
@@ -2032,7 +2033,7 @@ NTSTATUS KbFilter_PnP(PDEVICE_OBJECT DeviceObject , PIRP Irp )
                                               {
                                               irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
                                               nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
-                                              memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+                                              memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
                                               nextIrpSp->Control = 0;
 /*                                               KeInitializeEvent(& event, 0, 0); */ /* INLINED */
                                               }

--- a/c/ntdrivers/parport_false-unreach-call.i.cil.c
+++ b/c/ntdrivers/parport_false-unreach-call.i.cil.c
@@ -7573,7 +7573,7 @@ NTSTATUS PptPnpBounceAndCatchPnpIrp(PDEVICE_EXTENSION Extension , PIRP Irp )
 /*   KeInitializeEvent(& event, 0, 0); */ /* INLINED */
   irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (s != NP) {
@@ -7885,7 +7885,7 @@ NTSTATUS PptDispatchPower(PDEVICE_OBJECT pDeviceObject , PIRP pIrp )
   {
   irpSp = pIrp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = pIrp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (! (status >= 0L)) {

--- a/c/ntdrivers/parport_true-unreach-call.i.cil.c
+++ b/c/ntdrivers/parport_true-unreach-call.i.cil.c
@@ -2611,7 +2611,7 @@ void PptLogError(PDRIVER_OBJECT DriverObject , PDEVICE_OBJECT DeviceObject , PHY
   if (DumpToAllocate) {
     {
     memcpy_guard(ErrorLogEntry->DumpData, & P1, sizeof(PHYSICAL_ADDRESS ));
-    memcpy(ErrorLogEntry->DumpData, & P1, sizeof(PHYSICAL_ADDRESS ));
+    memmove(ErrorLogEntry->DumpData, & P1, sizeof(PHYSICAL_ADDRESS ));
     }
     if ((unsigned int )DumpToAllocate > sizeof(PHYSICAL_ADDRESS )) {
       {
@@ -7586,7 +7586,7 @@ NTSTATUS PptPnpBounceAndCatchPnpIrp(PDEVICE_EXTENSION Extension , PIRP Irp )
   irpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = Irp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
   memcpy_guard(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (s != NP) {
@@ -7899,7 +7899,7 @@ NTSTATUS PptDispatchPower(PDEVICE_OBJECT pDeviceObject , PIRP pIrp )
   irpSp = pIrp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation;
   nextIrpSp = pIrp->Tail.Overlay.__annonCompField17.__annonCompField16.CurrentStackLocation - 1;
   memcpy_guard(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
-  memcpy(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
+  memmove(nextIrpSp, irpSp, (long )(& ((IO_STACK_LOCATION *)0)->CompletionRoutine));
   nextIrpSp->Control = 0;
   }
   if (! (status >= 0L)) {


### PR DESCRIPTION
These benchmarks call memcpy with overlapping source and destination
areas, which is undefined behaviour according to POSIX.1-2008 and the C
standard. The CBMC tool therefore gives a result of false, including a
counterexample, on the benchmarks that are expected to return true.

These benchmarks, being examples from device drivers, were supposedly
written with overlapping source and memory regions intentionally, and
the code 'works' in practice. However, SV-COMP participants should
arguably not be expected to get the right result for benchmarks relying
on quirky, non-standards-conformant hardware behaviour.

Counterexamples for all the deleted files are available on [this page](https://karkhaz.com/tmp/log-matches).
