### PR TITLE
Fix concurrency data races

### DIFF
--- a/c/pthread/fib_bench_false-unreach-call.c
+++ b/c/pthread/fib_bench_false-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 #include <pthread.h>
 
 int i=1, j=1;
@@ -11,9 +14,11 @@ t1(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -22,9 +27,11 @@ t2(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -36,7 +43,15 @@ main(int argc, char **argv)
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= 144 || j >= 144) {
+  __VERIFIER_atomic_begin();
+  int condI = i >= 144;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= 144;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
 

--- a/c/pthread/fib_bench_false-unreach-call.c
+++ b/c/pthread/fib_bench_false-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <pthread.h>
 

--- a/c/pthread/fib_bench_false-unreach-call.i
+++ b/c/pthread/fib_bench_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -637,16 +638,22 @@ void *
 t1(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 5; k++)
+  for (k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 void *
 t2(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 5; k++)
+  for (k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 int
@@ -655,7 +662,13 @@ main(int argc, char **argv)
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= 144 || j >= 144) {
+  __VERIFIER_atomic_begin();
+  int condI = i >= 144;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j >= 144;
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
   return 0;

--- a/c/pthread/fib_bench_false-unreach-call.i
+++ b/c/pthread/fib_bench_false-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/fib_bench_longer_false-unreach-call.c
+++ b/c/pthread/fib_bench_longer_false-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 #include <pthread.h>
 
 int i=1, j=1;
@@ -11,9 +14,11 @@ t1(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -22,9 +27,11 @@ t2(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -36,7 +43,15 @@ main(int argc, char **argv)
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= 377 || j >= 377) {
+  __VERIFIER_atomic_begin();
+  int condI = i >= 377;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= 377;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
 

--- a/c/pthread/fib_bench_longer_false-unreach-call.c
+++ b/c/pthread/fib_bench_longer_false-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <pthread.h>
 

--- a/c/pthread/fib_bench_longer_false-unreach-call.i
+++ b/c/pthread/fib_bench_longer_false-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/fib_bench_longer_false-unreach-call.i
+++ b/c/pthread/fib_bench_longer_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -637,16 +638,22 @@ void *
 t1(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 6; k++)
+  for (k = 0; k < 6; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 void *
 t2(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 6; k++)
+  for (k = 0; k < 6; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 int
@@ -655,7 +662,13 @@ main(int argc, char **argv)
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= 377 || j >= 377) {
+  __VERIFIER_atomic_begin();
+  int condI = i >= 377;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j >= 377;
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
   return 0;

--- a/c/pthread/fib_bench_longer_true-unreach-call.c
+++ b/c/pthread/fib_bench_longer_true-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 #include <pthread.h>
 
 int i=1, j=1;
@@ -11,9 +14,11 @@ t1(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -22,9 +27,11 @@ t2(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -36,7 +43,15 @@ main(int argc, char **argv)
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > 377 || j > 377) {
+  __VERIFIER_atomic_begin();
+  int condI = i > 377;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j > 377;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
 

--- a/c/pthread/fib_bench_longer_true-unreach-call.c
+++ b/c/pthread/fib_bench_longer_true-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <pthread.h>
 

--- a/c/pthread/fib_bench_longer_true-unreach-call.i
+++ b/c/pthread/fib_bench_longer_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -637,16 +638,22 @@ void *
 t1(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 6; k++)
+  for (k = 0; k < 6; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 void *
 t2(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 6; k++)
+  for (k = 0; k < 6; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 int
@@ -655,7 +662,13 @@ main(int argc, char **argv)
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > 377 || j > 377) {
+  __VERIFIER_atomic_begin();
+  int condI = i > 377;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j > 377;
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
   return 0;

--- a/c/pthread/fib_bench_longer_true-unreach-call.i
+++ b/c/pthread/fib_bench_longer_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/fib_bench_longest_false-unreach-call.c
+++ b/c/pthread/fib_bench_longest_false-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 #include <pthread.h>
 
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error();}; return; }
@@ -13,9 +16,11 @@ t1(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -24,9 +29,11 @@ t2(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -38,7 +45,16 @@ main(int argc, char **argv)
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= 46368 || j >= 46368) {
+
+  __VERIFIER_atomic_begin();
+  int condI = i >= 46368;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= 46368;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
 

--- a/c/pthread/fib_bench_longest_false-unreach-call.c
+++ b/c/pthread/fib_bench_longest_false-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <pthread.h>
 

--- a/c/pthread/fib_bench_longest_false-unreach-call.i
+++ b/c/pthread/fib_bench_longest_false-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -638,16 +639,22 @@ void *
 t1(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 11; k++)
+  for (k = 0; k < 11; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 void *
 t2(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 11; k++)
+  for (k = 0; k < 11; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 int
@@ -656,7 +663,13 @@ main(int argc, char **argv)
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= 46368 || j >= 46368) {
+  __VERIFIER_atomic_begin();
+  int condI = i >= 46368;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j >= 46368;
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
   return 0;

--- a/c/pthread/fib_bench_longest_false-unreach-call.i
+++ b/c/pthread/fib_bench_longest_false-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/fib_bench_longest_true-unreach-call.c
+++ b/c/pthread/fib_bench_longest_true-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 #include <pthread.h>
 
 void __VERIFIER_assert(int expression) { if (!expression) { ERROR: __VERIFIER_error();}; return; }
@@ -13,9 +16,11 @@ t1(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -24,9 +29,11 @@ t2(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -38,7 +45,15 @@ main(int argc, char **argv)
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > 46368 || j > 46368) {
+  __VERIFIER_atomic_begin();
+  int condI = i > 46368;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j > 46368;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
 

--- a/c/pthread/fib_bench_longest_true-unreach-call.c
+++ b/c/pthread/fib_bench_longest_true-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <pthread.h>
 

--- a/c/pthread/fib_bench_longest_true-unreach-call.i
+++ b/c/pthread/fib_bench_longest_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/fib_bench_longest_true-unreach-call.i
+++ b/c/pthread/fib_bench_longest_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -638,16 +639,22 @@ void *
 t1(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 11; k++)
+  for (k = 0; k < 11; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 void *
 t2(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 11; k++)
+  for (k = 0; k < 11; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 int
@@ -656,7 +663,13 @@ main(int argc, char **argv)
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > 46368 || j > 46368) {
+  __VERIFIER_atomic_begin();
+  int condI = i > 46368;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j > 46368;
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
   return 0;

--- a/c/pthread/fib_bench_true-unreach-call.c
+++ b/c/pthread/fib_bench_true-unreach-call.c
@@ -1,5 +1,8 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 #include <pthread.h>
 
 int i=1, j=1;
@@ -11,9 +14,11 @@ t1(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -22,9 +27,11 @@ t2(void* arg)
 {
   int k = 0;
 
-  for (k = 0; k < NUM; k++)
+  for (k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
-
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(NULL);
 }
 
@@ -36,7 +43,15 @@ main(int argc, char **argv)
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > 144 || j > 144) {
+  __VERIFIER_atomic_begin();
+  int condI = i > 144;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j > 144;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
 

--- a/c/pthread/fib_bench_true-unreach-call.c
+++ b/c/pthread/fib_bench_true-unreach-call.c
@@ -1,7 +1,7 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 #include <pthread.h>
 

--- a/c/pthread/fib_bench_true-unreach-call.i
+++ b/c/pthread/fib_bench_true-unreach-call.i
@@ -1,5 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;
@@ -637,16 +638,22 @@ void *
 t1(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 5; k++)
+  for (k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     i+=j;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 void *
 t2(void* arg)
 {
   int k = 0;
-  for (k = 0; k < 5; k++)
+  for (k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     j+=i;
+    __VERIFIER_atomic_end();
+  }
   pthread_exit(((void *)0));
 }
 int
@@ -655,7 +662,13 @@ main(int argc, char **argv)
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > 144 || j > 144) {
+  __VERIFIER_atomic_begin();
+  int condI = i > 144;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j > 144;
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
     ERROR: __VERIFIER_error();
   }
   return 0;

--- a/c/pthread/fib_bench_true-unreach-call.i
+++ b/c/pthread/fib_bench_true-unreach-call.i
@@ -1,6 +1,6 @@
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 typedef unsigned char __u_char;
 typedef unsigned short int __u_short;
 typedef unsigned int __u_int;

--- a/c/pthread/triangular-longer_false-unreach-call.c
+++ b/c/pthread/triangular-longer_false-unreach-call.c
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 

--- a/c/pthread/triangular-longer_false-unreach-call.c
+++ b/c/pthread/triangular-longer_false-unreach-call.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
@@ -9,14 +12,18 @@ int i = 3, j = 6;
 
 void *t1(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
@@ -27,9 +34,16 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= LIMIT || j >= LIMIT) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
 
   return 0;

--- a/c/pthread/triangular-longer_false-unreach-call.i
+++ b/c/pthread/triangular-longer_false-unreach-call.i
@@ -654,17 +654,23 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
   for (int k = 0; k < 10; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
   for (int k = 0; k < 10; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
@@ -672,9 +678,14 @@ int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= (2*10 +6) || j >= (2*10 +6)) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i >= (2*10 +6);
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j >= (2*10 +6);
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
   return 0;
 }

--- a/c/pthread/triangular-longer_false-unreach-call.i
+++ b/c/pthread/triangular-longer_false-unreach-call.i
@@ -654,8 +654,8 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {

--- a/c/pthread/triangular-longer_true-unreach-call.c
+++ b/c/pthread/triangular-longer_true-unreach-call.c
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 

--- a/c/pthread/triangular-longer_true-unreach-call.c
+++ b/c/pthread/triangular-longer_true-unreach-call.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
@@ -9,14 +12,18 @@ int i = 3, j = 6;
 
 void *t1(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
@@ -27,9 +34,16 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > LIMIT || j > LIMIT) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i > LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j > LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
 
   return 0;

--- a/c/pthread/triangular-longer_true-unreach-call.i
+++ b/c/pthread/triangular-longer_true-unreach-call.i
@@ -654,8 +654,8 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {

--- a/c/pthread/triangular-longer_true-unreach-call.i
+++ b/c/pthread/triangular-longer_true-unreach-call.i
@@ -654,17 +654,23 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
   for (int k = 0; k < 10; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
   for (int k = 0; k < 10; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
@@ -672,9 +678,14 @@ int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > (2*10 +6) || j > (2*10 +6)) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i > (2*10 +6);
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j > (2*10 +6);
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
   return 0;
 }

--- a/c/pthread/triangular-longest_false-unreach-call.c
+++ b/c/pthread/triangular-longest_false-unreach-call.c
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 

--- a/c/pthread/triangular-longest_false-unreach-call.c
+++ b/c/pthread/triangular-longest_false-unreach-call.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
@@ -9,14 +12,18 @@ int i = 3, j = 6;
 
 void *t1(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
@@ -27,9 +34,16 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= LIMIT || j >= LIMIT) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
 
   return 0;

--- a/c/pthread/triangular-longest_false-unreach-call.i
+++ b/c/pthread/triangular-longest_false-unreach-call.i
@@ -654,8 +654,8 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {

--- a/c/pthread/triangular-longest_false-unreach-call.i
+++ b/c/pthread/triangular-longest_false-unreach-call.i
@@ -654,17 +654,23 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
   for (int k = 0; k < 20; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
   for (int k = 0; k < 20; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
@@ -672,9 +678,14 @@ int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= (2*20 +6) || j >= (2*20 +6)) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i >= (2*20 +6);
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j >= (2*20 +6);
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
   return 0;
 }

--- a/c/pthread/triangular-longest_true-unreach-call.c
+++ b/c/pthread/triangular-longest_true-unreach-call.c
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 

--- a/c/pthread/triangular-longest_true-unreach-call.c
+++ b/c/pthread/triangular-longest_true-unreach-call.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
@@ -9,14 +12,18 @@ int i = 3, j = 6;
 
 void *t1(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
@@ -27,9 +34,16 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > LIMIT || j > LIMIT) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i > LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j > LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
 
   return 0;

--- a/c/pthread/triangular-longest_true-unreach-call.i
+++ b/c/pthread/triangular-longest_true-unreach-call.i
@@ -654,8 +654,8 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {

--- a/c/pthread/triangular-longest_true-unreach-call.i
+++ b/c/pthread/triangular-longest_true-unreach-call.i
@@ -654,17 +654,23 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
   for (int k = 0; k < 20; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
   for (int k = 0; k < 20; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
@@ -672,9 +678,14 @@ int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > (2*20 +6) || j > (2*20 +6)) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i > (2*20 +6);
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j > (2*20 +6);
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
   return 0;
 }

--- a/c/pthread/triangular_false-unreach-call.c
+++ b/c/pthread/triangular_false-unreach-call.c
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 

--- a/c/pthread/triangular_false-unreach-call.c
+++ b/c/pthread/triangular_false-unreach-call.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
@@ -9,14 +12,18 @@ int i = 3, j = 6;
 
 void *t1(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
@@ -27,9 +34,16 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i >= LIMIT || j >= LIMIT) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
 
   return 0;

--- a/c/pthread/triangular_false-unreach-call.i
+++ b/c/pthread/triangular_false-unreach-call.i
@@ -654,8 +654,8 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {

--- a/c/pthread/triangular_false-unreach-call.i
+++ b/c/pthread/triangular_false-unreach-call.i
@@ -654,17 +654,23 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
   for (int k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
   for (int k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
@@ -672,9 +678,14 @@ int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i >= (2*5 +6) || j >= (2*5 +6)) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i >= (2*5 +6);
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j >= (2*5 +6);
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
   return 0;
 }

--- a/c/pthread/triangular_true-unreach-call.c
+++ b/c/pthread/triangular_true-unreach-call.c
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 

--- a/c/pthread/triangular_true-unreach-call.c
+++ b/c/pthread/triangular_true-unreach-call.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
+
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int i = 3, j = 6;
@@ -9,14 +12,18 @@ int i = 3, j = 6;
 
 void *t1(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
 
 void *t2(void *arg) {
   for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(NULL);
 }
@@ -27,9 +34,16 @@ int main(int argc, char **argv) {
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
 
-  if (i > LIMIT || j > LIMIT) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i > LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j > LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
 
   return 0;

--- a/c/pthread/triangular_true-unreach-call.i
+++ b/c/pthread/triangular_true-unreach-call.i
@@ -654,17 +654,23 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
+void __VERIFIER_atomic_begin();
+void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {
   for (int k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     i = j + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
 void *t2(void *arg) {
   for (int k = 0; k < 5; k++) {
+    __VERIFIER_atomic_begin();
     j = i + 1;
+    __VERIFIER_atomic_end();
   }
   pthread_exit(((void *)0));
 }
@@ -672,9 +678,14 @@ int main(int argc, char **argv) {
   pthread_t id1, id2;
   pthread_create(&id1, ((void *)0), t1, ((void *)0));
   pthread_create(&id2, ((void *)0), t2, ((void *)0));
-  if (i > (2*5 +6) || j > (2*5 +6)) {
-  ERROR:
-    __VERIFIER_error();
+  __VERIFIER_atomic_begin();
+  int condI = i > (2*5 +6);
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  int condJ = j > (2*5 +6);
+  __VERIFIER_atomic_end();
+  if (condI || condJ) {
+    ERROR: __VERIFIER_error();
   }
   return 0;
 }

--- a/c/pthread/triangular_true-unreach-call.i
+++ b/c/pthread/triangular_true-unreach-call.i
@@ -654,8 +654,8 @@ extern int pthread_atfork (void (*__prepare) (void),
       void (*__parent) (void),
       void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
 
-void __VERIFIER_atomic_begin();
-void __VERIFIER_atomic_end();
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
 extern void __VERIFIER_error() __attribute__((__noreturn__));
 int i = 3, j = 6;
 void *t1(void *arg) {


### PR DESCRIPTION
fixes for #657.

@zvonimir :
Could you review the changes?
For the variables `i` and `j` in the main function I assume that we do not need locking, because the variables are only read, not written there. Same opinion?