### PR TITLE
change pthread tasks to avoid overflows.

### DIFF
--- a/c/pthread/triangular-longer_false-unreach-call.c
+++ b/c/pthread/triangular-longer_false-unreach-call.c
@@ -5,20 +5,19 @@ extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 
 #define NUM 10
+#define LIMIT (2*NUM+6)
 
 void *t1(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    i = (j * (j + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    i = j + 1;
+  }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    j = (i * (i + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    j = i + 1;
+  }
   pthread_exit(NULL);
 }
 
@@ -28,7 +27,7 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= 276 || j >= 276) {
+  if (i >= LIMIT || j >= LIMIT) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular-longer_false-unreach-call.i
+++ b/c/pthread/triangular-longer_false-unreach-call.i
@@ -657,20 +657,22 @@ extern int pthread_atfork (void (*__prepare) (void),
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
-  for (int k = 0; k < 10; k++)
-    i = (j * (j + 1)) / 2;
+  for (int k = 0; k < 10; k++) {
+    i = j + 1;
+  }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
-  for (int k = 0; k < 10; k++)
-    j = (i * (i + 1)) / 2;
+  for (int k = 0; k < 10; k++) {
+    j = i + 1;
+  }
   pthread_exit(((void *)0));
 }
 int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= 276 || j >= 276) {
+  if (i >= (2*10 +6) || j >= (2*10 +6)) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular-longer_true-unreach-call.c
+++ b/c/pthread/triangular-longer_true-unreach-call.c
@@ -5,20 +5,19 @@ extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 
 #define NUM 10
+#define LIMIT (2*NUM+6)
 
 void *t1(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    i = (j * (j + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    i = j + 1;
+  }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    j = (i * (i + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    j = i + 1;
+  }
   pthread_exit(NULL);
 }
 
@@ -28,7 +27,7 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > 276 || j > 276) {
+  if (i > LIMIT || j > LIMIT) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular-longer_true-unreach-call.i
+++ b/c/pthread/triangular-longer_true-unreach-call.i
@@ -657,20 +657,22 @@ extern int pthread_atfork (void (*__prepare) (void),
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
-  for (int k = 0; k < 10; k++)
-    i = (j * (j + 1)) / 2;
+  for (int k = 0; k < 10; k++) {
+    i = j + 1;
+  }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
-  for (int k = 0; k < 10; k++)
-    j = (i * (i + 1)) / 2;
+  for (int k = 0; k < 10; k++) {
+    j = i + 1;
+  }
   pthread_exit(((void *)0));
 }
 int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > 276 || j > 276) {
+  if (i > (2*10 +6) || j > (2*10 +6)) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular-longest_false-unreach-call.c
+++ b/c/pthread/triangular-longest_false-unreach-call.c
@@ -5,20 +5,19 @@ extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 
 #define NUM 20
+#define LIMIT (2*NUM+6)
 
 void *t1(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    i = (j * (j + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    i = j + 1;
+  }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    j = (i * (i + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    j = i + 1;
+  }
   pthread_exit(NULL);
 }
 
@@ -28,7 +27,7 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= 946 || j >= 946) {
+  if (i >= LIMIT || j >= LIMIT) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular-longest_false-unreach-call.i
+++ b/c/pthread/triangular-longest_false-unreach-call.i
@@ -657,20 +657,22 @@ extern int pthread_atfork (void (*__prepare) (void),
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
-  for (int k = 0; k < 20; k++)
-    i = (j * (j + 1)) / 2;
+  for (int k = 0; k < 20; k++) {
+    i = j + 1;
+  }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
-  for (int k = 0; k < 20; k++)
-    j = (i * (i + 1)) / 2;
+  for (int k = 0; k < 20; k++) {
+    j = i + 1;
+  }
   pthread_exit(((void *)0));
 }
 int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= 946 || j >= 946) {
+  if (i >= (2*20 +6) || j >= (2*20 +6)) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular-longest_true-unreach-call.c
+++ b/c/pthread/triangular-longest_true-unreach-call.c
@@ -4,21 +4,20 @@ extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
 
-#define NUM 5
+#define NUM 20
+#define LIMIT (2*NUM+6)
 
 void *t1(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    i = (j * (j + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    i = j + 1;
+  }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    j = (i * (i + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    j = i + 1;
+  }
   pthread_exit(NULL);
 }
 
@@ -28,10 +27,11 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > 946 || j > 946) {
+  if (i > LIMIT || j > LIMIT) {
   ERROR:
     __VERIFIER_error();
   }
 
   return 0;
 }
+

--- a/c/pthread/triangular-longest_true-unreach-call.i
+++ b/c/pthread/triangular-longest_true-unreach-call.i
@@ -657,20 +657,22 @@ extern int pthread_atfork (void (*__prepare) (void),
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
-  for (int k = 0; k < 5; k++)
-    i = (j * (j + 1)) / 2;
+  for (int k = 0; k < 20; k++) {
+    i = j + 1;
+  }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
-  for (int k = 0; k < 5; k++)
-    j = (i * (i + 1)) / 2;
+  for (int k = 0; k < 20; k++) {
+    j = i + 1;
+  }
   pthread_exit(((void *)0));
 }
 int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > 946 || j > 946) {
+  if (i > (2*20 +6) || j > (2*20 +6)) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular_false-unreach-call.c
+++ b/c/pthread/triangular_false-unreach-call.c
@@ -5,20 +5,19 @@ extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 
 #define NUM 5
+#define LIMIT (2*NUM+6)
 
 void *t1(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    i = (j * (j + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    i = j + 1;
+  }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    j = (i * (i + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    j = i + 1;
+  }
   pthread_exit(NULL);
 }
 
@@ -28,7 +27,7 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= 91 || j >= 91) {
+  if (i >= LIMIT || j >= LIMIT) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular_false-unreach-call.i
+++ b/c/pthread/triangular_false-unreach-call.i
@@ -657,20 +657,22 @@ extern int pthread_atfork (void (*__prepare) (void),
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
-  for (int k = 0; k < 5; k++)
-    i = (j * (j + 1)) / 2;
+  for (int k = 0; k < 5; k++) {
+    i = j + 1;
+  }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
-  for (int k = 0; k < 5; k++)
-    j = (i * (i + 1)) / 2;
+  for (int k = 0; k < 5; k++) {
+    j = i + 1;
+  }
   pthread_exit(((void *)0));
 }
 int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= 91 || j >= 91) {
+  if (i >= (2*5 +6) || j >= (2*5 +6)) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular_true-unreach-call.c
+++ b/c/pthread/triangular_true-unreach-call.c
@@ -5,20 +5,19 @@ extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 
 #define NUM 5
+#define LIMIT (2*NUM+6)
 
 void *t1(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    i = (j * (j + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    i = j + 1;
+  }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
-
-  for (int k = 0; k < NUM; k++)
-    j = (i * (i + 1)) / 2;
-
+  for (int k = 0; k < NUM; k++) {
+    j = i + 1;
+  }
   pthread_exit(NULL);
 }
 
@@ -28,7 +27,7 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > 91 || j > 91) {
+  if (i > LIMIT || j > LIMIT) {
   ERROR:
     __VERIFIER_error();
   }

--- a/c/pthread/triangular_true-unreach-call.i
+++ b/c/pthread/triangular_true-unreach-call.i
@@ -657,20 +657,22 @@ extern int pthread_atfork (void (*__prepare) (void),
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
-  for (int k = 0; k < 5; k++)
-    i = (j * (j + 1)) / 2;
+  for (int k = 0; k < 5; k++) {
+    i = j + 1;
+  }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
-  for (int k = 0; k < 5; k++)
-    j = (i * (i + 1)) / 2;
+  for (int k = 0; k < 5; k++) {
+    j = i + 1;
+  }
   pthread_exit(((void *)0));
 }
 int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > 91 || j > 91) {
+  if (i > (2*5 +6) || j > (2*5 +6)) {
   ERROR:
     __VERIFIER_error();
   }


### PR DESCRIPTION
possible fix for #649.
A different calculation avoids overflows and matches the intention of the benchmark.