### PR TITLE
replace `MODULO` with proper `VERIFIER_assume`.

### DIFF
--- a/c/pthread/stack_false-unreach-call.c
+++ b/c/pthread/stack_false-unreach-call.c
@@ -81,7 +81,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
+    __VERIFIER_assume(tmp < SIZE);
     if (push(arr,tmp)==OVERFLOW)
       error();
     flag=TRUE;

--- a/c/pthread/stack_false-unreach-call.c
+++ b/c/pthread/stack_false-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 
 #include <pthread.h>
 #include <stdio.h>
@@ -79,7 +80,8 @@ void *t1(void *arg)
   for(i=0; i<SIZE; i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%SIZE;
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
     if (push(arr,tmp)==OVERFLOW)
       error();
     flag=TRUE;

--- a/c/pthread/stack_false-unreach-call.i
+++ b/c/pthread/stack_false-unreach-call.i
@@ -1920,7 +1920,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < (5));
+    __VERIFIER_assume(tmp < (5));
     if (push(arr,tmp)==(-1))
       error();
     flag=(1);

--- a/c/pthread/stack_false-unreach-call.i
+++ b/c/pthread/stack_false-unreach-call.i
@@ -1,12 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-
-
-
-
-
-
+extern void __VERIFIER_assume(int);
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -1926,7 +1919,8 @@ void *t1(void *arg)
   for(i=0; i<(5); i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%(5);
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < (5));
     if (push(arr,tmp)==(-1))
       error();
     flag=(1);

--- a/c/pthread/stack_longer_false-unreach-call.c
+++ b/c/pthread/stack_longer_false-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 #include <pthread.h>
 #include <stdio.h>
 
@@ -76,7 +77,8 @@ void *t1(void *arg)
   for(i=0; i<SIZE; i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%SIZE;
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
     if (push(arr,tmp)==OVERFLOW)
       error();
     flag=TRUE;

--- a/c/pthread/stack_longer_false-unreach-call.c
+++ b/c/pthread/stack_longer_false-unreach-call.c
@@ -78,7 +78,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
+    __VERIFIER_assume(tmp < SIZE);
     if (push(arr,tmp)==OVERFLOW)
       error();
     flag=TRUE;

--- a/c/pthread/stack_longer_false-unreach-call.i
+++ b/c/pthread/stack_longer_false-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -968,7 +969,8 @@ void *t1(void *arg)
   for(i=0; i<(400); i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%(400);
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < (400));
     if (push(arr,tmp)==(-1))
       error();
     flag=(1);

--- a/c/pthread/stack_longer_false-unreach-call.i
+++ b/c/pthread/stack_longer_false-unreach-call.i
@@ -970,7 +970,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < (400));
+    __VERIFIER_assume(tmp < (400));
     if (push(arr,tmp)==(-1))
       error();
     flag=(1);

--- a/c/pthread/stack_longer_true-unreach-call.c
+++ b/c/pthread/stack_longer_true-unreach-call.c
@@ -79,7 +79,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);   
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
+    __VERIFIER_assume(tmp < SIZE);
     if ((push(arr,tmp)==OVERFLOW))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longer_true-unreach-call.c
+++ b/c/pthread/stack_longer_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 #include <pthread.h>
 #include <stdio.h>
 
@@ -77,7 +78,8 @@ void *t1(void *arg)
   for(i=0; i<SIZE; i++)
   {
     pthread_mutex_lock(&m);   
-    tmp = __VERIFIER_nondet_uint()%SIZE;
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
     if ((push(arr,tmp)==OVERFLOW))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longer_true-unreach-call.i
+++ b/c/pthread/stack_longer_true-unreach-call.i
@@ -971,7 +971,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < (400));
+    __VERIFIER_assume(tmp < (400));
     if ((push(arr,tmp)==(-1)))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longer_true-unreach-call.i
+++ b/c/pthread/stack_longer_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -969,7 +970,8 @@ void *t1(void *arg)
   for(i=0; i<(400); i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%(400);
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < (400));
     if ((push(arr,tmp)==(-1)))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longest_false-unreach-call.c
+++ b/c/pthread/stack_longest_false-unreach-call.c
@@ -79,7 +79,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
+    __VERIFIER_assume(tmp < SIZE);
     if (push(arr,tmp)==OVERFLOW)
       error();
     flag=TRUE;

--- a/c/pthread/stack_longest_false-unreach-call.c
+++ b/c/pthread/stack_longest_false-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 #include <pthread.h>
 #include <stdio.h>
 
@@ -77,7 +78,8 @@ void *t1(void *arg)
   for(i=0; i<SIZE; i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%SIZE;
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
     if (push(arr,tmp)==OVERFLOW)
       error();
     flag=TRUE;

--- a/c/pthread/stack_longest_false-unreach-call.i
+++ b/c/pthread/stack_longest_false-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -969,7 +970,8 @@ void *t1(void *arg)
   for(i=0; i<(800); i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%(800);
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < (800));
     if (push(arr,tmp)==(-1))
       error();
     flag=(1);

--- a/c/pthread/stack_longest_false-unreach-call.i
+++ b/c/pthread/stack_longest_false-unreach-call.i
@@ -971,7 +971,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < (800));
+    __VERIFIER_assume(tmp < (800));
     if (push(arr,tmp)==(-1))
       error();
     flag=(1);

--- a/c/pthread/stack_longest_true-unreach-call.c
+++ b/c/pthread/stack_longest_true-unreach-call.c
@@ -79,7 +79,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);   
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
+    __VERIFIER_assume(tmp < SIZE);
     if ((push(arr,tmp)==OVERFLOW))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longest_true-unreach-call.c
+++ b/c/pthread/stack_longest_true-unreach-call.c
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 #include <pthread.h>
 #include <stdio.h>
 
@@ -77,7 +78,8 @@ void *t1(void *arg)
   for(i=0; i<SIZE; i++)
   {
     pthread_mutex_lock(&m);   
-    tmp = __VERIFIER_nondet_uint()%SIZE;
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
     if ((push(arr,tmp)==OVERFLOW))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longest_true-unreach-call.i
+++ b/c/pthread/stack_longest_true-unreach-call.i
@@ -971,7 +971,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < (800));
+    __VERIFIER_assume(tmp < (800));
     if ((push(arr,tmp)==(-1)))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_longest_true-unreach-call.i
+++ b/c/pthread/stack_longest_true-unreach-call.i
@@ -1,4 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -969,7 +970,8 @@ void *t1(void *arg)
   for(i=0; i<(800); i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%(800);
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < (800));
     if ((push(arr,tmp)==(-1)))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_true-unreach-call.c
+++ b/c/pthread/stack_true-unreach-call.c
@@ -80,7 +80,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);   
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
+    __VERIFIER_assume(tmp < SIZE);
     if ((push(arr,tmp)==OVERFLOW))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_true-unreach-call.c
+++ b/c/pthread/stack_true-unreach-call.c
@@ -1,5 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+extern void __VERIFIER_assume(int);
 #include <pthread.h>
 #include <stdio.h>
 
@@ -79,7 +79,8 @@ void *t1(void *arg)
   for(i=0; i<SIZE; i++)
   {
     pthread_mutex_lock(&m);   
-    tmp = __VERIFIER_nondet_uint()%SIZE;
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < SIZE);
     if ((push(arr,tmp)==OVERFLOW))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_true-unreach-call.i
+++ b/c/pthread/stack_true-unreach-call.i
@@ -1,12 +1,5 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
-
-
-
-
-
-
-
+extern void __VERIFIER_assume(int);
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -1926,7 +1919,8 @@ void *t1(void *arg)
   for(i=0; i<(5); i++)
   {
     pthread_mutex_lock(&m);
-    tmp = __VERIFIER_nondet_uint()%(5);
+    tmp = __VERIFIER_nondet_uint();
+    __VERIFIER_assume(0 <= tmp && tmp < (5));
     if ((push(arr,tmp)==(-1)))
       error();
     pthread_mutex_unlock(&m);

--- a/c/pthread/stack_true-unreach-call.i
+++ b/c/pthread/stack_true-unreach-call.i
@@ -1920,7 +1920,7 @@ void *t1(void *arg)
   {
     pthread_mutex_lock(&m);
     tmp = __VERIFIER_nondet_uint();
-    __VERIFIER_assume(0 <= tmp && tmp < (5));
+    __VERIFIER_assume(tmp < (5));
     if ((push(arr,tmp)==(-1)))
       error();
     pthread_mutex_unlock(&m);

--- a/c/seq-pthread/cs_stack_false-unreach-call.c
+++ b/c/seq-pthread/cs_stack_false-unreach-call.c
@@ -416,7 +416,7 @@ void *t1(void *arg)
 		__CS_pthread_mutex_lock(&m[__CS_round]);
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		tmp = __VERIFIER_nondet_uint();
-		__VERIFIER_assume(0 <= tmp && tmp < (5));
+		__VERIFIER_assume(tmp < (5));
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		if (push(arr[__CS_round], tmp) == (-1))
 		{

--- a/c/seq-pthread/cs_stack_false-unreach-call.c
+++ b/c/seq-pthread/cs_stack_false-unreach-call.c
@@ -415,7 +415,8 @@ void *t1(void *arg)
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		__CS_pthread_mutex_lock(&m[__CS_round]);
 		__CS_cs(); if (__CS_ret != 0) return 0;
-		tmp = __VERIFIER_nondet_uint() % 5;
+		tmp = __VERIFIER_nondet_uint();
+		__VERIFIER_assume(0 <= tmp && tmp < (5));
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		if (push(arr[__CS_round], tmp) == (-1))
 		{

--- a/c/seq-pthread/cs_stack_false-unreach-call.i
+++ b/c/seq-pthread/cs_stack_false-unreach-call.i
@@ -1100,7 +1100,7 @@ void *t1(void *arg)
   __CS_pthread_mutex_lock(&m[__CS_round]);
   __CS_cs(); if (__CS_ret != 0) return 0;
   tmp = __VERIFIER_nondet_uint();
-  __VERIFIER_assume(0 <= tmp && tmp < (5));
+  __VERIFIER_assume(tmp < (5));
   __CS_cs(); if (__CS_ret != 0) return 0;
   if (push(arr[__CS_round], tmp) == (-1))
   {

--- a/c/seq-pthread/cs_stack_false-unreach-call.i
+++ b/c/seq-pthread/cs_stack_false-unreach-call.i
@@ -1099,7 +1099,8 @@ void *t1(void *arg)
   __CS_cs(); if (__CS_ret != 0) return 0;
   __CS_pthread_mutex_lock(&m[__CS_round]);
   __CS_cs(); if (__CS_ret != 0) return 0;
-  tmp = __VERIFIER_nondet_uint() % 5;
+  tmp = __VERIFIER_nondet_uint();
+  __VERIFIER_assume(0 <= tmp && tmp < (5));
   __CS_cs(); if (__CS_ret != 0) return 0;
   if (push(arr[__CS_round], tmp) == (-1))
   {

--- a/c/seq-pthread/cs_stack_true-unreach-call.c
+++ b/c/seq-pthread/cs_stack_true-unreach-call.c
@@ -419,7 +419,7 @@ void *t1(void *arg)
 		__CS_pthread_mutex_lock(&m[__CS_round]);
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		tmp = __VERIFIER_nondet_uint();
-		__VERIFIER_assume(0 <= tmp && tmp < (5));
+		__VERIFIER_assume(tmp < (5));
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		if (push(arr[__CS_round], tmp) == (-1))
 		{

--- a/c/seq-pthread/cs_stack_true-unreach-call.c
+++ b/c/seq-pthread/cs_stack_true-unreach-call.c
@@ -418,7 +418,8 @@ void *t1(void *arg)
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		__CS_pthread_mutex_lock(&m[__CS_round]);
 		__CS_cs(); if (__CS_ret != 0) return 0;
-		tmp = __VERIFIER_nondet_uint() % 5;
+		tmp = __VERIFIER_nondet_uint();
+		__VERIFIER_assume(0 <= tmp && tmp < (5));
 		__CS_cs(); if (__CS_ret != 0) return 0;
 		if (push(arr[__CS_round], tmp) == (-1))
 		{

--- a/c/seq-pthread/cs_stack_true-unreach-call.i
+++ b/c/seq-pthread/cs_stack_true-unreach-call.i
@@ -1103,7 +1103,7 @@ void *t1(void *arg)
   __CS_pthread_mutex_lock(&m[__CS_round]);
   __CS_cs(); if (__CS_ret != 0) return 0;
   tmp = __VERIFIER_nondet_uint();
-  __VERIFIER_assume(0 <= tmp && tmp < (5));
+  __VERIFIER_assume(tmp < (5));
   __CS_cs(); if (__CS_ret != 0) return 0;
   if (push(arr[__CS_round], tmp) == (-1))
   {

--- a/c/seq-pthread/cs_stack_true-unreach-call.i
+++ b/c/seq-pthread/cs_stack_true-unreach-call.i
@@ -1102,7 +1102,8 @@ void *t1(void *arg)
   __CS_cs(); if (__CS_ret != 0) return 0;
   __CS_pthread_mutex_lock(&m[__CS_round]);
   __CS_cs(); if (__CS_ret != 0) return 0;
-  tmp = __VERIFIER_nondet_uint() % 5;
+  tmp = __VERIFIER_nondet_uint();
+  __VERIFIER_assume(0 <= tmp && tmp < (5));
   __CS_cs(); if (__CS_ret != 0) return 0;
   if (push(arr[__CS_round], tmp) == (-1))
   {


### PR DESCRIPTION
Simplifying some files by replacing statement `tmp=nondet_int()%N` with simpler assumption `tmp=nondet_int();assume(0<=tmp&&tmp<N)`.
Most verifiers handle linear arithmetic much easier than modulo operation.