### PR TITLE
Add ldv races into concurrency category

### DIFF
--- a/c/ConcurrencySafety-Main.set
+++ b/c/ConcurrencySafety-Main.set
@@ -10,6 +10,7 @@ pthread-lit/*_false-unreach-call*.i
 pthread-lit/*_true-unreach-call*.i
 ldv-races/*_true-unreach-call*.i
 ldv-races/*_false-unreach-call*.i
+ldv-linux-3.14-races/*_false-unreach-call*.i
 pthread-complex/*_false-unreach-call*.i
 pthread-complex/*_true-unreach-call*.i
 pthread-driver-races/*_true-unreach-call*.i

--- a/c/Systems_DeviceDriversLinux64_ConcurrencySafety.set
+++ b/c/Systems_DeviceDriversLinux64_ConcurrencySafety.set
@@ -1,1 +1,0 @@
-ldv-linux-3.14-races/*_false-unreach-call*.cil.i

--- a/c/ldv-linux-3.14-races/Makefile
+++ b/c/ldv-linux-3.14-races/Makefile
@@ -1,6 +1,6 @@
 LEVEL := ../
 
-CC.Arch := 64
+CC.Arch := 32
 
 IGNORE_DIRS := ./model/
 

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.c
@@ -39,7 +39,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_false-unreach-call.cil.i
@@ -84,7 +84,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.c
@@ -42,7 +42,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __u8 u_int8_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko_false-unreach-call.cil.i
@@ -87,7 +87,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __u8 u_int8_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.c
@@ -41,7 +41,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--net--irda--w83977af_ir.ko_false-unreach-call.cil.i
@@ -86,7 +86,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.c
@@ -36,7 +36,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--spi--spi-tegra20-slink.ko_false-unreach-call.cil.i
@@ -81,7 +81,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.c
@@ -39,7 +39,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--adutux.ko_false-unreach-call.cil.i
@@ -84,7 +84,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.c
@@ -39,7 +39,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--usb--misc--iowarrior.ko_false-unreach-call.cil.i
@@ -84,7 +84,7 @@ typedef _Bool bool;
 typedef __kernel_uid32_t uid_t;
 typedef __kernel_gid32_t gid_t;
 typedef __kernel_loff_t loff_t;
-typedef __kernel_size_t size_t;
+typedef unsigned int size_t;
 typedef __kernel_ssize_t ssize_t;
 typedef __kernel_time_t time_t;
 typedef __s32 int32_t;


### PR DESCRIPTION
The corresponding benchmarks are not new, they were placed into subcategory of software systems. The suggestion is to move them into main concurrency category.