### PR TITLE
include several 'mem-cleanup'-files in set-files.

### DIFF
--- a/c/MemSafety-Heap.set
+++ b/c/MemSafety-Heap.set
@@ -9,6 +9,7 @@ memsafety-ext2/*_true-valid-memsafety*.i
 list-ext-properties/*_false-valid-deref*.i
 list-ext-properties/*_false-valid-free*.i
 list-ext-properties/*_false-valid-memtrack*.i
+list-ext-properties/*_false-valid-memcleanup*.i
 list-ext-properties/*_true-valid-memsafety*.i
 # memory-alloca/*_false-valid-deref*.i
 # memory-alloca/*_false-valid-free*.i

--- a/c/MemSafety-LinkedLists.set
+++ b/c/MemSafety-LinkedLists.set
@@ -1,9 +1,12 @@
 heap-manipulation/*_true-valid-memsafety*.i
 heap-manipulation/*_false-valid-deref*.i
 heap-manipulation/*_false-valid-memtrack*.i
+heap-manipulation/*_false-valid-memcleanup*.i
 forester-heap/*_false-valid-memtrack*.i
+forester-heap/*_false-valid-memcleanup*.i
 list-properties/*_true-valid-memsafety*.i
 list-properties/*_false-valid-memtrack*.i
+list-properties/*_false-valid-memcleanup*.i
 ddv-machzwd/*_true-valid-memsafety*.i
 ddv-machzwd/*_false-valid-memtrack*.i
 forester-heap/*_true-valid-memsafety*.i


### PR DESCRIPTION
Some tasks have not yet been included in the corresponding set-files for memory-safety. Was there a reason for this?
I assume that "mem-cleanup" is a valid property for this year, because it appears in the [rules](https://sv-comp.sosy-lab.org/2019/rules.php).