### PR TITLE
Add memmove prototypes to LDV benchmarks

### DIFF
--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-dw2102.ko-entry_point_false-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--media--usb--dvb-usb--dvb-usb-dw2102.ko-entry_point_false-unreach-call.cil.out.c
@@ -7165,6 +7165,7 @@ typedef int ldv_func_ret_type;
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern void *kmemdup(void const   * , size_t  , gfp_t  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
@@ -9407,6 +9407,7 @@ extern void __bad_percpu_size(void) ;
 extern void __bad_size_call_parameter(void) ;
 extern void warn_slowpath_null(char const   * , int const    ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-08_1a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
@@ -10776,6 +10776,7 @@ __inline static int list_empty(struct list_head  const  *head )
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void *__memmove(void * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb--dvb-usb-opera.ko-entry_point_true-unreach-call.cil.out.c
@@ -6990,6 +6990,7 @@ typedef int ldv_func_ret_type___2;
 extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int mutex_trylock(struct mutex * ) ;
 int ldv_mutex_trylock_8(struct mutex *ldv_func_arg1 ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb-v2--dvb-usb-lmedm04.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--media--usb--dvb-usb-v2--dvb-usb-lmedm04.ko-entry_point_true-unreach-call.cil.out.c
@@ -7028,6 +7028,7 @@ extern struct module __this_module ;
 extern int printk(char const   *  , ...) ;
 extern void __dynamic_pr_debug(struct _ddebug * , char const   *  , ...) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern size_t strlcat(char * , char const   * , __kernel_size_t  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--ethernet--intel--i40e--i40e.ko-entry_point_true-unreach-call.cil.out.c
@@ -9396,6 +9396,7 @@ __inline static void hlist_del(struct hlist_node *n )
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern char *strncpy(char * , char const   * , __kernel_size_t  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--net--wireless--mwifiex--mwifiex.ko-entry_point_true-unreach-call.cil.out.c
@@ -10769,6 +10769,7 @@ __inline static int list_empty(struct list_head  const  *head )
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void *__memmove(void * , void const   * , size_t  ) ;
 extern size_t strlen(char const   * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--bluetooth--hci_uart.ko-entry_point_true-unreach-call.cil.out.c
@@ -8828,6 +8828,7 @@ __inline static __u16 __le16_to_cpup(__le16 const   *p )
 }
 void *ldv_err_ptr(long error ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 __inline static void *ERR_PTR(long error ) ;
 __inline static long PTR_ERR(void const   *ptr ) ;
 __inline static bool IS_ERR(void const   *ptr ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--xgbe--amd-xgbe.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--amd--xgbe--amd-xgbe.ko-entry_point_true-unreach-call.cil.out.c
@@ -7026,6 +7026,7 @@ __inline static long ldv__builtin_expect(long exp , long c )
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern int strcmp(char const   * , char const   * ) ;
 extern char *strchr(char const   * , int  ) ;
 extern int __bitmap_weight(unsigned long const   * , unsigned int  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--ethernet--natsemi--natsemi.ko-entry_point_true-unreach-call.cil.out.c
@@ -5707,6 +5707,7 @@ __inline static long ldv__builtin_expect(long exp , long c )
 }
 extern unsigned long __phys_addr(unsigned long  ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern int strncmp(char const   * , char const   * , __kernel_size_t  ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--net--fddi--defxx.ko-entry_point_true-unreach-call.cil.out.c
@@ -6369,6 +6369,7 @@ __inline static long ldv__builtin_expect(long exp , long c )
 }
 extern unsigned long __phys_addr(unsigned long  ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern void __raw_spin_lock_init(raw_spinlock_t * , char const   * , struct lock_class_key * ) ;
 extern void _raw_spin_lock(raw_spinlock_t * ) ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--bnx2i--bnx2i.ko-entry_point_true-unreach-call.cil.out.c
@@ -8354,6 +8354,7 @@ __inline static int list_empty(struct list_head  const  *head )
 extern unsigned long __per_cpu_offset[8192U] ;
 extern void warn_slowpath_null(char const   * , int const    ) ;
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern size_t strlcpy(char * , char const   * , size_t  ) ;
 extern int nr_cpu_ids ;
 extern struct cpumask  const  * const  cpu_possible_mask ;

--- a/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.c
+++ b/c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--tty--synclink_gt.ko-entry_point_true-unreach-call.cil.out.c
@@ -6177,6 +6177,7 @@ __inline static struct task_struct *get_current(void)
 }
 }
 extern void *memcpy(void * , void const   * , size_t  ) ;
+extern void *memmove(void * , void const   * , size_t  ) ;
 extern void *memset(void * , int  , size_t  ) ;
 extern int memcmp(void const   * , void const   * , size_t  ) ;
 extern char *strcat(char * , char const   * ) ;


### PR DESCRIPTION
This fixes a problem introduced in 55d4083, where some calls to memcpy
were converted to calls to memmove, but the files did not have a
prototype for memmove.