### PR TITLE
Define syslog, _IO_getc and nanosleep in Busybox files

### DIFF
--- a/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -47,6 +47,9 @@ static signed int bb_errno_location;
 static signed int * const bb_errno = &bb_errno_location;
 
 // file coreutils/basename.c line 49
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int m;

--- a/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/basename_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -1304,6 +1304,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 static const char *applet_name;
 static signed int bb_errno_location;
 static signed int * const bb_errno = &bb_errno_location;
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int m;

--- a/c/busybox-1.22.0/basename_false-valid-deref.c
+++ b/c/busybox-1.22.0/basename_false-valid-deref.c
@@ -47,6 +47,9 @@ static signed int bb_errno_location;
 static signed int * const bb_errno;
 
 // file coreutils/basename.c line 49
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int m;

--- a/c/busybox-1.22.0/basename_false-valid-deref.i
+++ b/c/busybox-1.22.0/basename_false-valid-deref.i
@@ -1304,6 +1304,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 static const char *applet_name;
 static signed int bb_errno_location;
 static signed int * const bb_errno;
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int m;

--- a/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.c
@@ -174,6 +174,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/chgrp.c line 42
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **p = argv;

--- a/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/chgrp-incomplete_false-no-overflow.i
@@ -2311,6 +2311,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **p = argv;

--- a/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.c
+++ b/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.c
@@ -174,6 +174,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/chgrp.c line 42
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **p = argv;

--- a/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.i
+++ b/c/busybox-1.22.0/chgrp-incomplete_true-no-overflow_false-valid-memtrack.i
@@ -2311,6 +2311,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **p = argv;

--- a/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.c
@@ -226,6 +226,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/chroot.c line 28
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   argv = argv + 1l;

--- a/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/chroot-incomplete_false-no-overflow.i
@@ -2383,6 +2383,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   argv = argv + 1l;

--- a/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.c
@@ -226,6 +226,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/chroot.c line 28
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   argv = argv + 1l;

--- a/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/chroot-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -2383,6 +2383,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   argv = argv + 1l;

--- a/c/busybox-1.22.0/cut_false-no-overflow.c
+++ b/c/busybox-1.22.0/cut_false-no-overflow.c
@@ -591,6 +591,9 @@ static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lis
 }
 
 // file coreutils/cut.c line 185
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct cut_list *cut_lists = (struct cut_list *)NULL;

--- a/c/busybox-1.22.0/cut_false-no-overflow.i
+++ b/c/busybox-1.22.0/cut_false-no-overflow.i
@@ -2548,6 +2548,9 @@ static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lis
   }
   while((_Bool)1);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct cut_list *cut_lists = (struct cut_list *)((void *)0);

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -591,6 +591,9 @@ static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lis
 }
 
 // file coreutils/cut.c line 185
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct cut_list *cut_lists = (struct cut_list *)NULL;

--- a/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/cut_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2548,6 +2548,9 @@ static void cut_file(struct _IO_FILE *file, char delim, struct cut_list *cut_lis
   }
   while((_Bool)1);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct cut_list *cut_lists = (struct cut_list *)((void *)0);

--- a/c/busybox-1.22.0/date_false-no-overflow.c
+++ b/c/busybox-1.22.0/date_false-no-overflow.c
@@ -387,6 +387,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/date.c line 174
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct timespec ts;

--- a/c/busybox-1.22.0/date_false-no-overflow.i
+++ b/c/busybox-1.22.0/date_false-no-overflow.i
@@ -2623,6 +2623,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct timespec ts;

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -389,6 +389,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/date.c line 174
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct timespec ts;

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -392,6 +392,11 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 void syslog(int priority, const char *format, ...)
 {
 }
+int stime (const time_t *__when)
+{
+        (void) __when;
+        return __VERIFIER_nondet_int();
+}
 signed int __main(signed int argc, char **argv)
 {
   struct timespec ts;

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2644,6 +2644,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct timespec ts;

--- a/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/date_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2647,6 +2647,11 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 void syslog(int priority, const char *format, ...)
 {
 }
+int stime (const time_t *__when)
+{
+        (void) __when;
+        return __VERIFIER_nondet_int();
+}
 signed int __main(signed int argc, char **argv)
 {
   struct timespec ts;

--- a/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.c
@@ -47,6 +47,9 @@ static void bb_show_usage(void)
 }
 
 // file coreutils/dirname.c line 29
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *return_value_single_argv$1;

--- a/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/dirname_true-no-overflow_true-valid-memsafety.i
@@ -1128,6 +1128,9 @@ static void bb_show_usage(void)
 {
   ;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *return_value_single_argv$1;

--- a/c/busybox-1.22.0/du_false-no-overflow.c
+++ b/c/busybox-1.22.0/du_false-no-overflow.c
@@ -565,6 +565,9 @@ static unsigned long long int du(const char *filename)
 }
 
 // file coreutils/du.c line 193
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long long int total;

--- a/c/busybox-1.22.0/du_false-no-overflow.i
+++ b/c/busybox-1.22.0/du_false-no-overflow.i
@@ -2847,6 +2847,9 @@ static unsigned long long int du(const char *filename)
     print(sum, filename);
   return sum;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long long int total;

--- a/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.c
@@ -565,6 +565,9 @@ static unsigned long long int du(const char *filename)
 }
 
 // file coreutils/du.c line 193
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long long int total;

--- a/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/du_true-no-overflow_true-valid-memsafety.i
@@ -2847,6 +2847,9 @@ static unsigned long long int du(const char *filename)
     print(sum, filename);
   return sum;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long long int total;

--- a/c/busybox-1.22.0/echo_false-no-overflow.c
+++ b/c/busybox-1.22.0/echo_false-no-overflow.c
@@ -266,6 +266,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/echo.c line 66
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/echo_false-no-overflow.i
+++ b/c/busybox-1.22.0/echo_false-no-overflow.i
@@ -2388,6 +2388,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.c
@@ -266,6 +266,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
 }
 
 // file coreutils/echo.c line 66
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/echo_true-no-overflow_true-valid-memsafety.i
@@ -2388,6 +2388,9 @@ static void bb_verror_msg(const char *s, va_list p, const char *strerr)
     syslog(3, "%s", msg + (signed long int)applet_len);
   free((void *)msg);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/expand_false-no-overflow.c
+++ b/c/busybox-1.22.0/expand_false-no-overflow.c
@@ -503,6 +503,9 @@ static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int op
 }
 
 // file coreutils/expand.c line 154
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *opt_t = "8";

--- a/c/busybox-1.22.0/expand_false-no-overflow.i
+++ b/c/busybox-1.22.0/expand_false-no-overflow.i
@@ -2474,6 +2474,9 @@ static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int op
   }
   while((_Bool)1);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *opt_t = "8";

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -503,6 +503,9 @@ static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int op
 }
 
 // file coreutils/expand.c line 154
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *opt_t = "8";

--- a/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/expand_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2474,6 +2474,9 @@ static void expand(struct _IO_FILE *file, unsigned int tab_size, unsigned int op
   }
   while((_Bool)1);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *opt_t = "8";

--- a/c/busybox-1.22.0/fold_false-no-overflow.c
+++ b/c/busybox-1.22.0/fold_false-no-overflow.c
@@ -424,6 +424,9 @@ static void fflush_stdout_and_exit(signed int retval)
 }
 
 // file coreutils/fold.c line 65
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *line_out = (char *)NULL;

--- a/c/busybox-1.22.0/fold_false-no-overflow.i
+++ b/c/busybox-1.22.0/fold_false-no-overflow.i
@@ -2417,6 +2417,9 @@ static void fflush_stdout_and_exit(signed int retval)
   }
   exit(retval);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *line_out = (char *)((void *)0);

--- a/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.c
@@ -424,6 +424,9 @@ static void fflush_stdout_and_exit(signed int retval)
 }
 
 // file coreutils/fold.c line 65
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *line_out = (char *)NULL;

--- a/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/fold_true-no-overflow_true-valid-memsafety.i
@@ -2417,6 +2417,9 @@ static void fflush_stdout_and_exit(signed int retval)
   }
   exit(retval);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *line_out = (char *)((void *)0);

--- a/c/busybox-1.22.0/head_false-no-overflow.c
+++ b/c/busybox-1.22.0/head_false-no-overflow.c
@@ -475,6 +475,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/head.c line 154
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int count = (unsigned long int)10;

--- a/c/busybox-1.22.0/head_false-no-overflow.i
+++ b/c/busybox-1.22.0/head_false-no-overflow.i
@@ -2467,6 +2467,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int count = (unsigned long int)10;

--- a/c/busybox-1.22.0/head_false-valid-deref.c
+++ b/c/busybox-1.22.0/head_false-valid-deref.c
@@ -475,6 +475,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/head.c line 154
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int count = (unsigned long int)10;

--- a/c/busybox-1.22.0/head_false-valid-deref.i
+++ b/c/busybox-1.22.0/head_false-valid-deref.i
@@ -2467,6 +2467,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int count = (unsigned long int)10;

--- a/c/busybox-1.22.0/head_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/head_true-no-overflow_true-valid-memsafety.c
@@ -475,6 +475,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/head.c line 154
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int count = (unsigned long int)10;

--- a/c/busybox-1.22.0/head_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/head_true-no-overflow_true-valid-memsafety.i
@@ -2467,6 +2467,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned long int count = (unsigned long int)10;

--- a/c/busybox-1.22.0/hostid_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/hostid_true-no-overflow_true-valid-memsafety.c
@@ -54,6 +54,9 @@ static signed int fflush_all(void)
 }
 
 // file coreutils/hostid.c line 33
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/hostid_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/hostid_true-no-overflow_true-valid-memsafety.i
@@ -1760,6 +1760,9 @@ static signed int fflush_all(void)
   return_value_fflush$1=fflush((struct _IO_FILE *)((void *)0));
   return return_value_fflush$1;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   if(!(*(1l + argv) == ((char *)((void *)0))))

--- a/c/busybox-1.22.0/logname_false-no-overflow.c
+++ b/c/busybox-1.22.0/logname_false-no-overflow.c
@@ -216,6 +216,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/logname.c line 37
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char buf[64l];

--- a/c/busybox-1.22.0/logname_false-no-overflow.i
+++ b/c/busybox-1.22.0/logname_false-no-overflow.i
@@ -2346,6 +2346,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char buf[64l];

--- a/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.c
@@ -216,6 +216,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/logname.c line 37
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char buf[64l];

--- a/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/logname_true-no-overflow_true-valid-memsafety.i
@@ -2346,6 +2346,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char buf[64l];

--- a/c/busybox-1.22.0/ls-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/ls-incomplete_false-no-overflow.c
@@ -1920,6 +1920,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
 }
 
 // file coreutils/ls.c line 1064
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct dnode **dnd;

--- a/c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-no-overflow.i
@@ -3969,6 +3969,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
   *list_head = (struct llist_t *)return_value_xzalloc$1;
   (*list_head)->data = (char *)data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct dnode **dnd;

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1920,6 +1920,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
 }
 
 // file coreutils/ls.c line 1064
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct dnode **dnd;

--- a/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/ls-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3969,6 +3969,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
   *list_head = (struct llist_t *)return_value_xzalloc$1;
   (*list_head)->data = (char *)data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct dnode **dnd;

--- a/c/busybox-1.22.0/mkdir_false-no-overflow.c
+++ b/c/busybox-1.22.0/mkdir_false-no-overflow.c
@@ -1139,6 +1139,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
 }
 
 // file coreutils/mkdir.c line 56
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed long int mode = (signed long int)-1;

--- a/c/busybox-1.22.0/mkdir_false-no-overflow.i
+++ b/c/busybox-1.22.0/mkdir_false-no-overflow.i
@@ -3259,6 +3259,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
   *list_head = (struct llist_t *)return_value_xzalloc$1;
   (*list_head)->data = (char *)data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed long int mode = (signed long int)-1;

--- a/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.c
@@ -1139,6 +1139,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
 }
 
 // file coreutils/mkdir.c line 56
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed long int mode = (signed long int)-1;

--- a/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkdir_true-no-overflow_true-valid-memsafety.i
@@ -3259,6 +3259,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
   *list_head = (struct llist_t *)return_value_xzalloc$1;
   (*list_head)->data = (char *)data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed long int mode = (signed long int)-1;

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.c
@@ -211,6 +211,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/mkfifo.c line 28
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned int mode;

--- a/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete_false-no-overflow.i
@@ -1999,6 +1999,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned int mode;

--- a/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.c
@@ -211,6 +211,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/mkfifo.c line 28
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned int mode;

--- a/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/mkfifo-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -1999,6 +1999,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   unsigned int mode;

--- a/c/busybox-1.22.0/od_false-no-overflow.c
+++ b/c/busybox-1.22.0/od_false-no-overflow.c
@@ -2046,6 +2046,9 @@ static void * llist_pop(struct llist_t **head)
 }
 
 // file coreutils/od_bloaty.c line 1167
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *str_A;

--- a/c/busybox-1.22.0/od_false-no-overflow.i
+++ b/c/busybox-1.22.0/od_false-no-overflow.i
@@ -3900,6 +3900,9 @@ static void * llist_pop(struct llist_t **head)
   }
   return data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *str_A;

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -2046,6 +2046,9 @@ static void * llist_pop(struct llist_t **head)
 }
 
 // file coreutils/od_bloaty.c line 1167
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *str_A;

--- a/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/od_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3900,6 +3900,9 @@ static void * llist_pop(struct llist_t **head)
   }
   return data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *str_A;

--- a/c/busybox-1.22.0/printf_false-no-overflow.c
+++ b/c/busybox-1.22.0/printf_false-no-overflow.c
@@ -1157,6 +1157,9 @@ static char ** print_formatted(char *f, char **argv, signed int *conv_err)
 }
 
 // file coreutils/printf.c line 376
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int conv_err;

--- a/c/busybox-1.22.0/printf_false-no-overflow.i
+++ b/c/busybox-1.22.0/printf_false-no-overflow.i
@@ -3167,6 +3167,9 @@ static char ** print_formatted(char *f, char **argv, signed int *conv_err)
   }
   return argv;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int conv_err;

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1157,6 +1157,9 @@ static char ** print_formatted(char *f, char **argv, signed int *conv_err)
 }
 
 // file coreutils/printf.c line 376
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int conv_err;

--- a/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/printf_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3167,6 +3167,9 @@ static char ** print_formatted(char *f, char **argv, signed int *conv_err)
   }
   return argv;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int conv_err;

--- a/c/busybox-1.22.0/readlink_false-no-overflow.c
+++ b/c/busybox-1.22.0/readlink_false-no-overflow.c
@@ -843,6 +843,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
 }
 
 // file coreutils/readlink.c line 49
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *buf;

--- a/c/busybox-1.22.0/readlink_false-no-overflow.i
+++ b/c/busybox-1.22.0/readlink_false-no-overflow.i
@@ -2778,6 +2778,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
   *list_head = (struct llist_t *)return_value_xzalloc$1;
   (*list_head)->data = (char *)data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *buf;

--- a/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.c
@@ -843,6 +843,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
 }
 
 // file coreutils/readlink.c line 49
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *buf;

--- a/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/readlink_true-no-overflow_true-valid-memsafety.i
@@ -2778,6 +2778,9 @@ static void llist_add_to_end(struct llist_t **list_head, void *data)
   *list_head = (struct llist_t *)return_value_xzalloc$1;
   (*list_head)->data = (char *)data;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char *buf;

--- a/c/busybox-1.22.0/realpath_false-no-overflow.c
+++ b/c/busybox-1.22.0/realpath_false-no-overflow.c
@@ -269,6 +269,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/realpath.c line 21
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int retval = 0;

--- a/c/busybox-1.22.0/realpath_false-no-overflow.i
+++ b/c/busybox-1.22.0/realpath_false-no-overflow.i
@@ -2384,6 +2384,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int retval = 0;

--- a/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.c
@@ -269,6 +269,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/realpath.c line 21
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int retval = 0;

--- a/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/realpath_true-no-overflow_true-valid-memsafety.i
@@ -2384,6 +2384,9 @@ static signed long int full_write(signed int fd, const void *buf, unsigned long 
   }
   return total;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int retval = 0;

--- a/c/busybox-1.22.0/rm_false-no-overflow.c
+++ b/c/busybox-1.22.0/rm_false-no-overflow.c
@@ -1138,6 +1138,9 @@ static signed int remove_file(const char *path, signed int flags)
 }
 
 // file coreutils/rm.c line 34
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int status = 0;

--- a/c/busybox-1.22.0/rm_false-no-overflow.i
+++ b/c/busybox-1.22.0/rm_false-no-overflow.i
@@ -3341,6 +3341,9 @@ static signed int remove_file(const char *path, signed int flags)
   }
   return 0;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int status = 0;

--- a/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.c
@@ -1138,6 +1138,9 @@ static signed int remove_file(const char *path, signed int flags)
 }
 
 // file coreutils/rm.c line 34
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int status = 0;

--- a/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/rm_true-no-overflow_true-valid-memsafety.i
@@ -3341,6 +3341,9 @@ static signed int remove_file(const char *path, signed int flags)
   }
   return 0;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int status = 0;

--- a/c/busybox-1.22.0/seq_false-no-overflow.c
+++ b/c/busybox-1.22.0/seq_false-no-overflow.c
@@ -808,6 +808,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/seq.c line 23
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double first;

--- a/c/busybox-1.22.0/seq_false-no-overflow.i
+++ b/c/busybox-1.22.0/seq_false-no-overflow.i
@@ -2755,6 +2755,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double first;

--- a/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.c
@@ -808,6 +808,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/seq.c line 23
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double first;

--- a/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/seq_true-no-overflow_true-valid-memsafety.i
@@ -2755,6 +2755,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double first;

--- a/c/busybox-1.22.0/sleep_false-no-overflow.c
+++ b/c/busybox-1.22.0/sleep_false-no-overflow.c
@@ -248,6 +248,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/sleep.c line 52
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_false-no-overflow.i
+++ b/c/busybox-1.22.0/sleep_false-no-overflow.i
@@ -2493,6 +2493,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_false-valid-deref.c
+++ b/c/busybox-1.22.0/sleep_false-valid-deref.c
@@ -270,6 +270,9 @@ int nanosleep (const struct timespec *__requested_time,
 }
 
 // file coreutils/sleep.c line 52
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_false-valid-deref.c
+++ b/c/busybox-1.22.0/sleep_false-valid-deref.c
@@ -247,6 +247,28 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   return n;
 }
 
+int nanosleep (const struct timespec *__requested_time,
+               struct timespec *__remaining)
+{
+        if (__VERIFIER_nondet_int()) {
+                __remaining->tv_sec = 0;
+                __remaining->tv_nsec = 0;
+                return 0;
+        } else {
+                long tv_nsec = __VERIFIER_nondet_long();
+                time_t tv_sec = __VERIFIER_nondet_long();
+                __VERIFIER_assume(tv_nsec >= 0 &&
+                                  tv_nsec <= __requested_time->tv_nsec);
+                __VERIFIER_assume(tv_sec >= 0 &&
+                                  tv_sec <= __requested_time->tv_sec);
+                __remaining->tv_sec = __requested_time->tv_sec - tv_sec;
+                __remaining->tv_nsec = __requested_time->tv_nsec - tv_nsec;
+                *bb_errno = __VERIFIER_nondet_int();
+                __VERIFIER_assume(*bb_errno != 0);
+                return -1;
+        }
+}
+
 // file coreutils/sleep.c line 52
 signed int __main(signed int argc, char **argv)
 {

--- a/c/busybox-1.22.0/sleep_false-valid-deref.i
+++ b/c/busybox-1.22.0/sleep_false-valid-deref.i
@@ -2514,6 +2514,9 @@ int nanosleep (const struct timespec *__requested_time,
                 return -1;
         }
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_false-valid-deref.i
+++ b/c/busybox-1.22.0/sleep_false-valid-deref.i
@@ -2493,6 +2493,27 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+int nanosleep (const struct timespec *__requested_time,
+               struct timespec *__remaining)
+{
+        if (__VERIFIER_nondet_int()) {
+                __remaining->tv_sec = 0;
+                __remaining->tv_nsec = 0;
+                return 0;
+        } else {
+                long tv_nsec = __VERIFIER_nondet_long();
+                time_t tv_sec = __VERIFIER_nondet_long();
+                __VERIFIER_assume(tv_nsec >= 0 &&
+                                  tv_nsec <= __requested_time->tv_nsec);
+                __VERIFIER_assume(tv_sec >= 0 &&
+                                  tv_sec <= __requested_time->tv_sec);
+                __remaining->tv_sec = __requested_time->tv_sec - tv_sec;
+                __remaining->tv_nsec = __requested_time->tv_nsec - tv_nsec;
+                *bb_errno = __VERIFIER_nondet_int();
+                __VERIFIER_assume(*bb_errno != 0);
+                return -1;
+        }
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.c
@@ -270,6 +270,9 @@ int nanosleep (const struct timespec *__requested_time,
 }
 
 // file coreutils/sleep.c line 52
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.c
@@ -247,6 +247,28 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   return n;
 }
 
+int nanosleep (const struct timespec *__requested_time,
+               struct timespec *__remaining)
+{
+        if (__VERIFIER_nondet_int()) {
+                __remaining->tv_sec = 0;
+                __remaining->tv_nsec = 0;
+                return 0;
+        } else {
+                long tv_nsec = __VERIFIER_nondet_long();
+                time_t tv_sec = __VERIFIER_nondet_long();
+                __VERIFIER_assume(tv_nsec >= 0 &&
+                                  tv_nsec <= __requested_time->tv_nsec);
+                __VERIFIER_assume(tv_sec >= 0 &&
+                                  tv_sec <= __requested_time->tv_sec);
+                __remaining->tv_sec = __requested_time->tv_sec - tv_sec;
+                __remaining->tv_nsec = __requested_time->tv_nsec - tv_nsec;
+                *bb_errno = __VERIFIER_nondet_int();
+                __VERIFIER_assume(*bb_errno != 0);
+                return -1;
+        }
+}
+
 // file coreutils/sleep.c line 52
 signed int __main(signed int argc, char **argv)
 {

--- a/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.i
@@ -2514,6 +2514,9 @@ int nanosleep (const struct timespec *__requested_time,
                 return -1;
         }
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sleep_true-no-overflow_true-valid-memsafety.i
@@ -2493,6 +2493,27 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+int nanosleep (const struct timespec *__requested_time,
+               struct timespec *__remaining)
+{
+        if (__VERIFIER_nondet_int()) {
+                __remaining->tv_sec = 0;
+                __remaining->tv_nsec = 0;
+                return 0;
+        } else {
+                long tv_nsec = __VERIFIER_nondet_long();
+                time_t tv_sec = __VERIFIER_nondet_long();
+                __VERIFIER_assume(tv_nsec >= 0 &&
+                                  tv_nsec <= __requested_time->tv_nsec);
+                __VERIFIER_assume(tv_sec >= 0 &&
+                                  tv_sec <= __requested_time->tv_sec);
+                __remaining->tv_sec = __requested_time->tv_sec - tv_sec;
+                __remaining->tv_nsec = __requested_time->tv_nsec - tv_nsec;
+                *bb_errno = __VERIFIER_nondet_int();
+                __VERIFIER_assume(*bb_errno != 0);
+                return -1;
+        }
+}
 signed int __main(signed int argc, char **argv)
 {
   double duration;

--- a/c/busybox-1.22.0/stty_false-no-overflow.c
+++ b/c/busybox-1.22.0/stty_false-no-overflow.c
@@ -1816,6 +1816,9 @@ static void set_window_size(signed int rows, signed int cols)
 }
 
 // file coreutils/stty.c line 1251
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct termios mode;

--- a/c/busybox-1.22.0/stty_false-no-overflow.i
+++ b/c/busybox-1.22.0/stty_false-no-overflow.i
@@ -3719,6 +3719,9 @@ static void set_window_size(signed int rows, signed int cols)
     perror_on_device("%s");
   }
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct termios mode;

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1816,6 +1816,9 @@ static void set_window_size(signed int rows, signed int cols)
 }
 
 // file coreutils/stty.c line 1251
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct termios mode;

--- a/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/stty_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3719,6 +3719,9 @@ static void set_window_size(signed int rows, signed int cols)
     perror_on_device("%s");
   }
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct termios mode;

--- a/c/busybox-1.22.0/sync_false-no-overflow.c
+++ b/c/busybox-1.22.0/sync_false-no-overflow.c
@@ -209,6 +209,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/sync.c line 22
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/sync_false-no-overflow.i
+++ b/c/busybox-1.22.0/sync_false-no-overflow.i
@@ -1895,6 +1895,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   bb_warn_ignoring_args(argv[(signed long int)1]);

--- a/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.c
@@ -209,6 +209,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/sync.c line 22
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/sync_true-no-overflow_true-valid-memsafety.i
@@ -1895,6 +1895,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   bb_warn_ignoring_args(argv[(signed long int)1]);

--- a/c/busybox-1.22.0/tac_false-no-overflow.c
+++ b/c/busybox-1.22.0/tac_false-no-overflow.c
@@ -893,6 +893,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/tac.c line 34
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **name;

--- a/c/busybox-1.22.0/tac_false-no-overflow.i
+++ b/c/busybox-1.22.0/tac_false-no-overflow.i
@@ -2815,6 +2815,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **name;

--- a/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.c
@@ -893,6 +893,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/tac.c line 34
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **name;

--- a/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tac_true-no-overflow_true-valid-memsafety.i
@@ -2815,6 +2815,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **name;

--- a/c/busybox-1.22.0/tee_false-no-overflow.c
+++ b/c/busybox-1.22.0/tee_false-no-overflow.c
@@ -919,6 +919,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/tee.c line 28
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *mode = "w";

--- a/c/busybox-1.22.0/tee_false-no-overflow.i
+++ b/c/busybox-1.22.0/tee_false-no-overflow.i
@@ -2838,6 +2838,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *mode = "w";

--- a/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.c
@@ -919,6 +919,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/tee.c line 28
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *mode = "w";

--- a/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/tee_true-no-overflow_true-valid-memsafety.i
@@ -2838,6 +2838,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *mode = "w";

--- a/c/busybox-1.22.0/test-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/test-incomplete_false-no-overflow.c
@@ -993,6 +993,9 @@ static signed int test_eaccess(char *path, signed int mode)
 }
 
 // file coreutils/test.c line 825
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int res;

--- a/c/busybox-1.22.0/test-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/test-incomplete_false-no-overflow.i
@@ -3124,6 +3124,9 @@ static signed int test_eaccess(char *path, signed int mode)
     return 0;
   return -1;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int res;

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -993,6 +993,9 @@ static signed int test_eaccess(char *path, signed int mode)
 }
 
 // file coreutils/test.c line 825
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int res;

--- a/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/test-incomplete_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3124,6 +3124,9 @@ static signed int test_eaccess(char *path, signed int mode)
     return 0;
   return -1;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int res;

--- a/c/busybox-1.22.0/touch_false-no-overflow.c
+++ b/c/busybox-1.22.0/touch_false-no-overflow.c
@@ -1208,6 +1208,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/touch.c line 89
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int fd;

--- a/c/busybox-1.22.0/touch_false-no-overflow.i
+++ b/c/busybox-1.22.0/touch_false-no-overflow.i
@@ -3390,6 +3390,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int fd;

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -1210,6 +1210,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/touch.c line 89
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int fd;

--- a/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/touch_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -3411,6 +3411,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   signed int fd;

--- a/c/busybox-1.22.0/uname_false-no-overflow.c
+++ b/c/busybox-1.22.0/uname_false-no-overflow.c
@@ -871,6 +871,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/uname.c line 91
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct anonymous uname_info;

--- a/c/busybox-1.22.0/uname_false-no-overflow.i
+++ b/c/busybox-1.22.0/uname_false-no-overflow.i
@@ -2810,6 +2810,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct anonymous uname_info;

--- a/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.c
@@ -871,6 +871,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/uname.c line 91
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct anonymous uname_info;

--- a/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uname_true-no-overflow_true-valid-memsafety.i
@@ -2810,6 +2810,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct anonymous uname_info;

--- a/c/busybox-1.22.0/uniq_false-no-overflow.c
+++ b/c/busybox-1.22.0/uniq_false-no-overflow.c
@@ -950,6 +950,9 @@ static char * skip_whitespace(const char *s)
 }
 
 // file coreutils/uniq.c line 33
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *input_filename;

--- a/c/busybox-1.22.0/uniq_false-no-overflow.i
+++ b/c/busybox-1.22.0/uniq_false-no-overflow.i
@@ -2972,6 +2972,9 @@ static char * skip_whitespace(const char *s)
     }
   return (char *)s;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *input_filename;

--- a/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.c
@@ -950,6 +950,9 @@ static char * skip_whitespace(const char *s)
 }
 
 // file coreutils/uniq.c line 33
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *input_filename;

--- a/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uniq_true-no-overflow_true-valid-memsafety.i
@@ -2972,6 +2972,9 @@ static char * skip_whitespace(const char *s)
     }
   return (char *)s;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *input_filename;

--- a/c/busybox-1.22.0/usleep_false-no-overflow.c
+++ b/c/busybox-1.22.0/usleep_false-no-overflow.c
@@ -257,6 +257,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/usleep.c line 26
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/usleep_false-no-overflow.i
+++ b/c/busybox-1.22.0/usleep_false-no-overflow.i
@@ -2373,6 +2373,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   if(*(1l + argv) == ((char *)((void *)0)))

--- a/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.c
@@ -257,6 +257,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/usleep.c line 26
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/usleep_true-no-overflow_true-valid-memsafety.i
@@ -2373,6 +2373,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   if(*(1l + argv) == ((char *)((void *)0)))

--- a/c/busybox-1.22.0/uudecode_false-no-overflow.c
+++ b/c/busybox-1.22.0/uudecode_false-no-overflow.c
@@ -1396,6 +1396,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/uudecode.c line 92
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct _IO_FILE *src_stream;

--- a/c/busybox-1.22.0/uudecode_false-no-overflow.i
+++ b/c/busybox-1.22.0/uudecode_false-no-overflow.i
@@ -3323,6 +3323,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct _IO_FILE *src_stream;

--- a/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.c
@@ -1396,6 +1396,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/uudecode.c line 92
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct _IO_FILE *src_stream;

--- a/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/uudecode_true-no-overflow_true-valid-memsafety.i
@@ -3323,6 +3323,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct _IO_FILE *src_stream;

--- a/c/busybox-1.22.0/wc_false-no-overflow.c
+++ b/c/busybox-1.22.0/wc_false-no-overflow.c
@@ -981,6 +981,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/wc.c line 92
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *arg;

--- a/c/busybox-1.22.0/wc_false-no-overflow.i
+++ b/c/busybox-1.22.0/wc_false-no-overflow.i
@@ -2885,6 +2885,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *arg;

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.c
@@ -981,6 +981,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/wc.c line 92
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *arg;

--- a/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/wc_false-unreach-call_true-no-overflow_true-valid-memsafety.i
@@ -2885,6 +2885,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   const char *arg;

--- a/c/busybox-1.22.0/who_false-no-overflow.c
+++ b/c/busybox-1.22.0/who_false-no-overflow.c
@@ -866,6 +866,9 @@ int stat(const char *__file, struct stat *__buf)
 }
 
 // file coreutils/who.c line 74
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct utmp *ut;

--- a/c/busybox-1.22.0/who_false-no-overflow.i
+++ b/c/busybox-1.22.0/who_false-no-overflow.i
@@ -3027,6 +3027,9 @@ int stat(const char *__file, struct stat *__buf)
   __VERIFIER_assume(__buf->st_atim.tv_sec >= 0);
   return 0;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct utmp *ut;

--- a/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.c
@@ -866,6 +866,9 @@ int stat(const char *__file, struct stat *__buf)
 }
 
 // file coreutils/who.c line 74
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct utmp *ut;

--- a/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/who_true-no-overflow_true-valid-memsafety.i
@@ -3027,6 +3027,9 @@ int stat(const char *__file, struct stat *__buf)
   __VERIFIER_assume(__buf->st_atim.tv_sec >= 0);
   return 0;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   struct utmp *ut;

--- a/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.c
+++ b/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.c
@@ -231,6 +231,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/whoami.c line 22
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
+++ b/c/busybox-1.22.0/whoami-incomplete_false-no-overflow.i
@@ -2391,6 +2391,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   if(!(*(1l + argv) == ((char *)((void *)0))))

--- a/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.c
@@ -231,6 +231,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
 }
 
 // file coreutils/whoami.c line 22
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
 

--- a/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/whoami-incomplete_true-no-overflow_true-valid-memsafety.i
@@ -2391,6 +2391,9 @@ static signed long int safe_write(signed int fd, const void *buf, unsigned long 
   while(tmp_if_expr$1 != (_Bool)0);
   return n;
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   if(!(*(1l + argv) == ((char *)((void *)0))))

--- a/c/busybox-1.22.0/yes_false-no-overflow.c
+++ b/c/busybox-1.22.0/yes_false-no-overflow.c
@@ -248,6 +248,9 @@ static void xfunc_die(void)
 }
 
 // file coreutils/yes.c line 27
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/yes_false-no-overflow.i
+++ b/c/busybox-1.22.0/yes_false-no-overflow.i
@@ -2371,6 +2371,9 @@ static void xfunc_die(void)
   }
   exit((signed int)xfunc_error_retval);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.c
+++ b/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.c
@@ -248,6 +248,9 @@ static void xfunc_die(void)
 }
 
 // file coreutils/yes.c line 27
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;

--- a/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.i
+++ b/c/busybox-1.22.0/yes_true-no-overflow_true-valid-memsafety.i
@@ -2371,6 +2371,9 @@ static void xfunc_die(void)
   }
   exit((signed int)xfunc_error_retval);
 }
+void syslog(int priority, const char *format, ...)
+{
+}
 signed int __main(signed int argc, char **argv)
 {
   char **pp;


### PR DESCRIPTION
Define `syslog` function and replace `_IO_getc` with `getc`. Part of #620.