### PR TITLE
Introduce Java verifier class

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -39,7 +39,7 @@ Other properties are currently not defined.
 The verification task need to be compilable by putting all `.java` files
 in directories listed as input files on the sourcepath of a Java 8 compiler.
 
-## Using the Verification Tasks with Benchexec
+## Using the Verification Tasks with BenchExec
 
 BenchExec will pass the paths
 that are listed as input files in a task-definition file
@@ -53,28 +53,30 @@ it should use regular Java utilities to create these artifacts
 
 ## Rules for Nondeterminism
 
-The arguments to `public static void main(String[] args)` are
-assumed to be nondeterministic under the following constraints:
-`assume(args != null && for all i. 0<=i<args.length =>
-  args[i] != null)`.
+The only admissible source of nondeterminism are the return values of
+the methods defined in the `org.sosy_lab.sv_benchmarks.Verifier`
+class, provided in
+`java/common/org/sosy_lab/sv_benchmarks/Verifier.java` in the
+`sv-benchmarks` repository. In order to make the benchmarks
+compilable, `../common/` needs to be added to the `input_files`
+property of the benchmark's YAML file.
 
-We do not specify custom methods for introducing nondeterminism as
-done in the C categories of SV-COMP (cf. `__VERIFIER_nondet`).
-Instead we use the `java.util.Random` class;  the methods in
-that class are expected to return a nondeterministic value instead of
-a random value, but satisfying the same constraints on their value
-range.
+The methods in `org.sosy_lab.sv_benchmarks.Verifier` call methods
+of the `java.util.Random` class. The rationale is to provide
+straightforward compatibility with verifiers that implement a
+nondeterministic semantics for the `java.util.Random` class, i.e.
+the methods in `java.util.Random` are expected to return a
+nondeterministic value instead of a random value, but satisfying
+the same constraints on their value range.
 
-Moreover, we do not specify a custom `assume` method. It is
-recommended to use `return` or `Runtime.getRuntime().halt(1)` to
-achieve the desired behavior as they do not impact the termination
-behavior of a program. Using `while(true); would make any
-program with assumptions classified non-terminating when a
-potential _Java Termination_ category might be introduced
-in future.
+`org.sosy_lab.sv_benchmarks.Verifier` also provides an `assume`
+method, which is defined as `Runtime.getRuntime().halt(1)`.  It is
+recommended to use `assume` or `return` (if in the entry point method)
+to restrict the nondeterminism as they do not impact the termination
+behavior of a program. For example, using `while(!condition); would
+make any program with such assumptions be classified non-terminating
+when a potential _Java Termination_ category might be introduced in
+future.
 
 Any library methods that make system calls are not allowed in
 verification tasks.
-Exceptions with well-defined behaviors can be explicitly granted if
-they allow a wider range of benchmarks to be included in the
-collection.

--- a/java/common/org/sosy_lab/sv_benchmarks/Verifier.java
+++ b/java/common/org/sosy_lab/sv_benchmarks/Verifier.java
@@ -1,0 +1,78 @@
+/*
+ * Contributed by Peter Schrammel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sosy_lab.sv_benchmarks;
+
+import java.util.Random;
+
+public final class Verifier
+{
+  public static void assume(boolean condition)
+  {
+    if(!condition) {
+      Runtime.getRuntime().halt(1);
+    }
+  }
+
+  public static boolean nondetBoolean()
+  {
+    return new Random().nextBoolean();
+  }
+
+  public static byte nondetByte()
+  {
+    return (byte)(new Random().nextInt());
+  }
+
+  public static char nondetChar()
+  {
+    return (char)(new Random().nextInt());
+  }
+
+  public static short nondetShort()
+  {
+    return (short)(new Random().nextInt());
+  }
+
+  public static int nondetInt()
+  {
+    return new Random().nextInt();
+  }
+
+  public static long nondetLong()
+  {
+    return new Random().nextLong();
+  }
+
+  public static float nondetFloat()
+  {
+    return new Random().nextFloat();
+  }
+
+  public static double nondetDouble()
+  {
+    return new Random().nextDouble();
+  }
+
+  public static String nondetString()
+  {
+    Random random = new Random();
+    int size = random.nextInt();
+    byte[] bytes = new byte[size];
+    random.nextBytes(bytes);
+    return new String(bytes);
+  }
+}


### PR DESCRIPTION
- [n/a] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [X] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (either in separate file or as comment at beginning of program)
- [X] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [n/a] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [n/a] intended property matches the corresponding `.prp` file
- [n/a] expected answer in file names according to [convention](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#properties)

<!-- For C programs: -->
- [n/a] [architecture](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#architecture) (32 bit vs. 64 bit) matches the corresponding `.cfg` file
- [n/a] original sources present
- [n/a] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [n/a] preprocessed files generated with correct architecture
- [n/a] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings
