### PR TITLE
Add a proper initialization to correspond the false verdict

### DIFF
--- a/c/ConcurrencySafety-Main.set
+++ b/c/ConcurrencySafety-Main.set
@@ -11,6 +11,7 @@ pthread-lit/*_true-unreach-call*.i
 ldv-races/*_true-unreach-call*.i
 ldv-races/*_false-unreach-call*.i
 ldv-linux-3.14-races/*_false-unreach-call*.i
+ldv-linux-3.14-races/*_true-unreach-call*.i
 pthread-complex/*_false-unreach-call*.i
 pthread-complex/*_true-unreach-call*.i
 pthread-driver-races/*_true-unreach-call*.i

--- a/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_true-unreach-call.cil.i
+++ b/c/ldv-linux-3.14-races/linux-3.14--drivers--media--platform--marvell-ccic--cafe_ccic.ko_true-unreach-call.cil.i
@@ -6152,7 +6152,6 @@ int ldv_emg_request_irq(unsigned int arg0 , irqreturn_t (*arg1)(int , void * ) ,
   }
 }
 }
-static bool alloc_bufs_at_read ;
 void *ldv_insmod_5(void *arg0 )
 {
   void (*ldv_5_cafe_exit_default)(void) ;
@@ -6172,7 +6171,6 @@ void *ldv_insmod_5(void *arg0 )
   ldv_5_ret_default = ldv_insmod_cafe_init_5_9(ldv_5_cafe_init_default);
   ldv_5_ret_default = ldv_post_init(ldv_5_ret_default);
   tmp___1 = ldv_undef_int();
-  alloc_bufs_at_read = ldv_undef_int();
   }
   if (tmp___1 != 0) {
     {
@@ -7356,6 +7354,7 @@ __inline static void mcam_reg_clear_bit(struct mcam_camera *cam , unsigned int r
   return;
 }
 }
+static bool alloc_bufs_at_read ;
 static int n_dma_bufs = 3;
 static int dma_buf_size = 614400;
 static bool flip ;


### PR DESCRIPTION
Add an initialization of a global variable with a nondeterministic value. Add an old version of the benchmark as 'true_unreach_call'.