### PR TITLE
Get rid of undefined behaviour in termination-crafted-lit

### DIFF
--- a/c/termination-crafted-lit/HeizmannHoenickeLeikePodelski-ATVA2013-Fig7_false-no-overflow.c
+++ b/c/termination-crafted-lit/HeizmannHoenickeLeikePodelski-ATVA2013-Fig7_false-no-overflow.c
@@ -14,6 +14,9 @@ int main() {
 		return 0;
 	}
 	int a[a_length];
+	for (int j = 0; j < a_length; j++) {
+		a[j] = __VERIFIER_nondet_int();
+	}
 	int offset = 1;
 	int i = 0;
 	while (i < a_length) {


### PR DESCRIPTION
There was an undefined behaviour in `termination-crafted-lit/HeizmannHoenickeLeikePodelski-ATVA2013-Fig7_false-no-overflow.c` since the values of the array `a` were uninitialized. This commit fixes the problem.