### PR TITLE
Revert "Integrate property valid-memcleanup into valid-mamsafety, as suggeste…"

### DIFF
--- a/c/properties/valid-memcleanup.prp
+++ b/c/properties/valid-memcleanup.prp
@@ -1,0 +1,2 @@
+CHECK( init(main()), LTL(G valid-memcleanup) )
+

--- a/c/properties/valid-memsafety.prp
+++ b/c/properties/valid-memsafety.prp
@@ -1,5 +1,4 @@
 CHECK( init(main()), LTL(G valid-free) )
 CHECK( init(main()), LTL(G valid-deref) )
 CHECK( init(main()), LTL(G valid-memtrack) )
-CHECK( init(main()), LTL(G valid-memcleanup) )
 


### PR DESCRIPTION
Reverts sosy-lab/sv-benchmarks#632

This pull request does not correctly implement the rules.
Memcleanup needs to be a new sub-category of category MemorySafety.