### PR TITLE
Fix calls to nonstandard extern functions in SSH programs

### DIFF
--- a/c/loops/s3_false-unreach-call.i
+++ b/c/loops/s3_false-unreach-call.i
@@ -1645,3 +1645,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_false-unreach-call.i.cil.c
@@ -1646,3 +1646,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.01_true-unreach-call.i.cil.c
@@ -1646,3 +1646,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_false-unreach-call.i.cil.c
@@ -1643,3 +1643,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.02_true-unreach-call.i.cil.c
@@ -1644,3 +1644,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_false-unreach-call.i.cil.c
@@ -1643,3 +1643,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.03_true-unreach-call.i.cil.c
@@ -1643,3 +1643,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_false-unreach-call.i.cil.c
@@ -1643,3 +1643,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_clnt.blast.04_true-unreach-call.i.cil.c
@@ -1643,3 +1643,14 @@ int ssl3_connect(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1709,38 +1704,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_false-unreach-call.i.cil.c
@@ -1706,3 +1706,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1709,38 +1704,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.01_true-unreach-call.i.cil.c
@@ -1706,3 +1706,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1705,38 +1700,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_false-unreach-call.i.cil.c
@@ -1702,3 +1702,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1705,38 +1700,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.02_true-unreach-call.i.cil.c
@@ -1702,3 +1702,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
@@ -1703,3 +1703,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.03_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1706,38 +1701,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1705,38 +1700,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.04_false-unreach-call.i.cil.c
@@ -1702,3 +1702,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1777,38 +1772,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_false-unreach-call.i.cil.c
@@ -1774,3 +1774,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1781,38 +1776,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.06_true-unreach-call.i.cil.c
@@ -1778,3 +1778,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
@@ -1726,3 +1726,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1729,38 +1724,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
@@ -1726,3 +1726,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.07_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1729,38 +1724,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
@@ -1723,3 +1723,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1726,38 +1721,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1730,38 +1725,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.08_true-unreach-call.i.cil.c
@@ -1727,3 +1727,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
@@ -1726,3 +1726,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1729,38 +1724,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
@@ -1726,3 +1726,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.09_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1729,38 +1724,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
@@ -1711,3 +1711,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1714,38 +1709,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1718,38 +1713,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.10_true-unreach-call.i.cil.c
@@ -1715,3 +1715,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
@@ -1726,3 +1726,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1729,38 +1724,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
@@ -1726,3 +1726,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.11_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1729,38 +1724,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
@@ -1738,3 +1738,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1741,38 +1736,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
@@ -1742,3 +1742,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.12_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1745,38 +1740,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1730,38 +1725,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_false-unreach-call.i.cil.c
@@ -1727,3 +1727,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1730,38 +1725,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.13_true-unreach-call.i.cil.c
@@ -1727,3 +1727,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
@@ -1750,3 +1750,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1753,38 +1748,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
@@ -1754,3 +1754,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.14_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1757,38 +1752,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
@@ -1735,3 +1735,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1738,38 +1733,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1742,38 +1737,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.15_true-unreach-call.i.cil.c
@@ -1739,3 +1739,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
@@ -1762,3 +1762,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_false-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1765,38 +1760,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }

--- a/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
@@ -1766,3 +1766,14 @@ int ssl3_accept(SSL *s )
   ERROR: __VERIFIER_error();
 }
 }
+
+extern void *calloc(size_t, size_t);
+SSL_METHOD *sslv3_base_method() {
+  // Most fields of SSL_METHOD are function pointers that are not used here,
+  // so we initialize them to null.
+  // The only other fiels are "version" (initialized nondeterministically)
+  // and "ssl3_enc_method" (unused, set to null).
+  SSL_METHOD *method = calloc(1, sizeof(SSL_METHOD));
+  method->version = __VERIFIER_nondet_int();
+  return method;
+}

--- a/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
+++ b/c/ssh/s3_srvr.blast.16_true-unreach-call.i.cil.c
@@ -1021,13 +1021,8 @@ struct ssl3_enc_method {
 };
 extern void *memcpy(void * __restrict  __dest , void const   * __restrict  __src ,
                     size_t __n ) ;
-extern void ERR_put_error(int lib , int func , int reason , char const   *file , int line ) ;
 SSL_METHOD *SSLv3_server_method(void) ;
 extern SSL_METHOD *sslv3_base_method(void) ;
-extern X509 *ssl_get_server_send_cert(SSL * ) ;
-int ssl3_send_server_certificate(SSL *s ) ;
-extern int ssl3_do_write(SSL *s , int type ) ;
-extern unsigned long ssl3_output_cert_chain(SSL *s , X509 *x ) ;
 int ssl3_accept(SSL *s ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) ;
 static SSL_METHOD *ssl3_get_server_method(int ver ) 
@@ -1769,38 +1764,5 @@ int ssl3_accept(SSL *s )
   }
   return (ret);
   ERROR: __VERIFIER_error();
-}
-}
-int ssl3_send_server_certificate(SSL *s ) 
-{ unsigned long l ;
-  X509 *x ;
-  int tmp ;
-
-  {
-  if (s->state == 8512) {
-    {
-    x = ssl_get_server_send_cert(s);
-    }
-    if ((unsigned long )x == (unsigned long )((void *)0)) {
-      {
-      ERR_put_error(20, 154, 157, "s3_srvr.c", 1844);
-      }
-      return (0);
-    } else {
-
-    }
-    {
-    l = ssl3_output_cert_chain(s, x);
-    s->state = 8513;
-    s->init_num = (int )l;
-    s->init_off = 0;
-    }
-  } else {
-
-  }
-  {
-  tmp = ssl3_do_write(s, 22);
-  }
-  return (tmp);
 }
 }


### PR DESCRIPTION
This fixes all the calls to nonstandard extern functions in the programs from `c/ssh` (and the one SSH program in `c/loops`, which was copied from them).

Basically, there was only one external function, which should allocate some memory. A stub for this was manually written. My assumption is that using `calloc` to initialize a struct safely initializes all fields with `0`.

There was also some dead code (an uncalled function) that called extern functions, which was simply removed.