### PR TITLE
fix typo in function names: __VEFIRIER -> __VERIFIER

### DIFF
--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.i
@@ -12137,9 +12137,9 @@ int ldv_atomic_dec_and_lock_siglock_of_sighand_struct(void)
   return (0);
 }
 }
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 void free(void *);
 void kfree(void const *p) {
@@ -12148,9 +12148,9 @@ void kfree(void const *p) {
 void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2){
   return;
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 size_t vb2_read(struct vb2_queue *arg0, char *arg1, size_t arg2, loff_t *arg3, int arg4){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 void debug_dma_alloc_coherent(struct device *arg0, size_t arg1, dma_addr_t arg2, void *arg3){
   return;
@@ -12161,13 +12161,13 @@ void __raw_spin_lock_init(raw_spinlock_t *arg0, const char *arg1, struct lock_cl
 void vb2_buffer_done(struct vb2_buffer *arg0, enum vb2_buffer_state arg1){
   return;
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int video_ioctl2(struct file *arg0, unsigned int arg1, unsigned long arg2){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __const_udelay(unsigned long arg0){
   return;
@@ -12186,9 +12186,9 @@ void *external_alloc(void);
 struct v4l2_subdev *v4l2_i2c_new_subdev_board(struct v4l2_device *arg0, struct i2c_adapter *arg1, struct i2c_board_info *arg2, const unsigned short *arg3){
   return (struct v4l2_subdev *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_streamon(struct vb2_queue *arg0, enum v4l2_buf_type arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void debug_dma_unmap_sg(struct device *arg0, struct scatterlist *arg1, int arg2, int arg3){
   return;
@@ -12211,9 +12211,9 @@ void ldv_after_alloc(void *arg0){
 void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3){
   return;
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 size_t strlcpy(char *arg0, const char *arg1, size_t arg2){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 void vb2_dma_contig_cleanup_ctx(void *arg0){
   return;
@@ -12221,9 +12221,9 @@ void vb2_dma_contig_cleanup_ctx(void *arg0){
 void iowrite32(u32 arg0, void *arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_queue_init(struct vb2_queue *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __tasklet_schedule(struct tasklet_struct *arg0){
   return;
@@ -12245,13 +12245,13 @@ void *external_alloc(void);
 void *vb2_dma_contig_init_ctx(struct device *arg0){
   return (void *)external_alloc();
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int v4l2_device_register(struct device *arg0, struct v4l2_device *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __ldv_spin_lock(spinlock_t *arg0){
   return;
@@ -12259,13 +12259,13 @@ void __ldv_spin_lock(spinlock_t *arg0){
 void ldv_switch_to_process_context(){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_mmap(struct vb2_queue *arg0, struct vm_area_struct *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_dqbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1, bool arg2){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void *external_alloc(void);
 void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2){
@@ -12274,9 +12274,9 @@ void *pci_iomap(struct pci_dev *arg0, int arg1, unsigned long arg2){
 void pci_iounmap(struct pci_dev *arg0, void *arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void tasklet_init(struct tasklet_struct *arg0, void (*arg1)(unsigned long), unsigned long arg2){
   return;
@@ -12290,20 +12290,20 @@ void ldv_pre_probe(){
 void vb2_queue_release(struct vb2_queue *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void pci_disable_device(struct pci_dev *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_qbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
@@ -12332,24 +12332,24 @@ void i2c_del_adapter(struct i2c_adapter *arg0){
 void video_unregister_device(struct video_device *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_querybuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void debug_dma_map_sg(struct device *arg0, struct scatterlist *arg1, int arg2, int arg3, int arg4){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int v4l2_ctrl_handler_init_class(struct v4l2_ctrl_handler *arg0, unsigned int arg1, struct lock_class_key *arg2, const char *arg3){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_warn(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int schedule_timeout(long arg0){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 void _raw_spin_lock(raw_spinlock_t *arg0){
   return;
@@ -12361,38 +12361,38 @@ void *vb2_plane_vaddr(struct vb2_buffer *arg0, unsigned int arg1){
 void debug_dma_free_coherent(struct device *arg0, size_t arg1, void *arg2, dma_addr_t arg3){
   return;
 }
-unsigned int __VEFIRIER_nondet_uint(void);
+unsigned int __VERIFIER_nondet_uint(void);
 unsigned int ioread32(void *arg0){
-  return __VEFIRIER_nondet_uint();
+  return __VERIFIER_nondet_uint();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __video_register_device(struct video_device *arg0, int arg1, int arg2, int arg3, struct module *arg4){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_streamoff(struct vb2_queue *arg0, enum v4l2_buf_type arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void *external_alloc(void);
 void *memcpy(void *arg0, const void *arg1, size_t arg2){
   return (void *)external_alloc();
 }
-unsigned int __VEFIRIER_nondet_uint(void);
+unsigned int __VERIFIER_nondet_uint(void);
 unsigned int vb2_poll(struct vb2_queue *arg0, struct file *arg1, poll_table *arg2){
-  return __VEFIRIER_nondet_uint();
+  return __VERIFIER_nondet_uint();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int pci_save_state(struct pci_dev *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void finish_wait(wait_queue_head_t *arg0, wait_queue_t *arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int i2c_add_adapter(struct i2c_adapter *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_reqbufs(struct vb2_queue *arg0, struct v4l2_requestbuffers *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.i
@@ -12747,9 +12747,9 @@ int ldv_atomic_dec_and_lock_tx_global_lock_of_net_device(void)
   return (0);
 }
 }
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 void free(void *);
 void kfree(void const *p) {
@@ -12762,9 +12762,9 @@ struct platform_device *platform_device_register_full(const struct platform_devi
 void debug_dma_alloc_coherent(struct device *arg0, size_t arg1, dma_addr_t arg2, void *arg3){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int async_wrap_skb(struct sk_buff *arg0, __u8 *arg1, int arg2){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void async_unwrap_char(struct net_device *arg0, struct net_device_stats *arg1, iobuff_t *arg2, __u8 arg3){
   return;
@@ -12782,9 +12782,9 @@ void consume_skb(struct sk_buff *arg0){
 void __const_udelay(unsigned long arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int sprintf(char *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1){
   return;
@@ -12801,9 +12801,9 @@ void ldv_after_alloc(void *arg0){
 void irda_qos_bits_to_value(struct qos_info *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netif_rx(struct sk_buff *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void pnp_unregister_driver(struct pnp_driver *arg0){
   return;
@@ -12845,16 +12845,16 @@ void *external_alloc(void);
 struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, gfp_t arg2){
   return (struct sk_buff *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void warn_slowpath_null(const char *arg0, const int arg1){
   return;
 }
-bool __VEFIRIER_nondet_bool(void);
+bool __VERIFIER_nondet_bool(void);
 bool capable(int arg0){
-  return __VEFIRIER_nondet_bool();
+  return __VERIFIER_nondet_bool();
 }
 void *external_alloc(void);
 unsigned char *skb_put(struct sk_buff *arg0, unsigned int arg1){
@@ -12866,16 +12866,16 @@ void do_gettimeofday(struct timeval *arg0){
 void netif_device_detach(struct net_device *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int net_ratelimit(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __udelay(unsigned long arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int request_dma(unsigned int arg0, const char *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void *external_alloc(void);
 void *external_allocated_data(){
@@ -12884,9 +12884,9 @@ void *external_allocated_data(){
 void irlap_close(struct irlap_cb *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_register_netdev(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void _raw_spin_lock(raw_spinlock_t *arg0){
   return;
@@ -12913,9 +12913,9 @@ void *external_alloc(void);
 struct irlap_cb *irlap_open(struct net_device *arg0, struct qos_info *arg1, const char *arg2){
   return (struct irlap_cb *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netpoll_trap(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void irda_device_set_media_busy(struct net_device *arg0, int arg1){
   return;
@@ -12923,7 +12923,7 @@ void irda_device_set_media_busy(struct net_device *arg0, int arg1){
 void __netif_schedule(struct Qdisc *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int pnp_register_driver(struct pnp_driver *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.i
@@ -10056,9 +10056,9 @@ int ldv_atomic_dec_and_lock_tx_global_lock_of_net_device(void)
   return (0);
 }
 }
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 void free(void *);
 void kfree(void const *p) {
@@ -10067,9 +10067,9 @@ void kfree(void const *p) {
 void debug_dma_alloc_coherent(struct device *arg0, size_t arg1, dma_addr_t arg2, void *arg3){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int async_wrap_skb(struct sk_buff *arg0, __u8 *arg1, int arg2){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void async_unwrap_char(struct net_device *arg0, struct net_device_stats *arg1, iobuff_t *arg2, __u8 arg3){
   return;
@@ -10083,9 +10083,9 @@ void consume_skb(struct sk_buff *arg0){
 void __const_udelay(unsigned long arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int sprintf(char *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1){
   return;
@@ -10099,9 +10099,9 @@ void ldv_after_alloc(void *arg0){
 void irda_qos_bits_to_value(struct qos_info *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netif_rx(struct sk_buff *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void ldv_switch_to_interrupt_context(){
   return;
@@ -10125,16 +10125,16 @@ void *external_alloc(void);
 struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, gfp_t arg2){
   return (struct sk_buff *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void warn_slowpath_null(const char *arg0, const int arg1){
   return;
 }
-bool __VEFIRIER_nondet_bool(void);
+bool __VERIFIER_nondet_bool(void);
 bool capable(int arg0){
-  return __VEFIRIER_nondet_bool();
+  return __VERIFIER_nondet_bool();
 }
 void *external_alloc(void);
 unsigned char *skb_put(struct sk_buff *arg0, unsigned int arg1){
@@ -10143,13 +10143,13 @@ unsigned char *skb_put(struct sk_buff *arg0, unsigned int arg1){
 void __udelay(unsigned long arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int request_dma(unsigned int arg0, const char *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int net_ratelimit(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void *external_alloc(void);
 void *external_allocated_data(){
@@ -10158,9 +10158,9 @@ void *external_allocated_data(){
 void irlap_close(struct irlap_cb *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_register_netdev(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void *external_alloc(void);
 struct resource *__request_region(struct resource *arg0, resource_size_t arg1, resource_size_t arg2, const char *arg3, int arg4){
@@ -10184,9 +10184,9 @@ void *external_alloc(void);
 struct irlap_cb *irlap_open(struct net_device *arg0, struct qos_info *arg1, const char *arg2){
   return (struct irlap_cb *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netpoll_trap(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void irda_device_set_media_busy(struct net_device *arg0, int arg1){
   return;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.i
@@ -7062,9 +7062,9 @@ int ldv_atomic_dec_and_lock_siglock_of_sighand_struct(void)
   return (0);
 }
 }
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 void free(void *);
 void kfree(void const *p) {
@@ -7085,17 +7085,17 @@ void __const_udelay(unsigned long arg0){
 void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int reset_control_assert(struct reset_control *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int platform_get_irq(struct platform_device *arg0, unsigned int arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int devm_spi_register_master(struct device *arg0, struct spi_master *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void ldv_after_alloc(void *arg0){
   return;
@@ -7103,21 +7103,21 @@ void ldv_after_alloc(void *arg0){
 void debug_dma_sync_single_for_cpu(struct device *arg0, dma_addr_t arg1, size_t arg2, int arg3){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int clk_enable(struct clk *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int wait_for_completion_interruptible_timeout(struct completion *arg0, unsigned long arg1){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 void *external_alloc(void);
 struct dma_chan *dma_request_slave_channel_reason(struct device *arg0, const char *arg1){
   return (struct dma_chan *)external_alloc();
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 void ldv_switch_to_interrupt_context(){
   return;
@@ -7125,9 +7125,9 @@ void ldv_switch_to_interrupt_context(){
 void __pm_runtime_disable(struct device *arg0, bool arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int reset_control_deassert(struct reset_control *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void ldv_check_alloc_flags(gfp_t arg0){
   return;
@@ -7136,16 +7136,16 @@ void *external_alloc(void);
 struct resource *platform_get_resource(struct platform_device *arg0, unsigned int arg1, unsigned int arg2){
   return (struct resource *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int clk_set_rate(struct clk *arg0, unsigned long arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void sg_init_table(struct scatterlist *arg0, unsigned int arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __pm_runtime_resume(struct device *arg0, int arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __ldv_spin_lock(spinlock_t *arg0){
   return;
@@ -7166,21 +7166,21 @@ void *external_alloc(void);
 struct reset_control *devm_reset_control_get(struct device *arg0, const char *arg1){
   return (struct reset_control *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int msecs_to_jiffies(const unsigned int arg0){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int spi_master_resume(struct spi_master *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void pm_runtime_enable(struct device *arg0){
   return;
@@ -7200,13 +7200,13 @@ struct clk *devm_clk_get(struct device *arg0, const char *arg1){
 void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __pm_runtime_idle(struct device *arg0, int arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int spi_master_suspend(struct spi_master *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void debug_dma_free_coherent(struct device *arg0, size_t arg1, void *arg2, dma_addr_t arg3){
   return;
@@ -7218,9 +7218,9 @@ void *external_alloc(void);
 void *memcpy(void *arg0, const void *arg1, size_t arg2){
   return (void *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int clk_prepare(struct clk *arg0){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void dma_release_channel(struct dma_chan *arg0){
   return;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.i
@@ -8116,9 +8116,9 @@ int ldv_atomic_dec_and_lock_siglock_of_sighand_struct(void)
   return (0);
 }
 }
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 void free(void *);
 void kfree(void const *p) {
@@ -8127,20 +8127,20 @@ void kfree(void const *p) {
 void __raw_spin_lock_init(raw_spinlock_t *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_submit_urb(struct urb *arg0, gfp_t arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int _dev_info(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void remove_wait_queue(wait_queue_head_t *arg0, wait_queue_t *arg1){
   return;
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_to_user(void *arg0, const void *arg1, unsigned int arg2){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1){
   return;
@@ -8151,9 +8151,9 @@ void ldv_after_alloc(void *arg0){
 void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_register_dev(struct usb_interface *arg0, struct usb_class_driver *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void usb_free_urb(struct urb *arg0){
   return;
@@ -8173,20 +8173,20 @@ void __ldv_spin_lock(spinlock_t *arg0){
 void might_fault(){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void ldv_pre_probe(){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
@@ -8194,13 +8194,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
 void usb_deregister_dev(struct usb_interface *arg0, struct usb_class_driver *arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_usb_register_driver(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 void __copy_to_user_overflow(){
   return;
@@ -8215,9 +8215,9 @@ void add_wait_queue(wait_queue_head_t *arg0, wait_queue_t *arg1){
 void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int schedule_timeout(long arg0){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 void __copy_from_user_overflow(){
   return;
@@ -8225,9 +8225,9 @@ void __copy_from_user_overflow(){
 void _raw_spin_lock(raw_spinlock_t *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_string(struct usb_device *arg0, int arg1, char *arg2, size_t arg3){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void *external_alloc(void);
 struct urb *usb_alloc_urb(int arg0, gfp_t arg1){
@@ -8241,7 +8241,7 @@ void *external_alloc(void);
 struct usb_interface *usb_find_interface(struct usb_driver *arg0, int arg1){
   return (struct usb_interface *)external_alloc();
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_from_user(void *arg0, const void *arg1, unsigned int arg2){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.i
@@ -7685,9 +7685,9 @@ int ldv_atomic_dec_and_lock_siglock_of_sighand_struct(void)
   return (0);
 }
 }
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 void free(void *);
 void kfree(void const *p) {
@@ -7696,25 +7696,25 @@ void kfree(void const *p) {
 void __raw_spin_lock_init(raw_spinlock_t *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_submit_urb(struct urb *arg0, gfp_t arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int _dev_info(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 size_t strlen(const char *arg0){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int memcmp(const void *arg0, const void *arg1, size_t arg2){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_to_user(void *arg0, const void *arg1, unsigned int arg2){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 void *external_alloc(void);
 char *kasprintf(gfp_t arg0, const char *arg1, ...){
@@ -7727,9 +7727,9 @@ void *external_alloc(void);
 void *usb_alloc_coherent(struct usb_device *arg0, size_t arg1, gfp_t arg2, dma_addr_t *arg3){
   return (void *)external_alloc();
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_control_msg(struct usb_device *arg0, unsigned int arg1, __u8 arg2, __u8 arg3, __u16 arg4, __u16 arg5, void *arg6, __u16 arg7, int arg8){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void ldv_after_alloc(void *arg0){
   return;
@@ -7737,9 +7737,9 @@ void ldv_after_alloc(void *arg0){
 void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_register_dev(struct usb_interface *arg0, struct usb_class_driver *arg1){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void usb_free_urb(struct urb *arg0){
   return;
@@ -7753,23 +7753,23 @@ void usb_kill_urb(struct urb *arg0){
 void ldv_check_alloc_flags(gfp_t arg0){
   return;
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 void might_fault(){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void ldv_pre_probe(){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2){
   return;
@@ -7777,13 +7777,13 @@ void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *a
 void usb_deregister_dev(struct usb_interface *arg0, struct usb_class_driver *arg1){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_usb_register_driver(){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2){
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 void __copy_to_user_overflow(){
   return;
@@ -7801,9 +7801,9 @@ void __copy_from_user_overflow(){
 void _raw_spin_lock(raw_spinlock_t *arg0){
   return;
 }
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_string(struct usb_device *arg0, int arg1, char *arg2, size_t arg3){
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 void schedule(){
   return;
@@ -7820,9 +7820,9 @@ void *external_alloc(void);
 struct usb_interface *usb_find_interface(struct usb_driver *arg0, int arg1){
   return (struct usb_interface *)external_alloc();
 }
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_from_user(void *arg0, const void *arg1, unsigned int arg2){
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 void finish_wait(wait_queue_head_t *arg0, wait_queue_t *arg1){
   return;

--- a/c/ldv-linux-3.14-races/model/common.env.c
+++ b/c/ldv-linux-3.14-races/model/common.env.c
@@ -1,7 +1,7 @@
-void *__VEFIRIER_nondet_pointer(void);
+void *__VERIFIER_nondet_pointer(void);
 
 void *external_alloc(void) {
-  return __VEFIRIER_nondet_pointer();
+  return __VERIFIER_nondet_pointer();
 }
 
 void free(void *);

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.env.c
@@ -9,7 +9,7 @@ void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head
 // Function: vb2_read
 // with type: size_t vb2_read(struct vb2_queue *, char *, size_t , loff_t *, int)
 // with return type: size_t 
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 size_t vb2_read(struct vb2_queue *arg0, char *arg1, size_t arg2, loff_t *arg3, int arg4){
   // Typedef type
   // Real type: __kernel_size_t 
@@ -18,7 +18,7 @@ size_t vb2_read(struct vb2_queue *arg0, char *arg1, size_t arg2, loff_t *arg3, i
   // Typedef type
   // Real type: unsigned long
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Skip function: pthread_join
@@ -50,10 +50,10 @@ void vb2_buffer_done(struct vb2_buffer *arg0, enum vb2_buffer_state arg1){
 // Function: video_ioctl2
 // with type: long int video_ioctl2(struct file *, unsigned int, unsigned long)
 // with return type: long int
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int video_ioctl2(struct file *arg0, unsigned int arg1, unsigned long arg2){
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Skip function: pthread_mutex_trylock
@@ -61,10 +61,10 @@ long int video_ioctl2(struct file *arg0, unsigned int arg1, unsigned long arg2){
 // Function: pci_enable_device
 // with type: int pci_enable_device(struct pci_dev *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int pci_enable_device(struct pci_dev *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __const_udelay
@@ -112,10 +112,10 @@ struct v4l2_subdev *v4l2_i2c_new_subdev_board(struct v4l2_device *arg0, struct i
 // Function: vb2_streamon
 // with type: int vb2_streamon(struct vb2_queue *, enum v4l2_buf_type )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_streamon(struct vb2_queue *arg0, enum v4l2_buf_type arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: debug_dma_unmap_sg
@@ -181,7 +181,7 @@ void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3)
 // Function: strlcpy
 // with type: size_t strlcpy(char *, const char *, size_t )
 // with return type: size_t 
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 size_t strlcpy(char *arg0, const char *arg1, size_t arg2){
   // Typedef type
   // Real type: __kernel_size_t 
@@ -190,7 +190,7 @@ size_t strlcpy(char *arg0, const char *arg1, size_t arg2){
   // Typedef type
   // Real type: unsigned long
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Skip function: __VERIFIER_nondet_pointer
@@ -214,10 +214,10 @@ void iowrite32(u32 arg0, void *arg1){
 // Function: vb2_queue_init
 // with type: int vb2_queue_init(struct vb2_queue *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_queue_init(struct vb2_queue *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __tasklet_schedule
@@ -277,19 +277,19 @@ void *vb2_dma_contig_init_ctx(struct device *arg0){
 // Function: prepare_to_wait_event
 // with type: long int prepare_to_wait_event(wait_queue_head_t *, wait_queue_t *, int)
 // with return type: long int
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2){
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Function: v4l2_device_register
 // with type: int v4l2_device_register(struct device *, struct v4l2_device *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int v4l2_device_register(struct device *arg0, struct v4l2_device *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: kfree
@@ -313,19 +313,19 @@ void ldv_switch_to_process_context(){
 // Function: vb2_mmap
 // with type: int vb2_mmap(struct vb2_queue *, struct vm_area_struct *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_mmap(struct vb2_queue *arg0, struct vm_area_struct *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: vb2_dqbuf
 // with type: int vb2_dqbuf(struct vb2_queue *, struct v4l2_buffer *, bool )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_dqbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1, bool arg2){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: pci_iomap
@@ -348,10 +348,10 @@ void pci_iounmap(struct pci_dev *arg0, void *arg1){
 // Function: printk
 // with type: int printk(const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: tasklet_init
@@ -391,10 +391,10 @@ void vb2_queue_release(struct vb2_queue *arg0){
 // Function: dev_err
 // with type: int dev_err(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: pci_disable_device
@@ -408,19 +408,19 @@ void pci_disable_device(struct pci_dev *arg0){
 // Function: __dynamic_dev_dbg
 // with type: int __dynamic_dev_dbg(struct _ddebug *, const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: vb2_qbuf
 // with type: int vb2_qbuf(struct vb2_queue *, struct v4l2_buffer *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_qbuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __mutex_init
@@ -499,10 +499,10 @@ void video_unregister_device(struct video_device *arg0){
 // Function: vb2_querybuf
 // with type: int vb2_querybuf(struct vb2_queue *, struct v4l2_buffer *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_querybuf(struct vb2_queue *arg0, struct v4l2_buffer *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: debug_dma_map_sg
@@ -516,28 +516,28 @@ void debug_dma_map_sg(struct device *arg0, struct scatterlist *arg1, int arg2, i
 // Function: v4l2_ctrl_handler_init_class
 // with type: int v4l2_ctrl_handler_init_class(struct v4l2_ctrl_handler *, unsigned int, struct lock_class_key *, const char *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int v4l2_ctrl_handler_init_class(struct v4l2_ctrl_handler *arg0, unsigned int arg1, struct lock_class_key *arg2, const char *arg3){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: dev_warn
 // with type: int dev_warn(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_warn(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: schedule_timeout
 // with type: long int schedule_timeout(long)
 // with return type: long int
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int schedule_timeout(long arg0){
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Function: _raw_spin_lock
@@ -568,28 +568,28 @@ void debug_dma_free_coherent(struct device *arg0, size_t arg1, void *arg2, dma_a
 // Function: ioread32
 // with type: unsigned int ioread32(void *)
 // with return type: unsigned int
-unsigned int __VEFIRIER_nondet_uint(void);
+unsigned int __VERIFIER_nondet_uint(void);
 unsigned int ioread32(void *arg0){
   // Simple type
-  return __VEFIRIER_nondet_uint();
+  return __VERIFIER_nondet_uint();
 }
 
 // Function: __video_register_device
 // with type: int __video_register_device(struct video_device *, int, int, int, struct module *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __video_register_device(struct video_device *arg0, int arg1, int arg2, int arg3, struct module *arg4){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: vb2_streamoff
 // with type: int vb2_streamoff(struct vb2_queue *, enum v4l2_buf_type )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_streamoff(struct vb2_queue *arg0, enum v4l2_buf_type arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: memcpy
@@ -606,19 +606,19 @@ void *memcpy(void *arg0, const void *arg1, size_t arg2){
 // Function: vb2_poll
 // with type: unsigned int vb2_poll(struct vb2_queue *, struct file *, poll_table *)
 // with return type: unsigned int
-unsigned int __VEFIRIER_nondet_uint(void);
+unsigned int __VERIFIER_nondet_uint(void);
 unsigned int vb2_poll(struct vb2_queue *arg0, struct file *arg1, poll_table *arg2){
   // Simple type
-  return __VEFIRIER_nondet_uint();
+  return __VERIFIER_nondet_uint();
 }
 
 // Function: pci_save_state
 // with type: int pci_save_state(struct pci_dev *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int pci_save_state(struct pci_dev *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: finish_wait
@@ -632,10 +632,10 @@ void finish_wait(wait_queue_head_t *arg0, wait_queue_t *arg1){
 // Function: i2c_add_adapter
 // with type: int i2c_add_adapter(struct i2c_adapter *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int i2c_add_adapter(struct i2c_adapter *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: pthread_create
@@ -643,9 +643,9 @@ int i2c_add_adapter(struct i2c_adapter *arg0){
 // Function: vb2_reqbufs
 // with type: int vb2_reqbufs(struct vb2_queue *, struct v4l2_requestbuffers *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int vb2_reqbufs(struct vb2_queue *arg0, struct v4l2_requestbuffers *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.env.c
@@ -20,10 +20,10 @@ void debug_dma_alloc_coherent(struct device *arg0, size_t arg1, dma_addr_t arg2,
 // Function: async_wrap_skb
 // with type: int async_wrap_skb(struct sk_buff *, __u8 *, int)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int async_wrap_skb(struct sk_buff *arg0, __u8 *arg1, int arg2){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: async_unwrap_char
@@ -72,10 +72,10 @@ void __const_udelay(unsigned long arg0){
 // Function: sprintf
 // with type: int sprintf(char *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int sprintf(char *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: pthread_mutex_lock
@@ -127,10 +127,10 @@ void irda_qos_bits_to_value(struct qos_info *arg0){
 // Function: netif_rx
 // with type: int netif_rx(struct sk_buff *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netif_rx(struct sk_buff *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: pnp_unregister_driver
@@ -245,10 +245,10 @@ struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, g
 // Function: printk
 // with type: int printk(const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: warn_slowpath_null
@@ -262,12 +262,12 @@ void warn_slowpath_null(const char *arg0, const int arg1){
 // Function: capable
 // with type: bool capable(int)
 // with return type: bool 
-bool __VEFIRIER_nondet_bool(void);
+bool __VERIFIER_nondet_bool(void);
 bool capable(int arg0){
   // Typedef type
   // Real type: _Bool
   // Simple type
-  return __VEFIRIER_nondet_bool();
+  return __VERIFIER_nondet_bool();
 }
 
 // Skip function: calloc
@@ -302,10 +302,10 @@ void netif_device_detach(struct net_device *arg0){
 // Function: net_ratelimit
 // with type: int net_ratelimit()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int net_ratelimit(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __udelay
@@ -319,10 +319,10 @@ void __udelay(unsigned long arg0){
 // Function: request_dma
 // with type: int request_dma(unsigned int, const char *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int request_dma(unsigned int arg0, const char *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: free
@@ -349,10 +349,10 @@ void irlap_close(struct irlap_cb *arg0){
 // Function: ldv_failed_register_netdev
 // with type: int ldv_failed_register_netdev()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_register_netdev(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: _raw_spin_lock
@@ -420,10 +420,10 @@ struct irlap_cb *irlap_open(struct net_device *arg0, struct qos_info *arg1, cons
 // Function: netpoll_trap
 // with type: int netpoll_trap()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netpoll_trap(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: irda_device_set_media_busy
@@ -445,10 +445,10 @@ void __netif_schedule(struct Qdisc *arg0){
 // Function: pnp_register_driver
 // with type: int pnp_register_driver(struct pnp_driver *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int pnp_register_driver(struct pnp_driver *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: pthread_create

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.env.c
@@ -11,10 +11,10 @@ void debug_dma_alloc_coherent(struct device *arg0, size_t arg1, dma_addr_t arg2,
 // Function: async_wrap_skb
 // with type: int async_wrap_skb(struct sk_buff *, __u8 *, int)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int async_wrap_skb(struct sk_buff *arg0, __u8 *arg1, int arg2){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: async_unwrap_char
@@ -54,10 +54,10 @@ void __const_udelay(unsigned long arg0){
 // Function: sprintf
 // with type: int sprintf(char *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int sprintf(char *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: pthread_mutex_lock
@@ -101,10 +101,10 @@ void irda_qos_bits_to_value(struct qos_info *arg0){
 // Function: netif_rx
 // with type: int netif_rx(struct sk_buff *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netif_rx(struct sk_buff *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: memset
@@ -171,10 +171,10 @@ struct sk_buff *__netdev_alloc_skb(struct net_device *arg0, unsigned int arg1, g
 // Function: printk
 // with type: int printk(const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: warn_slowpath_null
@@ -188,12 +188,12 @@ void warn_slowpath_null(const char *arg0, const int arg1){
 // Function: capable
 // with type: bool capable(int)
 // with return type: bool 
-bool __VEFIRIER_nondet_bool(void);
+bool __VERIFIER_nondet_bool(void);
 bool capable(int arg0){
   // Typedef type
   // Real type: _Bool
   // Simple type
-  return __VEFIRIER_nondet_bool();
+  return __VERIFIER_nondet_bool();
 }
 
 // Skip function: calloc
@@ -220,19 +220,19 @@ void __udelay(unsigned long arg0){
 // Function: request_dma
 // with type: int request_dma(unsigned int, const char *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int request_dma(unsigned int arg0, const char *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: net_ratelimit
 // with type: int net_ratelimit()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int net_ratelimit(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: free
@@ -259,10 +259,10 @@ void irlap_close(struct irlap_cb *arg0){
 // Function: ldv_failed_register_netdev
 // with type: int ldv_failed_register_netdev()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_register_netdev(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __request_region
@@ -322,10 +322,10 @@ struct irlap_cb *irlap_open(struct net_device *arg0, struct qos_info *arg1, cons
 // Function: netpoll_trap
 // with type: int netpoll_trap()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int netpoll_trap(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: irda_device_set_media_busy

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.env.c
@@ -49,28 +49,28 @@ void _raw_spin_unlock_irqrestore(raw_spinlock_t *arg0, unsigned long arg1){
 // Function: reset_control_assert
 // with type: int reset_control_assert(struct reset_control *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int reset_control_assert(struct reset_control *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: platform_get_irq
 // with type: int platform_get_irq(struct platform_device *, unsigned int)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int platform_get_irq(struct platform_device *arg0, unsigned int arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: devm_spi_register_master
 // with type: int devm_spi_register_master(struct device *, struct spi_master *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int devm_spi_register_master(struct device *arg0, struct spi_master *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: ldv_after_alloc
@@ -94,19 +94,19 @@ void debug_dma_sync_single_for_cpu(struct device *arg0, dma_addr_t arg1, size_t 
 // Function: clk_enable
 // with type: int clk_enable(struct clk *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int clk_enable(struct clk *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: wait_for_completion_interruptible_timeout
 // with type: long int wait_for_completion_interruptible_timeout(struct completion *, unsigned long)
 // with return type: long int
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int wait_for_completion_interruptible_timeout(struct completion *arg0, unsigned long arg1){
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Function: dma_request_slave_channel_reason
@@ -121,10 +121,10 @@ struct dma_chan *dma_request_slave_channel_reason(struct device *arg0, const cha
 // Function: wait_for_completion_timeout
 // with type: unsigned long int wait_for_completion_timeout(struct completion *, unsigned long)
 // with return type: unsigned long int
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int wait_for_completion_timeout(struct completion *arg0, unsigned long arg1){
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Skip function: memset
@@ -148,10 +148,10 @@ void __pm_runtime_disable(struct device *arg0, bool arg1){
 // Function: reset_control_deassert
 // with type: int reset_control_deassert(struct reset_control *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int reset_control_deassert(struct reset_control *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: ldv_check_alloc_flags
@@ -174,10 +174,10 @@ struct resource *platform_get_resource(struct platform_device *arg0, unsigned in
 // Function: clk_set_rate
 // with type: int clk_set_rate(struct clk *, unsigned long)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int clk_set_rate(struct clk *arg0, unsigned long arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: sg_init_table
@@ -191,10 +191,10 @@ void sg_init_table(struct scatterlist *arg0, unsigned int arg1){
 // Function: __pm_runtime_resume
 // with type: int __pm_runtime_resume(struct device *, int)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __pm_runtime_resume(struct device *arg0, int arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: __VERIFIER_nondet_ulong
@@ -253,28 +253,28 @@ struct reset_control *devm_reset_control_get(struct device *arg0, const char *ar
 // Function: dev_err
 // with type: int dev_err(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: msecs_to_jiffies
 // with type: unsigned long int msecs_to_jiffies(const unsigned int)
 // with return type: unsigned long int
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int msecs_to_jiffies(const unsigned int arg0){
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Function: __dynamic_dev_dbg
 // with type: int __dynamic_dev_dbg(struct _ddebug *, const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: __VERIFIER_error
@@ -282,10 +282,10 @@ int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const cha
 // Function: spi_master_resume
 // with type: int spi_master_resume(struct spi_master *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int spi_master_resume(struct spi_master *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: free
@@ -338,19 +338,19 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // Function: __pm_runtime_idle
 // with type: int __pm_runtime_idle(struct device *, int)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __pm_runtime_idle(struct device *arg0, int arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: spi_master_suspend
 // with type: int spi_master_suspend(struct spi_master *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int spi_master_suspend(struct spi_master *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: debug_dma_free_coherent
@@ -381,10 +381,10 @@ void *memcpy(void *arg0, const void *arg1, size_t arg2){
 // Function: clk_prepare
 // with type: int clk_prepare(struct clk *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int clk_prepare(struct clk *arg0){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: __VERIFIER_nondet_int

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.env.c
@@ -15,19 +15,19 @@ void __raw_spin_lock_init(raw_spinlock_t *arg0, const char *arg1, struct lock_cl
 // Function: usb_submit_urb
 // with type: int usb_submit_urb(struct urb *, gfp_t )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_submit_urb(struct urb *arg0, gfp_t arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: _dev_info
 // with type: int _dev_info(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int _dev_info(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: remove_wait_queue
@@ -41,10 +41,10 @@ void remove_wait_queue(wait_queue_head_t *arg0, wait_queue_t *arg1){
 // Function: _copy_to_user
 // with type: unsigned long int _copy_to_user(void *, const void *, unsigned int)
 // with return type: unsigned long int
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_to_user(void *arg0, const void *arg1, unsigned int arg2){
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Skip function: pthread_mutex_lock
@@ -80,10 +80,10 @@ void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3)
 // Function: usb_register_dev
 // with type: int usb_register_dev(struct usb_interface *, struct usb_class_driver *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_register_dev(struct usb_interface *arg0, struct usb_class_driver *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: usb_free_urb
@@ -143,10 +143,10 @@ void might_fault(){
 // Function: printk
 // with type: int printk(const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: calloc
@@ -162,19 +162,19 @@ void ldv_pre_probe(){
 // Function: dev_err
 // with type: int dev_err(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __dynamic_dev_dbg
 // with type: int __dynamic_dev_dbg(struct _ddebug *, const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int __dynamic_dev_dbg(struct _ddebug *arg0, const struct device *arg1, const char *arg2, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __mutex_init
@@ -198,23 +198,23 @@ void usb_deregister_dev(struct usb_interface *arg0, struct usb_class_driver *arg
 // Function: ldv_failed_usb_register_driver
 // with type: int ldv_failed_usb_register_driver()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_usb_register_driver(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: noop_llseek
 // with type: loff_t noop_llseek(struct file *, loff_t , int)
 // with return type: loff_t 
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2){
   // Typedef type
   // Real type: __kernel_loff_t 
   // Typedef type
   // Real type: long long
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Skip function: free
@@ -257,10 +257,10 @@ void __init_waitqueue_head(wait_queue_head_t *arg0, const char *arg1, struct loc
 // Function: schedule_timeout
 // with type: long int schedule_timeout(long)
 // with return type: long int
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int schedule_timeout(long arg0){
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Function: __copy_from_user_overflow
@@ -282,10 +282,10 @@ void _raw_spin_lock(raw_spinlock_t *arg0){
 // Function: usb_string
 // with type: int usb_string(struct usb_device *, int, char *, size_t )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_string(struct usb_device *arg0, int arg1, char *arg2, size_t arg3){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: usb_alloc_urb
@@ -320,10 +320,10 @@ struct usb_interface *usb_find_interface(struct usb_driver *arg0, int arg1){
 // Function: _copy_from_user
 // with type: unsigned long int _copy_from_user(void *, const void *, unsigned int)
 // with return type: unsigned long int
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_from_user(void *arg0, const void *arg1, unsigned int arg2){
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Skip function: pthread_create

--- a/c/ldv-linux-3.14-races/model/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.env.c
+++ b/c/ldv-linux-3.14-races/model/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.env.c
@@ -15,25 +15,25 @@ void __raw_spin_lock_init(raw_spinlock_t *arg0, const char *arg1, struct lock_cl
 // Function: usb_submit_urb
 // with type: int usb_submit_urb(struct urb *, gfp_t )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_submit_urb(struct urb *arg0, gfp_t arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: _dev_info
 // with type: int _dev_info(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int _dev_info(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: strlen
 // with type: size_t strlen(const char *)
 // with return type: size_t 
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 size_t strlen(const char *arg0){
   // Typedef type
   // Real type: __kernel_size_t 
@@ -42,25 +42,25 @@ size_t strlen(const char *arg0){
   // Typedef type
   // Real type: unsigned long
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Function: memcmp
 // with type: int memcmp(const void *, const void *, size_t )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int memcmp(const void *arg0, const void *arg1, size_t arg2){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: _copy_to_user
 // with type: unsigned long int _copy_to_user(void *, const void *, unsigned int)
 // with return type: unsigned long int
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_to_user(void *arg0, const void *arg1, unsigned int arg2){
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Skip function: pthread_mutex_lock
@@ -96,10 +96,10 @@ void *usb_alloc_coherent(struct usb_device *arg0, size_t arg1, gfp_t arg2, dma_a
 // Function: usb_control_msg
 // with type: int usb_control_msg(struct usb_device *, unsigned int, __u8 , __u8 , __u16 , __u16 , void *, __u16 , int)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_control_msg(struct usb_device *arg0, unsigned int arg1, __u8 arg2, __u8 arg3, __u16 arg4, __u16 arg5, void *arg6, __u16 arg7, int arg8){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: ldv_after_alloc
@@ -123,10 +123,10 @@ void __wake_up(wait_queue_head_t *arg0, unsigned int arg1, int arg2, void *arg3)
 // Function: usb_register_dev
 // with type: int usb_register_dev(struct usb_interface *, struct usb_class_driver *)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_register_dev(struct usb_interface *arg0, struct usb_class_driver *arg1){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: usb_free_urb
@@ -168,10 +168,10 @@ void ldv_check_alloc_flags(gfp_t arg0){
 // Function: prepare_to_wait_event
 // with type: long int prepare_to_wait_event(wait_queue_head_t *, wait_queue_t *, int)
 // with return type: long int
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 long int prepare_to_wait_event(wait_queue_head_t *arg0, wait_queue_t *arg1, int arg2){
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Skip function: kfree
@@ -187,10 +187,10 @@ void might_fault(){
 // Function: printk
 // with type: int printk(const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int printk(const char *arg0, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Skip function: calloc
@@ -206,10 +206,10 @@ void ldv_pre_probe(){
 // Function: dev_err
 // with type: int dev_err(const struct device *, const char *, ...)
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int dev_err(const struct device *arg0, const char *arg1, ...){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: __mutex_init
@@ -233,23 +233,23 @@ void usb_deregister_dev(struct usb_interface *arg0, struct usb_class_driver *arg
 // Function: ldv_failed_usb_register_driver
 // with type: int ldv_failed_usb_register_driver()
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int ldv_failed_usb_register_driver(){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: noop_llseek
 // with type: loff_t noop_llseek(struct file *, loff_t , int)
 // with return type: loff_t 
-long __VEFIRIER_nondet_long(void);
+long __VERIFIER_nondet_long(void);
 loff_t noop_llseek(struct file *arg0, loff_t arg1, int arg2){
   // Typedef type
   // Real type: __kernel_loff_t 
   // Typedef type
   // Real type: long long
   // Simple type
-  return __VEFIRIER_nondet_long();
+  return __VERIFIER_nondet_long();
 }
 
 // Skip function: free
@@ -300,10 +300,10 @@ void _raw_spin_lock(raw_spinlock_t *arg0){
 // Function: usb_string
 // with type: int usb_string(struct usb_device *, int, char *, size_t )
 // with return type: int
-int __VEFIRIER_nondet_int(void);
+int __VERIFIER_nondet_int(void);
 int usb_string(struct usb_device *arg0, int arg1, char *arg2, size_t arg3){
   // Simple type
-  return __VEFIRIER_nondet_int();
+  return __VERIFIER_nondet_int();
 }
 
 // Function: schedule
@@ -346,10 +346,10 @@ struct usb_interface *usb_find_interface(struct usb_driver *arg0, int arg1){
 // Function: _copy_from_user
 // with type: unsigned long int _copy_from_user(void *, const void *, unsigned int)
 // with return type: unsigned long int
-unsigned long __VEFIRIER_nondet_ulong(void);
+unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long int _copy_from_user(void *arg0, const void *arg1, unsigned int arg2){
   // Simple type
-  return __VEFIRIER_nondet_ulong();
+  return __VERIFIER_nondet_ulong();
 }
 
 // Function: finish_wait


### PR DESCRIPTION
This fixes an obvious typo in the name of the standard `__VERIFIER_*` functions.