### PR TITLE
Fixes of ldv-linux-3.14-races/ benchmarks

### DIFF
--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.c
@@ -6391,6 +6391,12 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   tmp___2 = ldv_xmalloc(2936UL);
   ldv_3_resource_dev = (struct pci_dev *)tmp___2;
+  ldv_3_resource_dev->bus = external_allocated_data();
+  ldv_3_resource_dev->subordinate = external_allocated_data();
+  ldv_3_resource_dev->sysdata = external_allocated_data();
+  ldv_3_resource_dev->procent = external_allocated_data();
+  ldv_3_resource_dev->slot = external_allocated_data();
+
   }
   goto ldv_main_3;
   return ((void *)0);
@@ -11677,7 +11683,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -11760,7 +11766,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -11843,7 +11849,7 @@ void ldv_mutex_unlock_lock_of_v4l2_ctrl_handler(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_lock_of_v4l2_ctrl_handler);
+  pthread_mutex_unlock(& pmutex_lock_of_v4l2_ctrl_handler);
   }
   return;
 }
@@ -11926,7 +11932,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }
@@ -12009,7 +12015,7 @@ void ldv_mutex_unlock_s_mutex_of_mcam_camera(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_s_mutex_of_mcam_camera);
+  pthread_mutex_unlock(& pmutex_s_mutex_of_mcam_camera);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.i
@@ -6334,6 +6334,11 @@ void *ldv_pci_scenario_3(void *arg0 )
   {
   tmp___2 = ldv_xmalloc(2936UL);
   ldv_3_resource_dev = (struct pci_dev *)tmp___2;
+  ldv_3_resource_dev->bus = external_allocated_data();
+  ldv_3_resource_dev->subordinate = external_allocated_data();
+  ldv_3_resource_dev->sysdata = external_allocated_data();
+  ldv_3_resource_dev->procent = external_allocated_data();
+  ldv_3_resource_dev->slot = external_allocated_data();
   }
   goto ldv_main_3;
   return ((void *)0);
@@ -11091,7 +11096,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -11165,7 +11170,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -11239,7 +11244,7 @@ void ldv_mutex_unlock_lock_of_v4l2_ctrl_handler(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_lock_of_v4l2_ctrl_handler);
+  pthread_mutex_unlock(& pmutex_lock_of_v4l2_ctrl_handler);
   }
   return;
 }
@@ -11313,7 +11318,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }
@@ -11387,7 +11392,7 @@ void ldv_mutex_unlock_s_mutex_of_mcam_camera(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_s_mutex_of_mcam_camera);
+  pthread_mutex_unlock(& pmutex_s_mutex_of_mcam_camera);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.c
@@ -11774,7 +11774,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -11857,7 +11857,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -11940,7 +11940,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.i
@@ -11309,7 +11309,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -11383,7 +11383,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -11457,7 +11457,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.c
@@ -5699,7 +5699,8 @@ extern void *external_allocated_data(void) ;
 void *ldv_xmalloc_unknown_size(size_t size ) ;
 extern void __raw_spin_lock_init(raw_spinlock_t * , char const   * , struct lock_class_key * ) ;
 extern void _raw_spin_unlock_irqrestore(raw_spinlock_t * , unsigned long  ) ;
-void ldv_assert(char const   *desc , int expr ) ;
+void ldv_assert(int expr ) ;
+__u32 io_speed;
 __inline static raw_spinlock_t *spinlock_check(spinlock_t *lock ) 
 { 
 
@@ -6601,7 +6602,6 @@ static void w83977af_change_speed(struct w83977af_ir *self , __u32 speed )
   ir_mode = 96;
   iobase = self->io.fir_base;
   self->io.speed = speed;
-  ldv_assert("", self->io.speed == speed);
   set = inb(iobase + 3);
   switch_bank(iobase, 3);
   outb(0, iobase + 1);
@@ -6759,6 +6759,8 @@ static netdev_tx_t w83977af_hard_xmit(struct sk_buff *skb , struct net_device *d
   tmp___0 = irda_get_next_speed((struct sk_buff  const  *)skb);
   speed = (__s32 )tmp___0;
   }
+  io_speed = self->io.speed;
+  ldv_assert(io_speed == self->io.speed);
   if ((__u32 )speed != self->io.speed && speed != -1) {
     if (skb->len == 0U) {
       {
@@ -8506,7 +8508,7 @@ void ldv__builtin_trap(void)
 
   {
   {
-  ldv_assert("", 0);
+  ldv_assert(0);
   }
   return;
 }
@@ -9040,7 +9042,7 @@ void ldv_check_final_state(void)
   return;
 }
 }
-void ldv_assert(char const   *desc , int expr ) 
+void ldv_assert(int expr ) 
 { 
 
 

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.i
@@ -5729,7 +5729,8 @@ extern void *external_allocated_data(void) ;
 void *ldv_xmalloc_unknown_size(size_t size ) ;
 extern void __raw_spin_lock_init(raw_spinlock_t * , char const * , struct lock_class_key * ) ;
 extern void _raw_spin_unlock_irqrestore(raw_spinlock_t * , unsigned long ) ;
-void ldv_assert(char const *desc , int expr ) ;
+void ldv_assert(int expr ) ;
+__u32 io_speed;
 __inline static raw_spinlock_t *spinlock_check(spinlock_t *lock )
 {
   {
@@ -6542,7 +6543,6 @@ static void w83977af_change_speed(struct w83977af_ir *self , __u32 speed )
   ir_mode = 96;
   iobase = self->io.fir_base;
   self->io.speed = speed;
-  ldv_assert("", self->io.speed == speed);
   set = inb(iobase + 3);
   switch_bank(iobase, 3);
   outb(0, iobase + 1);
@@ -6690,6 +6690,8 @@ static netdev_tx_t w83977af_hard_xmit(struct sk_buff *skb , struct net_device *d
   tmp___0 = irda_get_next_speed((struct sk_buff const *)skb);
   speed = (__s32 )tmp___0;
   }
+  io_speed = self->io.speed;
+  ldv_assert(io_speed == self->io.speed);
   if ((__u32 )speed != self->io.speed && speed != -1) {
     if (skb->len == 0U) {
       {
@@ -8296,7 +8298,7 @@ void ldv__builtin_trap(void)
 {
   {
   {
-  ldv_assert("", 0);
+  ldv_assert(0);
   }
   return;
 }
@@ -8783,7 +8785,7 @@ void ldv_check_final_state(void)
   return;
 }
 }
-void ldv_assert(char const *desc , int expr )
+void ldv_assert(int expr )
 {
   {
   if (expr == 0) {

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.c
@@ -3323,13 +3323,14 @@ __inline static int of_property_read_u32(struct device_node  const  *np , char c
   return (tmp);
 }
 }
+extern void *__VERIFIER_nondet_pointer(void);
 __inline static struct of_device_id  const  *__of_match_device(struct of_device_id  const  *matches ,
                                                                struct device  const  *dev ) 
 { 
 
 
   {
-  return ((struct of_device_id  const  *)0);
+  return ((struct of_device_id  const  *)__VERIFIER_nondet_pointer());
 }
 }
 extern int reset_control_assert(struct reset_control * ) ;
@@ -6474,7 +6475,6 @@ unsigned long ldv_undef_ulong(void) ;
 int ldv_undef_int_nonpositive(void) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
-extern void *__VERIFIER_nondet_pointer(void) ;
 int ldv_undef_int(void) 
 { 
   int tmp ;
@@ -6617,7 +6617,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -6700,7 +6700,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.i
@@ -3298,11 +3298,12 @@ __inline static int of_property_read_u32(struct device_node const *np , char con
   return (tmp);
 }
 }
+extern void *__VERIFIER_nondet_pointer(void);
 __inline static struct of_device_id const *__of_match_device(struct of_device_id const *matches ,
                                                                struct device const *dev )
 {
   {
-  return ((struct of_device_id const *)0);
+  return ((struct of_device_id const *)__VERIFIER_nondet_pointer());
 }
 }
 extern int reset_control_assert(struct reset_control * ) ;
@@ -6199,7 +6200,6 @@ unsigned long ldv_undef_ulong(void) ;
 int ldv_undef_int_nonpositive(void) ;
 extern int __VERIFIER_nondet_int(void) ;
 extern unsigned long __VERIFIER_nondet_ulong(void) ;
-extern void *__VERIFIER_nondet_pointer(void) ;
 int ldv_undef_int(void)
 {
   int tmp ;
@@ -6328,7 +6328,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -6402,7 +6402,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.c
@@ -7318,7 +7318,7 @@ void ldv_mutex_unlock_adutux_mutex(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_adutux_mutex);
+  pthread_mutex_unlock(& pmutex_adutux_mutex);
   }
   return;
 }
@@ -7401,7 +7401,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -7484,7 +7484,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -7567,7 +7567,7 @@ void ldv_mutex_unlock_mtx_of_adu_device(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mtx_of_adu_device);
+  pthread_mutex_unlock(& pmutex_mtx_of_adu_device);
   }
   return;
 }
@@ -7650,7 +7650,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.i
@@ -4036,7 +4036,7 @@ extern void kfree(void const * ) ;
 extern void *ldv_malloc(size_t);
 void *__kmalloc(size_t size, gfp_t t)
 {
-        return ldv_malloc(size);
+ return ldv_malloc(size);
 }
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
@@ -7070,7 +7070,7 @@ void ldv_mutex_unlock_adutux_mutex(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_adutux_mutex);
+  pthread_mutex_unlock(& pmutex_adutux_mutex);
   }
   return;
 }
@@ -7144,7 +7144,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -7218,7 +7218,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -7292,7 +7292,7 @@ void ldv_mutex_unlock_mtx_of_adu_device(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mtx_of_adu_device);
+  pthread_mutex_unlock(& pmutex_mtx_of_adu_device);
   }
   return;
 }
@@ -7366,7 +7366,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -6819,7 +6819,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -6902,7 +6902,7 @@ void ldv_mutex_unlock_iowarrior_mutex(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_iowarrior_mutex);
+  pthread_mutex_unlock(& pmutex_iowarrior_mutex);
   }
   return;
 }
@@ -6985,7 +6985,7 @@ void ldv_mutex_unlock_iowarrior_open_disc_lock(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_iowarrior_open_disc_lock);
+  pthread_mutex_unlock(& pmutex_iowarrior_open_disc_lock);
   }
   return;
 }
@@ -7068,7 +7068,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -7151,7 +7151,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }
@@ -7234,7 +7234,7 @@ void ldv_mutex_unlock_mutex_of_iowarrior(struct mutex *lock )
 
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_iowarrior);
+  pthread_mutex_unlock(& pmutex_mutex_of_iowarrior);
   }
   return;
 }

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.i
@@ -3932,7 +3932,7 @@ extern void kfree(void const * ) ;
 extern void *ldv_malloc(size_t);
 void *__kmalloc(size_t size, gfp_t t)
 {
-        return ldv_malloc(size);
+ return ldv_malloc(size);
 }
 __inline static void *kmalloc(size_t size , gfp_t flags )
 {
@@ -6565,7 +6565,7 @@ void ldv_mutex_unlock_i_mutex_of_inode(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_i_mutex_of_inode);
+  pthread_mutex_unlock(& pmutex_i_mutex_of_inode);
   }
   return;
 }
@@ -6639,7 +6639,7 @@ void ldv_mutex_unlock_iowarrior_mutex(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_iowarrior_mutex);
+  pthread_mutex_unlock(& pmutex_iowarrior_mutex);
   }
   return;
 }
@@ -6713,7 +6713,7 @@ void ldv_mutex_unlock_iowarrior_open_disc_lock(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_iowarrior_open_disc_lock);
+  pthread_mutex_unlock(& pmutex_iowarrior_open_disc_lock);
   }
   return;
 }
@@ -6787,7 +6787,7 @@ void ldv_mutex_unlock_lock(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_lock);
+  pthread_mutex_unlock(& pmutex_lock);
   }
   return;
 }
@@ -6861,7 +6861,7 @@ void ldv_mutex_unlock_mutex_of_device(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_device);
+  pthread_mutex_unlock(& pmutex_mutex_of_device);
   }
   return;
 }
@@ -6935,7 +6935,7 @@ void ldv_mutex_unlock_mutex_of_iowarrior(struct mutex *lock )
 {
   {
   {
-  pthread_mutex_lock(& pmutex_mutex_of_iowarrior);
+  pthread_mutex_unlock(& pmutex_mutex_of_iowarrior);
   }
   return;
 }


### PR DESCRIPTION
A number of fixes related to six benchmarks in ldv-linux-3.14-races/. Missed unlock functions, some initializations, fix clang warnings. 