### PR TITLE
Add symbolic link MemSafety-MemCleanup.prp to property for convenience and consistency

### DIFF
--- a/c/MemSafety-MemCleanup.prp
+++ b/c/MemSafety-MemCleanup.prp
@@ -1,0 +1,1 @@
+properties/valid-memcleanup.prp


### PR DESCRIPTION
This is a follow up completion step.
The link is not really necessary, but it was done this way for the other categories.

Belongs to issue #633.