### PR TITLE
Added benchmarks for ReachSafety Arrays. 

### DIFF
--- a/c/ReachSafety-Arrays.set
+++ b/c/ReachSafety-Arrays.set
@@ -12,3 +12,6 @@ array-tiling/*_true-unreach-call*.i
 
 array-programs/*_false-unreach-call*.i
 array-programs/*_true-unreach-call*.i
+
+array-crafted/*_true-unreach-call*.i
+array-crafted/zero_sum*_true-unreach-call*.c

--- a/c/array-crafted/License.txt
+++ b/c/array-crafted/License.txt
@@ -1,0 +1,1 @@
+../LICENSE.Apache-2.0.txt

--- a/c/array-crafted/Makefile
+++ b/c/array-crafted/Makefile
@@ -1,0 +1,3 @@
+LEVEL := ../
+
+include $(LEVEL)/Makefile.config

--- a/c/array-crafted/README.txt
+++ b/c/array-crafted/README.txt
@@ -1,0 +1,1 @@
+Benchmarks submitted by VeriAbs team, TCS Innovation labs, Pune.

--- a/c/array-crafted/bAnd1_true-unreach-call.c
+++ b/c/array-crafted/bAnd1_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100
+#define fun bAnd
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd1_true-unreach-call.i
+++ b/c/array-crafted/bAnd1_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[100])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 100; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[100];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bAnd(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bAnd(x);
+  temp=x[0];
+  for(int i =0 ; i<100 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100 -1] = temp;
+  ret5 = bAnd(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd2_true-unreach-call.c
+++ b/c/array-crafted/bAnd2_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 1000
+#define fun bAnd
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd2_true-unreach-call.i
+++ b/c/array-crafted/bAnd2_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[1000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 1000; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[1000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 1000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bAnd(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bAnd(x);
+  temp=x[0];
+  for(int i =0 ; i<1000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[1000 -1] = temp;
+  ret5 = bAnd(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd3_true-unreach-call.c
+++ b/c/array-crafted/bAnd3_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 10000
+#define fun bAnd
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd3_true-unreach-call.i
+++ b/c/array-crafted/bAnd3_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[10000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 10000; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[10000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 10000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bAnd(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bAnd(x);
+  temp=x[0];
+  for(int i =0 ; i<10000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[10000 -1] = temp;
+  ret5 = bAnd(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd4_true-unreach-call.c
+++ b/c/array-crafted/bAnd4_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100000
+#define fun bAnd
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd4_true-unreach-call.i
+++ b/c/array-crafted/bAnd4_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bAnd (int x[100000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 100000; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[100000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bAnd(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bAnd(x);
+  temp=x[0];
+  for(int i =0 ; i<100000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100000 -1] = temp;
+  ret5 = bAnd(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd5_true-unreach-call.c
+++ b/c/array-crafted/bAnd5_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define fun bAnd
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int bAnd (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+  
+    ret = fun(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = fun(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = fun(x);
+
+    if(ret != ret2 || ret !=ret5){ 
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/bAnd5_true-unreach-call.i
+++ b/c/array-crafted/bAnd5_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int bAnd (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res & x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+
+    ret = bAnd(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = bAnd(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = bAnd(x);
+
+    if(ret != ret2 || ret !=ret5){
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/bor1_true-unreach-call.c
+++ b/c/array-crafted/bor1_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100
+#define fun bor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor1_true-unreach-call.i
+++ b/c/array-crafted/bor1_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[100])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 100; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[100];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bor(x);
+  temp=x[0];
+  for(int i =0 ; i<100 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100 -1] = temp;
+  ret5 = bor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor2_true-unreach-call.c
+++ b/c/array-crafted/bor2_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 1000
+#define fun bor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor2_true-unreach-call.i
+++ b/c/array-crafted/bor2_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[1000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 1000; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[1000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 1000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bor(x);
+  temp=x[0];
+  for(int i =0 ; i<1000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[1000 -1] = temp;
+  ret5 = bor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor3_true-unreach-call.c
+++ b/c/array-crafted/bor3_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 10000
+#define fun bor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor3_true-unreach-call.i
+++ b/c/array-crafted/bor3_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[10000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 10000; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[10000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 10000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bor(x);
+  temp=x[0];
+  for(int i =0 ; i<10000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[10000 -1] = temp;
+  ret5 = bor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor4_true-unreach-call.c
+++ b/c/array-crafted/bor4_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100000
+#define fun bor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor4_true-unreach-call.i
+++ b/c/array-crafted/bor4_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int bor (int x[100000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 100000; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[100000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = bor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = bor(x);
+  temp=x[0];
+  for(int i =0 ; i<100000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100000 -1] = temp;
+  ret5 = bor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/bor5_true-unreach-call.c
+++ b/c/array-crafted/bor5_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define fun bor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int bor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+  
+    ret = fun(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = fun(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = fun(x);
+
+    if(ret != ret2 || ret !=ret5){ 
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/bor5_true-unreach-call.i
+++ b/c/array-crafted/bor5_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int bor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res | x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+
+    ret = bor(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = bor(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = bor(x);
+
+    if(ret != ret2 || ret !=ret5){
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg1_true-unreach-call.c
+++ b/c/array-crafted/mapavg1_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100
+#define fun mapavg
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / N;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg1_true-unreach-call.i
+++ b/c/array-crafted/mapavg1_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[100])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 100; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / 100;
+}
+
+int main ()
+{
+  int x[100];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapavg(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapavg(x);
+  temp=x[0];
+  for(int i =0 ; i<100 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100 -1] = temp;
+  ret5 = mapavg(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg2_true-unreach-call.c
+++ b/c/array-crafted/mapavg2_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 1000
+#define fun mapavg
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / N;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg2_true-unreach-call.i
+++ b/c/array-crafted/mapavg2_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[1000])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 1000; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / 1000;
+}
+
+int main ()
+{
+  int x[1000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 1000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapavg(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapavg(x);
+  temp=x[0];
+  for(int i =0 ; i<1000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[1000 -1] = temp;
+  ret5 = mapavg(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg3_true-unreach-call.c
+++ b/c/array-crafted/mapavg3_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 10000
+#define fun mapavg
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / N;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg3_true-unreach-call.i
+++ b/c/array-crafted/mapavg3_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[10000])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 10000; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / 10000;
+}
+
+int main ()
+{
+  int x[10000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 10000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapavg(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapavg(x);
+  temp=x[0];
+  for(int i =0 ; i<10000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[10000 -1] = temp;
+  ret5 = mapavg(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg4_true-unreach-call.c
+++ b/c/array-crafted/mapavg4_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100000
+#define fun mapavg
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / N;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg4_true-unreach-call.i
+++ b/c/array-crafted/mapavg4_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapavg (int x[100000])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 100000; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret / 100000;
+}
+
+int main ()
+{
+  int x[100000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapavg(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapavg(x);
+  temp=x[0];
+  for(int i =0 ; i<100000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100000 -1] = temp;
+  ret5 = mapavg(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg5_true-unreach-call.c
+++ b/c/array-crafted/mapavg5_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define fun mapavg
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int mapavg (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret + i + x[i];
+  }
+  return ret / N;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+  
+    ret = fun(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = fun(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = fun(x);
+
+    if(ret != ret2 || ret !=ret5){ 
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/mapavg5_true-unreach-call.i
+++ b/c/array-crafted/mapavg5_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int mapavg (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret + i + x[i];
+  }
+  return ret / N;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+
+    ret = mapavg(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = mapavg(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = mapavg(x);
+
+    if(ret != ret2 || ret !=ret5){
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum1_true-unreach-call.c
+++ b/c/array-crafted/mapsum1_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100
+#define fun mapsum
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum1_true-unreach-call.i
+++ b/c/array-crafted/mapsum1_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[100])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 100; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[100];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapsum(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapsum(x);
+  temp=x[0];
+  for(int i =0 ; i<100 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100 -1] = temp;
+  ret5 = mapsum(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum2_true-unreach-call.c
+++ b/c/array-crafted/mapsum2_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 1000
+#define fun mapsum
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum2_true-unreach-call.i
+++ b/c/array-crafted/mapsum2_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[1000])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 1000; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[1000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 1000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapsum(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapsum(x);
+  temp=x[0];
+  for(int i =0 ; i<1000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[1000 -1] = temp;
+  ret5 = mapsum(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum3_true-unreach-call.c
+++ b/c/array-crafted/mapsum3_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 10000
+#define fun mapsum
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum3_true-unreach-call.i
+++ b/c/array-crafted/mapsum3_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[10000])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 10000; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[10000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 10000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapsum(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapsum(x);
+  temp=x[0];
+  for(int i =0 ; i<10000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[10000 -1] = temp;
+  ret5 = mapsum(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum4_true-unreach-call.c
+++ b/c/array-crafted/mapsum4_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100000
+#define fun mapsum
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum4_true-unreach-call.i
+++ b/c/array-crafted/mapsum4_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int mapsum (int x[100000])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < 100000; i++) {
+    ret = ret+ i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  int x[100000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = mapsum(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = mapsum(x);
+  temp=x[0];
+  for(int i =0 ; i<100000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100000 -1] = temp;
+  ret5 = mapsum(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum5_true-unreach-call.c
+++ b/c/array-crafted/mapsum5_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define fun mapsum
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int mapsum (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret + i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+  
+    ret = fun(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = fun(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = fun(x);
+
+    if(ret != ret2 || ret !=ret5){ 
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/mapsum5_true-unreach-call.i
+++ b/c/array-crafted/mapsum5_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int mapsum (int x[N])
+{
+  int i;
+  long long ret;
+  ret = 0;
+  for (i = 0; i < N; i++) {
+    ret = ret + i + x[i];
+  }
+  return ret;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+
+    ret = mapsum(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = mapsum(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = mapsum(x);
+
+    if(ret != ret2 || ret !=ret5){
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/xor1_true-unreach-call.c
+++ b/c/array-crafted/xor1_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100
+#define fun xor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor1_true-unreach-call.i
+++ b/c/array-crafted/xor1_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[100])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 100; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[100];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = xor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = xor(x);
+  temp=x[0];
+  for(int i =0 ; i<100 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100 -1] = temp;
+  ret5 = xor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor2_true-unreach-call.c
+++ b/c/array-crafted/xor2_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 1000
+#define fun xor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor2_true-unreach-call.i
+++ b/c/array-crafted/xor2_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[1000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 1000; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[1000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 1000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = xor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = xor(x);
+  temp=x[0];
+  for(int i =0 ; i<1000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[1000 -1] = temp;
+  ret5 = xor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor3_true-unreach-call.c
+++ b/c/array-crafted/xor3_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 10000
+#define fun xor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor3_true-unreach-call.i
+++ b/c/array-crafted/xor3_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[10000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 10000; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[10000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 10000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = xor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = xor(x);
+  temp=x[0];
+  for(int i =0 ; i<10000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[10000 -1] = temp;
+  ret5 = xor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor4_true-unreach-call.c
+++ b/c/array-crafted/xor4_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define N 100000
+#define fun xor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[N];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < N; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = fun(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = fun(x);
+  temp=x[0];
+  for(int i =0 ; i<N-1; i++){
+     x[i] = x[i+1];
+  }
+  x[N-1] = temp;
+  ret5 = fun(x);
+
+  if(ret != ret2 || ret !=ret5){ 
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor4_true-unreach-call.i
+++ b/c/array-crafted/xor4_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int();
+
+int xor (int x[100000])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < 100000; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  int x[100000];
+  int temp;
+  int ret;
+  int ret2;
+  int ret5;
+
+  for (int i = 0; i < 100000; i++) {
+    x[i] = __VERIFIER_nondet_int();
+  }
+
+  ret = xor(x);
+
+  temp=x[0];x[0] = x[1]; x[1] = temp;
+  ret2 = xor(x);
+  temp=x[0];
+  for(int i =0 ; i<100000 -1; i++){
+     x[i] = x[i+1];
+  }
+  x[100000 -1] = temp;
+  ret5 = xor(x);
+
+  if(ret != ret2 || ret !=ret5){
+    __VERIFIER_error();
+  }
+  return 1;
+}

--- a/c/array-crafted/xor5_true-unreach-call.c
+++ b/c/array-crafted/xor5_true-unreach-call.c
@@ -1,0 +1,45 @@
+#define fun xor
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int xor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+  
+    ret = fun(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = fun(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = fun(x);
+
+    if(ret != ret2 || ret !=ret5){ 
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/xor5_true-unreach-call.i
+++ b/c/array-crafted/xor5_true-unreach-call.i
@@ -1,0 +1,45 @@
+
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+
+int N;
+
+int xor (int x[N])
+{
+  int i;
+  long long res;
+  res = x[0];
+  for (i = 1; i < N; i++) {
+    res = res ^ x[i];
+  }
+  return res;
+}
+
+int main ()
+{
+  N = __VERIFIER_nondet_int();
+  if (N > 1) {
+    int x[N];
+    int temp;
+    int ret;
+    int ret2;
+    int ret5;
+
+    ret = xor(x);
+
+    temp=x[0];x[0] = x[1]; x[1] = temp;
+    ret2 = xor(x);
+    temp=x[0];
+    for(int i =0 ; i<N-1; i++){
+       x[i] = x[i+1];
+    }
+    x[N-1] = temp;
+    ret5 = xor(x);
+
+    if(ret != ret2 || ret !=ret5){
+      __VERIFIER_error();
+    }
+  }
+  return 1;
+}

--- a/c/array-crafted/zero_sum1_true-unreach-call.c
+++ b/c/array-crafted/zero_sum1_true-unreach-call.c
@@ -1,0 +1,29 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum2_true-unreach-call.c
+++ b/c/array-crafted/zero_sum2_true-unreach-call.c
@@ -1,0 +1,40 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum3_true-unreach-call.c
+++ b/c/array-crafted/zero_sum3_true-unreach-call.c
@@ -1,0 +1,50 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+                {
+                        sum = sum + a[i];
+                }
+
+                for(i = 0; i < SIZE; i++)
+                {
+                        sum = sum - a[i];
+                }
+
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum4_true-unreach-call.c
+++ b/c/array-crafted/zero_sum4_true-unreach-call.c
@@ -1,0 +1,59 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+                {
+                        sum = sum + a[i];
+                }
+
+                for(i = 0; i < SIZE; i++)
+                {
+                        sum = sum - a[i];
+                }
+
+		for(i = 0; i < SIZE; i++ )
+                {
+                        sum = sum + a[i];
+                }
+
+                for(i = 0; i < SIZE; i++)
+                {
+                        sum = sum - a[i];
+                }
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum5_true-unreach-call.c
+++ b/c/array-crafted/zero_sum5_true-unreach-call.c
@@ -1,0 +1,70 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+                {
+                        sum = sum + a[i];
+                }
+
+                for(i = 0; i < SIZE; i++)
+                {
+                        sum = sum - a[i];
+                }
+
+		for(i = 0; i < SIZE; i++ )
+                {
+                        sum = sum + a[i];
+                }
+
+                for(i = 0; i < SIZE; i++)
+                {
+                        sum = sum - a[i];
+                }
+		
+		for(i = 0; i < SIZE; i++ )
+                {
+                        sum = sum + a[i];
+                }
+
+                for(i = 0; i < SIZE; i++)
+                {
+                        sum = sum - a[i];
+                }
+		__VERIFIER_assert(sum == 0);
+
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const1_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const1_true-unreach-call.c
@@ -1,0 +1,34 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const2_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const2_true-unreach-call.c
@@ -1,0 +1,44 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const3_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const3_true-unreach-call.c
@@ -1,0 +1,54 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const4_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const4_true-unreach-call.c
@@ -1,0 +1,64 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const5_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const5_true-unreach-call.c
@@ -1,0 +1,74 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const_m2_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const_m2_true-unreach-call.c
@@ -1,0 +1,44 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const_m3_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const_m3_true-unreach-call.c
@@ -1,0 +1,54 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const_m4_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const_m4_true-unreach-call.c
@@ -1,0 +1,64 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_const_m5_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_const_m5_true-unreach-call.c
@@ -1,0 +1,74 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern long __VERIFIER_nondet_long(void);
+
+long SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_long();
+	if(SIZE > 1)
+	{
+		int i;
+		long a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			a[i] = 1;
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_m2_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_m2_true-unreach-call.c
@@ -1,0 +1,39 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_m3_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_m3_true-unreach-call.c
@@ -1,0 +1,50 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_m4_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_m4_true-unreach-call.c
@@ -1,0 +1,59 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}

--- a/c/array-crafted/zero_sum_m5_true-unreach-call.c
+++ b/c/array-crafted/zero_sum_m5_true-unreach-call.c
@@ -1,0 +1,69 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+extern short __VERIFIER_nondet_short(void);
+
+short SIZE;
+
+int main()
+{
+	SIZE = __VERIFIER_nondet_short();
+	if(SIZE > 1)
+	{
+		int i;
+		short a[SIZE];
+		long long sum=0;
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum + a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++)
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum - a[i];
+		}
+
+		for(i = 0; i < SIZE; i++ )
+		{
+			sum = sum - a[i];
+		}
+		__VERIFIER_assert(sum == 0);
+	}
+	return 1;
+}


### PR DESCRIPTION
<!--
  Please describe your PR as usual.

  For submission of new verification tasks,
  keep the following checklist and make sure that all items are fullfilled.
  For other PRs, just remove it.
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
