### PR TITLE
Move ldv races into concurrency category

### DIFF
--- a/c/ConcurrencySafety-Main.set
+++ b/c/ConcurrencySafety-Main.set
@@ -10,6 +10,7 @@ pthread-lit/*_false-unreach-call*.i
 pthread-lit/*_true-unreach-call*.i
 ldv-races/*_true-unreach-call*.i
 ldv-races/*_false-unreach-call*.i
+ldv-linux-3.14-races/*_false-unreach-call*.i
 pthread-complex/*_false-unreach-call*.i
 pthread-complex/*_true-unreach-call*.i
 pthread-driver-races/*_true-unreach-call*.i

--- a/c/Systems_DeviceDriversLinux64_ConcurrencySafety.set
+++ b/c/Systems_DeviceDriversLinux64_ConcurrencySafety.set
@@ -1,1 +1,0 @@
-ldv-linux-3.14-races/*_false-unreach-call*.cil.i

--- a/c/ldv-linux-3.14-races/Makefile
+++ b/c/ldv-linux-3.14-races/Makefile
@@ -1,6 +1,6 @@
 LEVEL := ../
 
-CC.Arch := 64
+CC.Arch := 32
 
 IGNORE_DIRS := ./model/
 


### PR DESCRIPTION
The corresponding benchmarks are not new, they were placed into subcategory of software systems. The suggestion is to move them into main concurrency category.