### PR TITLE
added multi dimensional array follow up of #589 (resolved difference)

### DIFF
--- a/c/ReachSafety-Arrays.set
+++ b/c/ReachSafety-Arrays.set
@@ -16,3 +16,6 @@ array-programs/*_true-unreach-call*.i
 
 array-crafted/*_true-unreach-call*.i
 array-crafted/zero_sum*_true-unreach-call*.c
+
+array-multidimensional/*_true-unreach-call*.i
+

--- a/c/array-multidimensional/License.txt
+++ b/c/array-multidimensional/License.txt
@@ -1,0 +1,1 @@
+../LICENSE.Apache-2.0.txt

--- a/c/array-multidimensional/Makefile
+++ b/c/array-multidimensional/Makefile
@@ -1,0 +1,6 @@
+LEVEL := ../
+
+CLANG_WARNINGS := \
+	-Wno-error=uninitialized \
+
+include $(LEVEL)/Makefile.config

--- a/c/array-multidimensional/ReadMe.txt
+++ b/c/array-multidimensional/ReadMe.txt
@@ -1,0 +1,1 @@
+Benchmarks used in the paper "Extending VIAP to Handle Array Program" which was published at VSTTE 2018 and written by Pritom Rajkhowa and Fangzhen Lin

--- a/c/array-multidimensional/add-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/add-2-n-u_true-unreach-call.c
@@ -1,0 +1,63 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [m][n];
+        int B [m][n];
+        int C [m][n];
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+	
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					C[i][j]=A[i][j]+B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					__VERIFIER_assert(C[i][j]==A[i][j]+B[i][j]);
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+return 0;
+
+}

--- a/c/array-multidimensional/add-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/add-2-n-u_true-unreach-call.c
@@ -6,24 +6,24 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __VERIFIER_nondet_int();
+int __VERIFIER_nondet_uint();
 
 int main()
 {
 
 	int i,j;
 	int m=1000,n=1500;
-	int A [m][n];
-        int B [m][n];
-        int C [m][n];
+	unsigned int A [m][n];
+        unsigned int B [m][n];
+        unsigned int C [m][n];
 
 	i=0;
 	j=0;
 	while(i < m){
 		j=0;
 		while(j < n){
-					A[i][j]=__VERIFIER_nondet_int();
-					B[i][j]=__VERIFIER_nondet_int();
+					A[i][j]=__VERIFIER_nondet_uint();
+					B[i][j]=__VERIFIER_nondet_uint();
 
 			j=j+1;
 		}

--- a/c/array-multidimensional/add-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/add-2-n-u_true-unreach-call.i
@@ -1,0 +1,63 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [m][n];
+        int B [m][n];
+        int C [m][n];
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+	
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					C[i][j]=A[i][j]+B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					__VERIFIER_assert(C[i][j]==A[i][j]+B[i][j]);
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+return 0;
+
+}

--- a/c/array-multidimensional/add-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/add-2-n-u_true-unreach-call.i
@@ -6,24 +6,24 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __VERIFIER_nondet_int();
+int __VERIFIER_nondet_uint();
 
 int main()
 {
 
 	int i,j;
 	int m=1000,n=1500;
-	int A [m][n];
-        int B [m][n];
-        int C [m][n];
+	unsigned int A [m][n];
+        unsigned int B [m][n];
+        unsigned int C [m][n];
 
 	i=0;
 	j=0;
 	while(i < m){
 		j=0;
 		while(j < n){
-					A[i][j]=__VERIFIER_nondet_int();
-					B[i][j]=__VERIFIER_nondet_int();
+					A[i][j]=__VERIFIER_nondet_uint();
+					B[i][j]=__VERIFIER_nondet_uint();
 
 			j=j+1;
 		}

--- a/c/array-multidimensional/add-3-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/add-3-n-u_true-unreach-call.c
@@ -6,16 +6,16 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __VERIFIER_nondet_int();
+int __VERIFIER_nondet_uint();
 
 int main()
 {
 
 	int i,j,k;
 	int m=1000,n=1500,p=1800;
-	int A [m][n][p];
-        int B [m][n][p];
-        int C [m][n][p];
+	unsigned int A [m][n][p];
+        unsigned int B [m][n][p];
+        unsigned int C [m][n][p];
 	
 	i=0;
 	j=0;
@@ -26,8 +26,8 @@ int main()
 		while(j < n){
 			k=0;
 			while(k < p){
-					A[i][j][k]= __VERIFIER_nondet_int();
-                                        B[i][j][k]= __VERIFIER_nondet_int();
+					A[i][j][k]= __VERIFIER_nondet_uint();
+                                        B[i][j][k]= __VERIFIER_nondet_uint();
 					k=k+1;
 			}
 			j=j+1;

--- a/c/array-multidimensional/add-3-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/add-3-n-u_true-unreach-call.c
@@ -1,0 +1,75 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+        int B [m][n][p];
+        int C [m][n][p];
+	
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+                                        B[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					C[i][j][k]=A[i][j][k]+B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(C[i][j][k]==A[i][j][k]+B[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/add-3-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/add-3-n-u_true-unreach-call.i
@@ -6,16 +6,16 @@ void __VERIFIER_assert(int cond) {
   }
   return;
 }
-int __VERIFIER_nondet_int();
+int __VERIFIER_nondet_uint();
 
 int main()
 {
 
 	int i,j,k;
 	int m=1000,n=1500,p=1800;
-	int A [m][n][p];
-        int B [m][n][p];
-        int C [m][n][p];
+	unsigned int A [m][n][p];
+        unsigned int B [m][n][p];
+        unsigned int C [m][n][p];
 	
 	i=0;
 	j=0;
@@ -26,8 +26,8 @@ int main()
 		while(j < n){
 			k=0;
 			while(k < p){
-					A[i][j][k]= __VERIFIER_nondet_int();
-                                        B[i][j][k]= __VERIFIER_nondet_int();
+					A[i][j][k]= __VERIFIER_nondet_uint();
+                                        B[i][j][k]= __VERIFIER_nondet_uint();
 					k=k+1;
 			}
 			j=j+1;

--- a/c/array-multidimensional/add-3-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/add-3-n-u_true-unreach-call.i
@@ -1,0 +1,75 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+        int B [m][n][p];
+        int C [m][n][p];
+	
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+                                        B[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					C[i][j][k]=A[i][j][k]+B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(C[i][j][k]==A[i][j][k]+B[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-2-u_true-unreach-call.c
+++ b/c/array-multidimensional/copy-2-u_true-unreach-call.c
@@ -1,0 +1,64 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int n=1000;
+	int A [n][n];
+        int B [n][n];
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+			
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+			
+					A[i][j]=B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+			
+                            __VERIFIER_assert(A[i][j]==B[i][j]);
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-2-u_true-unreach-call.i
+++ b/c/array-multidimensional/copy-2-u_true-unreach-call.i
@@ -1,0 +1,64 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int n=1000;
+	int A [n][n];
+        int B [n][n];
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+			
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+			
+					A[i][j]=B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+			
+                            __VERIFIER_assert(A[i][j]==B[i][j]);
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-3-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/copy-3-n-u_true-unreach-call.c
@@ -1,0 +1,77 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+	int B [m][n][p];
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					B[i][j][k]=__VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]=B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(A[i][j][k]==B[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-3-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/copy-3-n-u_true-unreach-call.i
@@ -1,0 +1,77 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+	int B [m][n][p];
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					B[i][j][k]=__VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]=B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(A[i][j][k]==B[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-partial-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/copy-partial-2-n-u_true-unreach-call.c
@@ -1,0 +1,69 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int q=500,s=700;
+	int A [m][n];
+        int B [m][n];
+
+
+	__VERIFIER_assume(q<m);
+	__VERIFIER_assume(s<n);
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+                    
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+	i=0;
+	j=0;
+	while(i < q){
+		j=0;
+		while(j < s){
+                    
+					A[i][j]=B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < q){
+		j=0;
+		while(j < s){
+
+                                __VERIFIER_assert(A[i][j]==B[i][j]);
+
+                                j=j+1;
+		}
+		i=i+1;
+    }
+
+return 0;
+
+}

--- a/c/array-multidimensional/copy-partial-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/copy-partial-2-n-u_true-unreach-call.i
@@ -1,0 +1,67 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int q=500,s=700;
+	int A [m][n];
+        int B [m][n];
+
+
+	__VERIFIER_assume(q<m);
+	__VERIFIER_assume(s<n);
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+                    
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+	i=0;
+	j=0;
+	while(i < q){
+		j=0;
+		while(j < s){
+                    
+					A[i][j]=B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < q){
+		j=0;
+		while(j < s){
+
+                                __VERIFIER_assert(A[i][j]==B[i][j]);
+
+                                j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-partial-3-u_true-unreach-call.c
+++ b/c/array-multidimensional/copy-partial-3-u_true-unreach-call.c
@@ -1,0 +1,81 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int p=500;
+	int A [n][n][n];
+        int B [n][n][n];
+	__VERIFIER_assume(p<n);
+        
+
+	i=0;
+	j=0;
+	k=0;
+
+	while(i < p){
+		j=0;
+		k=0;
+		while(j < p){
+			k=0;
+			while(k < p){
+					B[i][j][k] = __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+
+	while(i < p){
+		j=0;
+		k=0;
+		while(j < p){
+			k=0;
+			while(k < p){
+					A[i][j][k]=B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==A[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/copy-partial-3-u_true-unreach-call.i
+++ b/c/array-multidimensional/copy-partial-3-u_true-unreach-call.i
@@ -1,0 +1,81 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int p=500;
+	int A [n][n][n];
+        int B [n][n][n];
+	__VERIFIER_assume(p<n);
+        
+
+	i=0;
+	j=0;
+	k=0;
+
+	while(i < p){
+		j=0;
+		k=0;
+		while(j < p){
+			k=0;
+			while(k < p){
+					B[i][j][k] = __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+
+	while(i < p){
+		j=0;
+		k=0;
+		while(j < p){
+			k=0;
+			while(k < p){
+					A[i][j][k]=B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==A[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/diff-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/diff-2-n-u_true-unreach-call.c
@@ -1,0 +1,78 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [m][n];
+        int B [m][n];
+        int C [m][n];
+	
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+                                        B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					C[i][j]=A[i][j]-B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					__VERIFIER_assert(C[i][j]==A[i][j]-B[i][j]);
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+return 0;
+
+}

--- a/c/array-multidimensional/diff-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/diff-2-n-u_true-unreach-call.i
@@ -1,0 +1,78 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [m][n];
+        int B [m][n];
+        int C [m][n];
+	
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+                                        B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					C[i][j]=A[i][j]-B[i][j];
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					__VERIFIER_assert(C[i][j]==A[i][j]-B[i][j]);
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+return 0;
+
+}

--- a/c/array-multidimensional/diff-3-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/diff-3-n-u_true-unreach-call.c
@@ -1,0 +1,80 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+        int B [m][n][p];
+        int C [m][n][p];
+	
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+                                        B[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					C[i][j][k]=A[i][j][k]+B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(C[i][j][k]==A[i][j][k]+B[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/diff-3-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/diff-3-n-u_true-unreach-call.i
@@ -1,0 +1,80 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+        int B [m][n][p];
+        int C [m][n][p];
+	
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+                                        B[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					C[i][j][k]=A[i][j][k]+B[i][j][k];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(C[i][j][k]==A[i][j][k]+B[i][j][k]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/init-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/init-2-n-u_true-unreach-call.c
@@ -1,0 +1,47 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [m][n];
+	int C=__VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+
+                        A[i][j]=C;
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+
+                        __VERIFIER_assert(A[i][j]==C);
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+return 0;
+}

--- a/c/array-multidimensional/init-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/init-2-n-u_true-unreach-call.i
@@ -1,0 +1,47 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [m][n];
+	int C=__VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+
+                        A[i][j]=C;
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+
+                        __VERIFIER_assert(A[i][j]==C);
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+return 0;
+
+}

--- a/c/array-multidimensional/init-3-u_true-unreach-call.c
+++ b/c/array-multidimensional/init-3-u_true-unreach-call.c
@@ -1,0 +1,56 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int A [n][n][n];
+	int C=__VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					A[i][j][k]=C;
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==C);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/init-3-u_true-unreach-call.i
+++ b/c/array-multidimensional/init-3-u_true-unreach-call.i
@@ -1,0 +1,56 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int A [n][n][n];
+	int C=__VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					A[i][j][k]=C;
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==C);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/init-4-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/init-4-n-u_true-unreach-call.c
@@ -1,0 +1,72 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k,l;
+	int m=1000,n=1500,p=1800,q=2000;
+	int A [m][n][p][q];
+	int C=__VERIFIER_nondet_int();
+        
+        
+
+	i=0;
+	j=0;
+	k=0;
+        l=0;
+	while(i < m){
+		j=0;
+		k=0;
+                l=0;
+		while(j < n){
+			k=0;
+                        l=0;
+			while(k < p){
+                            l=0;
+                            while(l < q){
+					A[i][j][k][l]=C;
+                                        l=l+1;
+                                        }
+                        k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	k=0;
+        l=0;
+	while(i < m){
+		j=0;
+		k=0;
+                l=0;
+		while(j < n){
+			k=0;
+                        l=0;
+			while(k < p){
+                            l=0;
+                            while(l < q){
+					__VERIFIER_assert(A[i][j][k][l]==C);
+					l=l+1;
+                                }
+                                k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+return 0;
+}

--- a/c/array-multidimensional/init-4-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/init-4-n-u_true-unreach-call.i
@@ -1,0 +1,72 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k,l;
+	int m=1000,n=1500,p=1800,q=2000;
+	int A [m][n][p][q];
+	int C=__VERIFIER_nondet_int();
+        
+        
+
+	i=0;
+	j=0;
+	k=0;
+        l=0;
+	while(i < m){
+		j=0;
+		k=0;
+                l=0;
+		while(j < n){
+			k=0;
+                        l=0;
+			while(k < p){
+                            l=0;
+                            while(l < q){
+					A[i][j][k][l]=C;
+                                        l=l+1;
+                                        }
+                        k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	k=0;
+        l=0;
+	while(i < m){
+		j=0;
+		k=0;
+                l=0;
+		while(j < n){
+			k=0;
+                        l=0;
+			while(k < p){
+                            l=0;
+                            while(l < q){
+					__VERIFIER_assert(A[i][j][k][l]==C);
+					l=l+1;
+                                }
+                                k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+return 0;
+
+}

--- a/c/array-multidimensional/init-non-constant-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/init-non-constant-2-n-u_true-unreach-call.c
@@ -1,0 +1,51 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int q,s;
+	int A [m][n];
+	int C=__VERIFIER_nondet_int();
+        
+        q= __VERIFIER_nondet_int();
+        s= __VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	__VERIFIER_assume(q<m);
+	__VERIFIER_assume(s<n);
+
+	while(i < q){
+		j=0;
+		while(j < s){
+                        A[i][j]=i+j+C;
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < q){
+		j=0;
+		while(j < s){
+                        __VERIFIER_assert(A[i][j]==i+j+C);
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+return 0;
+
+}

--- a/c/array-multidimensional/init-non-constant-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/init-non-constant-2-n-u_true-unreach-call.i
@@ -1,0 +1,51 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_assume(int);
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int q,s;
+	int A [m][n];
+	int C=__VERIFIER_nondet_int();
+        
+        q= __VERIFIER_nondet_int();
+        s= __VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	__VERIFIER_assume(q<m);
+	__VERIFIER_assume(s<n);
+
+	while(i < q){
+		j=0;
+		while(j < s){
+                        A[i][j]=i+j+C;
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < q){
+		j=0;
+		while(j < s){
+                        __VERIFIER_assert(A[i][j]==i+j+C);
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+return 0;
+
+}

--- a/c/array-multidimensional/init-non-constant-3-u_true-unreach-call.c
+++ b/c/array-multidimensional/init-non-constant-3-u_true-unreach-call.c
@@ -1,0 +1,56 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int A [n][n][n];
+	int C=__VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					A[i][j][k]=i+j+k+C;
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==i+j+k+C);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/init-non-constant-3-u_true-unreach-call.i
+++ b/c/array-multidimensional/init-non-constant-3-u_true-unreach-call.i
@@ -1,0 +1,56 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int A [n][n][n];
+	int C=__VERIFIER_nondet_int();
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					A[i][j][k]=i+j+k+C;
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==i+j+k+C);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/max-2-u_true-unreach-call.c
+++ b/c/array-multidimensional/max-2-u_true-unreach-call.c
@@ -1,0 +1,62 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [n][n];
+	int max;
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+        max=A [0][0];
+	while(i < n){
+		j=0;
+		while(j < n){
+			if(A[i][j]>max){
+                            max=A[i][j];
+                        }
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+                    
+			__VERIFIER_assert(A[i][j]<=max);
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/max-2-u_true-unreach-call.i
+++ b/c/array-multidimensional/max-2-u_true-unreach-call.i
@@ -1,0 +1,62 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [n][n];
+	int max;
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+        max=A [0][0];
+	while(i < n){
+		j=0;
+		while(j < n){
+			if(A[i][j]>max){
+                            max=A[i][j];
+                        }
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+                    
+			__VERIFIER_assert(A[i][j]<=max);
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/max-3-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/max-3-n-u_true-unreach-call.c
@@ -1,0 +1,78 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+	int max;
+        
+        
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+        
+
+	i=0;
+	j=0;
+	k=0;
+        max=A [0][0][0];
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+                                    if(A[i][j][k]>max){
+					max=A[i][j][k];}
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(A[i][j][k]<=max);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/max-3-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/max-3-n-u_true-unreach-call.i
@@ -1,0 +1,78 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+	int max;
+        
+        
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+        
+
+	i=0;
+	j=0;
+	k=0;
+        max=A [0][0][0];
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+                                    if(A[i][j][k]>max){
+					max=A[i][j][k];}
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(A[i][j][k]<=max);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/min-2-u_true-unreach-call.c
+++ b/c/array-multidimensional/min-2-u_true-unreach-call.c
@@ -1,0 +1,62 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [n][n];
+	int min;
+        
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+        min=A [0][0];
+	while(i < n){
+		j=0;
+		while(j < n){
+			if(A[i][j]<min){
+                            min=A[i][j];
+                        }
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+                    
+			__VERIFIER_assert(A[i][j]>=min);
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/min-2-u_true-unreach-call.i
+++ b/c/array-multidimensional/min-2-u_true-unreach-call.i
@@ -1,0 +1,62 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500;
+	int A [n][n];
+	int min;
+        
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					A[i][j]=__VERIFIER_nondet_int();
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+        min=A [0][0];
+	while(i < n){
+		j=0;
+		while(j < n){
+			if(A[i][j]<min){
+                            min=A[i][j];
+                        }
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < n){
+		j=0;
+		while(j < n){
+                    
+			__VERIFIER_assert(A[i][j]>=min);
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/min-3-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/min-3-n-u_true-unreach-call.c
@@ -1,0 +1,77 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+	int min;
+        
+        
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	k=0;
+        min=A [0][0][0];
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+                                    if(A[i][j][k]<min){
+					min=A[i][j][k];}
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(A[i][j][k]>=min);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/min-3-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/min-3-n-u_true-unreach-call.i
@@ -1,0 +1,77 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int m=1000,n=1500,p=1800;
+	int A [m][n][p];
+	int min;
+        
+        
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					A[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	k=0;
+        min=A [0][0][0];
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+                                    if(A[i][j][k]<min){
+					min=A[i][j][k];}
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < m){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < p){
+					__VERIFIER_assert(A[i][j][k]>=min);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/rev-2-n-u_true-unreach-call.c
+++ b/c/array-multidimensional/rev-2-n-u_true-unreach-call.c
@@ -1,0 +1,63 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500,p=1800;
+	int A [m][n];
+	int B [m][n];
+        
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+			
+                            A[i][j]=B[m-i-1][n-j-1];
+			
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+			
+                            __VERIFIER_assert(A[i][j]==B[m-i-1][n-j-1]);
+		
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/rev-2-n-u_true-unreach-call.i
+++ b/c/array-multidimensional/rev-2-n-u_true-unreach-call.i
@@ -1,0 +1,63 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j;
+	int m=1000,n=1500,p=1800;
+	int A [m][n];
+	int B [m][n];
+        
+        
+        
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+					B[i][j]=__VERIFIER_nondet_int();
+
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+			
+                            A[i][j]=B[m-i-1][n-j-1];
+			
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	while(i < m){
+		j=0;
+		while(j < n){
+			
+                            __VERIFIER_assert(A[i][j]==B[m-i-1][n-j-1]);
+		
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/rev-3-u_true-unreach-call.c
+++ b/c/array-multidimensional/rev-3-u_true-unreach-call.c
@@ -1,0 +1,77 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int A [n][n][n];
+        int B [n][n][n];
+        
+        
+        
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+                                        B[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					A[i][j][k]=B[n-i-1][n-j-1][n-k-1];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==B[n-i-1][n-j-1][n-k-1]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/rev-3-u_true-unreach-call.i
+++ b/c/array-multidimensional/rev-3-u_true-unreach-call.i
@@ -1,0 +1,77 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: __VERIFIER_error();
+  }
+  return;
+}
+int __VERIFIER_nondet_int();
+
+int main()
+{
+
+	int i,j,k;
+	int n=1000;
+	int A [n][n][n];
+        int B [n][n][n];
+        
+        
+        
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+                                        B[i][j][k]= __VERIFIER_nondet_int();
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					A[i][j][k]=B[n-i-1][n-j-1][n-k-1];
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+
+
+
+
+	i=0;
+	j=0;
+	k=0;
+	while(i < n){
+		j=0;
+		k=0;
+		while(j < n){
+			k=0;
+			while(k < n){
+					__VERIFIER_assert(A[i][j][k]==B[n-i-1][n-j-1][n-k-1]);
+					k=k+1;
+			}
+			j=j+1;
+		}
+		i=i+1;
+    }
+return 0;
+}

--- a/c/array-multidimensional/transpose-u_true-unreach-call.c
+++ b/c/array-multidimensional/transpose-u_true-unreach-call.c
@@ -1,0 +1,40 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int __VERIFIER_nondet_int();
+int main()
+{
+
+	int i;
+	int k;
+	int j;
+	int n=1000;
+        int m=1800;
+	int A[n][n];
+	int C[n][n];
+
+	for ( i = 0 ; i < n ; i++ ){
+          for ( j = 0 ; j < n ; j++ ){
+                A[i][j]= __VERIFIER_nondet_int();
+          }
+    }
+
+
+	i=0;
+	j=0;
+
+	while(i < n){
+		  j=0;
+           while(j < n){
+                C[j][i] = A[i][j];
+		  		j=j+1;
+          }
+	i=i+1;
+    }
+
+	for ( i = 0 ; i < n ; i++ ){
+          for ( j = 0 ; j < n ; j++ ){
+                __VERIFIER_assert(C[i][j] == A[i][j]);
+          }
+    }
+return 0;
+}

--- a/c/array-multidimensional/transpose-u_true-unreach-call.i
+++ b/c/array-multidimensional/transpose-u_true-unreach-call.i
@@ -1,0 +1,40 @@
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: __VERIFIER_error(); } }
+int __VERIFIER_nondet_int();
+int main()
+{
+
+	int i;
+	int k;
+	int j;
+	int n=1000;
+        int m=1800;
+	int A[n][n];
+	int C[n][n];
+
+	for ( i = 0 ; i < n ; i++ ){
+          for ( j = 0 ; j < n ; j++ ){
+                A[i][j]= __VERIFIER_nondet_int();
+          }
+    }
+
+
+	i=0;
+	j=0;
+
+	while(i < n){
+		  j=0;
+           while(j < n){
+                C[j][i] = A[i][j];
+		  		j=j+1;
+          }
+	i=i+1;
+    }
+
+	for ( i = 0 ; i < n ; i++ ){
+          for ( j = 0 ; j < n ; j++ ){
+                __VERIFIER_assert(C[i][j] == A[i][j]);
+          }
+    }
+return 0;
+}


### PR DESCRIPTION


<!--
  added multidimensional array follow up of #589 (resolved difference)
-->

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [x] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [x] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [x] original sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
