### PR TITLE
Add stubs for all undefined extern functions called by programs in seq-mthreaded

### DIFF
--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M1.c
@@ -2353,3 +2353,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.1.M4.c
@@ -14495,3 +14495,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M1.c
@@ -2425,3 +2425,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.2.M4.c
@@ -14652,3 +14652,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M1.c
@@ -3042,3 +3042,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.3.M4.c
@@ -15946,3 +15946,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M1.c
@@ -3029,3 +3029,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_false-unreach-call.4.M4.c
@@ -15977,3 +15977,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M1.c
@@ -2359,3 +2359,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.1.M4.c
@@ -14501,3 +14501,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M1.c
@@ -3030,3 +3030,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_aso_true-unreach-call.2.M4.c
@@ -15980,3 +15980,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M1.c
@@ -1953,3 +1953,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.1.M4.c
@@ -13566,3 +13566,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M1.c
@@ -2186,3 +2186,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_false-unreach-call.2.M4.c
@@ -14127,3 +14127,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M1.c
@@ -1953,3 +1953,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.1.M4.c
@@ -13566,3 +13566,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M1.c
@@ -2010,3 +2010,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.2.M4.c
@@ -13708,3 +13708,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M1.c
@@ -2186,3 +2186,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekcba_nxt_true-unreach-call.3.M4.c
@@ -14127,3 +14127,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M1.c
@@ -2792,3 +2792,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.1.M4.c
@@ -2808,3 +2808,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M1.c
@@ -2884,3 +2884,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.2.M4.c
@@ -2900,3 +2900,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M1.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M1.c
@@ -4042,3 +4042,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M4.c
+++ b/c/seq-mthreaded/rekh_aso_false-unreach-call.4.M4.c
@@ -4070,3 +4070,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M1.c
@@ -2798,3 +2798,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.1.M4.c
@@ -2814,3 +2814,19 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M1.c
@@ -4043,3 +4043,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.2.M4.c
@@ -4071,3 +4071,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M1.c
@@ -4055,3 +4055,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekh_aso_true-unreach-call.3.M4.c
@@ -4083,3 +4083,27 @@ __inline void __startrek_init_shared(void)
   ___startrek_current_priority_[0] = __startrek_hidden___startrek_current_priority;
 }
 }
+
+void __startrek_get_pi_lock(char arg0) {
+  return;
+}
+
+void __startrek_release_pi_lock(char arg0) {
+  return;
+}
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M1.c
@@ -2075,3 +2075,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.1.M4.c
@@ -2085,3 +2085,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M1.c
@@ -2403,3 +2403,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_false-unreach-call.2.M4.c
@@ -2416,3 +2416,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M1.c
@@ -2075,3 +2075,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.1.M4.c
@@ -2085,3 +2085,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M1.c
@@ -2129,3 +2129,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.2.M4.c
@@ -2139,3 +2139,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M1.c
@@ -2403,3 +2403,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}

--- a/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M4.c
+++ b/c/seq-mthreaded/rekh_nxt_true-unreach-call.3.M4.c
@@ -2416,3 +2416,27 @@ __inline void __startrek_init_shared(void)
   _nxtway_gs_mode_[0] = __startrek_hidden_nxtway_gs_mode;
 }
 }
+
+void ecrobot_bt_data_logger(char arg0, char arg1) {
+  return;
+}
+
+void ecrobot_sound_tone(unsigned int arg0, unsigned int arg1, char arg2) {
+  return;
+}
+
+void ecrobot_status_monitor(char *arg0) {
+  return;
+}
+
+void nxt_motor_set_count(unsigned char arg0, char arg1) {
+  return;
+}
+
+void nxt_motor_set_speed(unsigned char arg0, char arg1, char arg2) {
+  return;
+}
+
+void write_mode_on_lcd(unsigned char arg0) {
+  return;
+}


### PR DESCRIPTION
All these functions are void functions and have mostly scalar parameters (only a few char pointers).

The programs here seem to simulate a controller software, and the extern functions are there for simulating triggering actions in the controlled system (e.g., `nxt_motor_set_speed).

So adding no-op stubs for them should not affect neither the actual nor the intended semantics.